### PR TITLE
fix: 修复输入框有多个多选控件时，多个控件的选项会串的问题

### DIFF
--- a/src/frontend/src/pages/BuildPage/flow/FlowChat/InputForm.tsx
+++ b/src/frontend/src/pages/BuildPage/flow/FlowChat/InputForm.tsx
@@ -87,7 +87,7 @@ const InputForm = ({ data, onSubmit }: { data: WorkflowNodeParam, onSubmit: (dat
                                                 <MultiSelect
                                                     multiple
                                                     className={''}
-                                                    value={multiVal}
+                                                    value={multiVal[item.key] || []}
                                                     options={
                                                         item.options.map(el => ({
                                                             label: el.text,
@@ -96,7 +96,7 @@ const InputForm = ({ data, onSubmit }: { data: WorkflowNodeParam, onSubmit: (dat
                                                     }
                                                     placeholder={'请选择'}
                                                     onChange={(v) => {
-                                                        setMultiVal(v);
+                                                        setMultiVal(prev => ({ ...prev, [item.key]: v }));
                                                         handleChange(item, v.join(','))
                                                     }}
                                                 >


### PR DESCRIPTION
问题复现例如
https://bisheng.dataelem.com/flow/e1342d98-0220-4839-b09d-9fe774f43355
a to c选a，d to f选d，提交后显示a to c: a , d to f: a,d