### PR TITLE
fix: 修复工作流大模型节点温度选项不生效的问题

### DIFF
--- a/src/backend/bisheng/workflow/nodes/llm/llm.py
+++ b/src/backend/bisheng/workflow/nodes/llm/llm.py
@@ -34,6 +34,8 @@ class LLMNode(BaseNode):
         # 初始化llm对象
         self._stream = True
         self._llm = LLMService.get_bisheng_llm(model_id=self.node_params['model_id'],
+                                               temperature=self.node_params.get(
+                                                   'temperature', 0.3),
                                                params={'stream': self._stream},
                                                cache=False)
 


### PR DESCRIPTION
工作流的大模型节点温度选项不起作用，不管界面怎么选调接口时总是传的0.3，助手节点则没有这个问题，参照助手节点修复了一下