### PR TITLE
Bugfix 修复会话列表相同类型不同chat_id的技能只展示一个的bug

### DIFF
--- a/src/backend/bisheng/api/v1/chat.py
+++ b/src/backend/bisheng/api/v1/chat.py
@@ -51,11 +51,11 @@ def get_chatlist_list(*, session: Session = Depends(get_session), Authorize: Aut
     Authorize.jwt_required()
     payload = json.loads(Authorize.get_jwt_subject())
 
-    smt = (select(ChatMessage.flow_id, ChatMessage.chat_id, ChatMessage.chat_id,
+    smt = (select(ChatMessage.flow_id, ChatMessage.chat_id,
                   func.max(ChatMessage.create_time).label('create_time'),
                   func.max(ChatMessage.update_time).label('update_time')).where(
                       ChatMessage.user_id == payload.get('user_id')).group_by(
-                          ChatMessage.flow_id).order_by(func.max(ChatMessage.create_time).desc()))
+                          ChatMessage.flow_id, ChatMessage.chat_id).order_by(func.max(ChatMessage.create_time).desc()))
     db_message = session.exec(smt).all()
     flow_ids = [message.flow_id for message in db_message]
     db_flow = session.exec(select(Flow).where(Flow.id.in_(flow_ids))).all()

--- a/src/backend/bisheng/api/v1/skillcenter.py
+++ b/src/backend/bisheng/api/v1/skillcenter.py
@@ -22,7 +22,11 @@ def create_template(*, session: Session = Depends(get_session), template: Templa
 
     # 增加 order_num  x,x+65535
     max_order = session.exec(select(Template).order_by(Template.order_num.desc()).limit(1)).first()
-    db_template.order_num = max_order.order_num + ORDER_GAP
+    # 如果没有数据，就从 65535 开始
+    if max_order is None:
+        db_template.order_num = ORDER_GAP
+    else:
+        db_template.order_num = max_order.order_num + ORDER_GAP
     session.add(db_template)
     session.commit()
     session.refresh(db_template)


### PR DESCRIPTION
Bugfix
[fc91061](https://github.com/dataelement/bisheng/pull/58/commits/fc91061167a07e354fbc10dec9e8a1f9aafa3205) 修复会话列表使用相同技能创建多个会话后，/chat/list接口从mysql查询时相同flow_id只查到多个chat_id中的一个的BUG
[45fdbb6](https://github.com/dataelement/bisheng/pull/58/commits/45fdbb6cdfe497007e3ea2099903bb964366cf5e) 修复mysql - template表为空时，添加技能模板失败问题