### PR TITLE
Add report component

### DIFF
--- a/src/bisheng-langchain/bisheng_langchain/chains/__init__.py
+++ b/src/bisheng-langchain/bisheng_langchain/chains/__init__.py
@@ -1,6 +1,6 @@
 from bisheng_langchain.chains.combine_documents.stuff import StuffDocumentsChain
 
 from .loader_output import LoaderOutputChain
+from bisheng_langchain.chains.report.credit_report import Report
 
-__all__ = ['StuffDocumentsChain', 'LoaderOutputChain']
-
+__all__ = ['StuffDocumentsChain', 'LoaderOutputChain', 'Report']

--- a/src/bisheng-langchain/bisheng_langchain/chains/report/credit_report.py
+++ b/src/bisheng-langchain/bisheng_langchain/chains/report/credit_report.py
@@ -1,0 +1,139 @@
+from typing import Any, Dict, List, Optional
+
+from langchain.callbacks.manager import (
+    AsyncCallbackManagerForChainRun,
+    CallbackManagerForChainRun,
+)
+from langchain.chains.base import Chain
+from langchain.agents.agent import AgentExecutor
+from langchain.pydantic_v1 import Extra, root_validator
+from langchain.utils.input import get_color_mapping
+
+
+class Reprot(Chain):
+    chains: Optional[List[Dict]] = None
+    agents: Optional[List[Dict]] = None
+    input_key: str = "report_name"  #: :meta private:
+    output_key: str = "report_content"  #: :meta private:
+
+    class Config:
+        """Configuration for this pydantic object."""
+
+        extra = Extra.forbid
+        arbitrary_types_allowed = True
+
+    @property
+    def input_keys(self) -> List[str]:
+        """Expect input key.
+
+        :meta private:
+        """
+        return [self.input_key]
+
+    @property
+    def output_keys(self) -> List[str]:
+        """Return output key.
+
+        :meta private:
+        """
+        return [self.output_key]
+    
+    @root_validator(pre=True)
+    def validate_input_key(cls, values: Dict) -> None:
+        if not values.get("input_key"):
+           raise ValueError(
+                        "Report must set name."
+                    ) 
+           
+        return values
+
+    def validate_chains(cls, values: Dict) -> Dict:
+        """Validate chains."""
+        if values.get("chains"):
+            for chain in values["chains"]:
+                chain_output_keys = chain["object"].output_keys
+                if len(chain_output_keys) != 1:
+                    raise ValueError(
+                        "Chain used in Report should all have one output, got "
+                        f"{chain['object']} with {len(chain_output_keys)} outputs."
+                    )
+            return values
+    
+    def validate_agents(cls, values: Dict) -> Dict:
+        """Validate agents."""
+        if values.get("agents"):
+            for agent in values["agents"]:
+                agent_output_keys = agent["object"].output_keys
+                if len(agent_output_keys) != 1:
+                    raise ValueError(
+                        "Agent used in Report should all have one output, got "
+                        f"{agent['object']} with {len(agent_output_keys)} outputs."
+                    )
+            return values
+
+    def _call(
+        self,
+        verbose: Optional[bool] = None,
+        run_manager: Optional[CallbackManagerForChainRun] = None,
+    ) -> Dict[str, str]:
+        _run_manager = run_manager or CallbackManagerForChainRun.get_noop_manager()
+        outputs = {}
+        color_mapping = get_color_mapping([str(i) for i in range(len(self.chains))])
+        if self.chains:
+            for i, chain in enumerate(self.chains):
+                if not isinstance(chain["object"], Chain):
+                    raise TypeError(
+                        f"{chain['object']} not be runnable Chain object"
+                    )
+                chain_outputs = chain["object"](chain["input"], callbacks=_run_manager.get_child(f"step_{i+1}"))
+                _run_manager.on_text(
+                    chain_outputs, color=color_mapping[str(i)], end="\n", verbose=verbose
+                )
+                outputs.update({chain["node_id"]: chain_outputs.get("text")})
+                
+        if self.agents:
+            for agent in self.agents:
+                print(agent["object"])
+                if not isinstance(agent["object"],  AgentExecutor):
+                    raise TypeError(
+                        f"{agent['object']} not be AgentExecutor object"
+                    )
+                agent_outputs = agent["object"](agent["input"], callbacks=run_manager)
+                outputs.update({agent["node_id"]: agent_outputs.get("output")})
+        
+        return {self.output_key: outputs}
+
+    async def _acall(
+        self,
+        report_name: str,
+        verbose: Optional[bool] = None,
+        run_manager: Optional[AsyncCallbackManagerForChainRun] = None,
+    ) -> Dict[str, Any]:
+        _run_manager = run_manager or AsyncCallbackManagerForChainRun.get_noop_manager()
+        outputs = {}
+        color_mapping = get_color_mapping([str(i) for i in range(len(self.chains))])
+        for i, chain in enumerate(self.chains):
+            chain_outputs = await chain["object"].arun(chain["input"], callbacks=_run_manager.get_child(f"step_{i+1}"))
+            await _run_manager.on_text(
+                chain_outputs, color=color_mapping[str(i)], end="\n", verbose=verbose
+            )
+            outputs.update({chain["node_id"]: chain_outputs})
+
+        if self.agents:
+            for agent in self.agents:
+                if not isinstance(agent["object"],  AgentExecutor):
+                    raise TypeError(
+                        f"{agent['object']} not be AgentExecutor object"
+                    )
+                agent_outputs = await agent["object"].arun(agent["input"], callbacks=run_manager)
+                outputs.update({agent["node_id"]: agent_outputs})
+        return {self.output_key: outputs, self.input_key: report_name}
+    
+    async def arun(
+        self,
+        report_name: str,
+        verbose: Optional[bool] = None,
+        run_manager: Optional[AsyncCallbackManagerForChainRun] = None,
+    ) -> Dict[str, Any]:
+        result = await self._acall(report_name, verbose, run_manager)
+        return result

--- a/src/bisheng-langchain/bisheng_langchain/chains/report/test_report.py
+++ b/src/bisheng-langchain/bisheng_langchain/chains/report/test_report.py
@@ -1,0 +1,69 @@
+from credit_report import Reprot
+from langchain.agents import initialize_agent
+from langchain.agents import AgentType
+from langchain.chains import LLMChain
+from langchain.llms import OpenAI
+from langchain.prompts import PromptTemplate
+from langchain.tools import  Tool
+from langchain.utilities.google_search import GoogleSearchAPIWrapper
+from langchain.memory import ConversationBufferMemory
+
+async def async_test(chains, agents):
+    report =  Reprot(chains=chains, agents=agents, input_key="report_name", verbose=True)
+    result = await report.arun("贷后报告")
+    print(result)
+    
+    
+def test(chains, agents):
+    report =  Reprot(chains=chains, agents=agents, input_key="report_name", verbose=True)
+    result = report("贷后报告")
+    print(result)
+
+
+if __name__ == "__main__":
+    search = GoogleSearchAPIWrapper()
+    tools = [
+        Tool(
+            name = "Current Search",
+            func=search.run,
+            description="useful for when you need to answer questions about current events or the current state of the world"
+        ),
+    ]
+    llm = OpenAI()
+    memory = ConversationBufferMemory(memory_key="chat_history")
+    agent1 = initialize_agent(tools, llm, agent=AgentType.CONVERSATIONAL_REACT_DESCRIPTION, verbose=True, memory=memory)
+    input="查询中国人口数量"
+    
+    agents = [
+            {
+                "object": agent1,
+                "input": input,
+                "node_id": "agent_1" 
+            }
+        ]
+
+    prompt = PromptTemplate.from_template("回答下面问题: {question}")
+    llm_chain = LLMChain(llm=llm, prompt=prompt)
+    
+    prompt2 = PromptTemplate.from_template("下列国家的首都是: {country}")
+    llm_chain2 = LLMChain(llm=llm, prompt=prompt2)
+    
+    input1 = {"question": "世界上有多少个国家和地区"}
+    input2 = {"country": "中国"}
+    
+    chains = [
+        {
+            "object": llm_chain,
+            "input": input1,
+            "node_id": "chain_1"
+        },
+        {
+            "object":  llm_chain2,
+            "input": input2,
+            "node_id": "chain_2"
+        }
+    ]
+    
+    import asyncio
+    asyncio.run(async_test(chains=chains, agents=agents))
+    test(chains=chains, agents=agents)


### PR DESCRIPTION
Add report component (a custom chain)  to consolidate the output of multiple agents and chains.
Example of report component call results：
```json
{
    "report_name": "",
    "report_content": {
        "chain_node_1": "",
        "chain_node_2": "",
        "agent_node_1": "",
        "agent_node_2": ""
    }
}
```