### PR TITLE
fix: 修复 sse 接口在构建对话历史的时候，用户输入和模型回答构建处理错误问题

### DIFF
--- a/src/backend/bisheng/restructure/assistants/services.py
+++ b/src/backend/bisheng/restructure/assistants/services.py
@@ -22,10 +22,12 @@ def get_chat_history(chat_id: str, size: int = DEFAULT_SIZE):
     chat_history = []
     messages = ChatMessageDao.get_messages_by_chat_id(chat_id, ['question', 'answer'], size)
     for one in messages:
+        # bug fix When constructing multi-turn dialogues, the input and response of
+        # the user and the assistant were reversed, leading to incorrect question-and-answer sequences.
         if one.category == MsgCategory.Question:
-            chat_history.append(AIMessage(content=one.message))
-        elif one.category == MsgCategory.Answer:
             chat_history.append(HumanMessage(content=one.message))
+        elif one.category == MsgCategory.Answer:
+            chat_history.append(AIMessage(content=one.message))
     logger.info(f"loaded {len(chat_history)} chat history for chat_id {chat_id}")
     return chat_history
 


### PR DESCRIPTION
api 接口在进行助手回答的时候，读取历史纪录构建大模型请求，userMessage 和 assisantMessage 处理反了