### PR TITLE
自定义api工具测试和使用接口返回会报错缺少参数，原因是前端组件传参错误导致后端组装请求参数取不到对应参数

### DIFF
--- a/src/frontend/platform/src/pages/BuildPage/tools/EditTool.tsx
+++ b/src/frontend/platform/src/pages/BuildPage/tools/EditTool.tsx
@@ -83,12 +83,12 @@ export const TestDialog = forwardRef<{
         await captureAndAlertRequestErrorHoc(testToolApi({
             server_host,
             extra: children.find(el => el.name === apiData.name).extra,
-            auth_method: toolRef.current.authMethod === 'apikey' ? 1 : 0,
-            auth_type: toolRef.current.authType,
-            api_key: toolRef.current.apiKey,
+            auth_method: toolRef.current.auth_method,
+            auth_type: toolRef.current.auth_type,
+            api_key: toolRef.current.api_key,
             request_params: formRef.current.values,
-            api_location: toolRef.current.apiLocation,
-            parameter_name: toolRef.current.parameter
+            api_location: toolRef.current.api_location,
+            parameter_name: toolRef.current.parameter_name
         }).then(setResult))
         setLoading(false)
     }


### PR DESCRIPTION
## 🛠️ 修复内容
1.2.0和1.2.1都存在此问题，自定义api工具测试和使用接口返回会报错缺少参数，前端组件EditTool向后端接口传值参数名错误导致tool_run方法接收不到正确的参数
![f2497ff55d761a779f6ea2b3a6f6d63](https://github.com/user-attachments/assets/a3c19c5c-7cb8-4c9e-a1ec-d613c8bd6a1f)


## 📌 问题复现步骤
1. API工具->编辑API工具->鉴权方式->API Key->Custom->header->Parameter name
2. OpenAPI Schema：

openapi: 3.0.3
info:
  title: 企业变更记录查询接口
  description: |
    通过公司名称或ID获取企业变更记录，变更记录包括工商变更事项、变更前后信息等字段的详细信息。
    接口ID：822
    价格：¥0.15/次（近30天申请：7889次）
    更多套餐请联系商务咨询，咨询电话：400-608-0000。
  version: '2.0'
servers:
  - url: http://open.api.tianyancha.com
paths:
  /services/open/ic/changeinfo/2.0:
    get:
      summary: 获取企业变更记录
      description: |
        通过公司名称或ID获取企业变更记录，包含工商变更事项、变更前后信息等字段的详细信息。
      operationId: getCompanyChangeRecords
      tags:
        - 企业变更
      parameters:
        - name: keyword
          in: query
          description: 搜索关键字（公司名称、公司ID、注册号或社会统一信用代码）
          required: true
          schema:
            type: string
        - name: pageNum
          in: query
          description: 当前页数（默认第1页）
          required: false
          schema:
            type: integer
            default: 1
        - name: pageSize
          in: query
          description: 每页条数（默认20条，最大20条）
          required: false
          schema:
            type: integer
            default: 20
            maximum: 20
      responses:
        '200':
          description: 成功响应
          content:
            application/json:
              schema:
                type: object
                properties:
                  result:
                    type: object
                    properties:
                      total:
                        type: integer
                        description: 记录总数
                      items:
                        type: array
                        items:
                          type: object
                          properties:
                            changeTime:
                              type: string
                              format: date
                              description: 变更日期
                            contentBefore:
                              type: string
                              description: 变更前信息
                            contentAfter:
                              type: string
                              description: 变更后信息
                            createTime:
                              type: string
                              format: date
                              description: 记录创建时间
                            changeItem:
                              type: string
                              description: 变更事项
        '400':
          description: 请求参数错误
        '401':
          description: 未授权（请检查Token）
        '500':
          description: 服务器错误
      security:
        - ApiKeyAuth: []
components:
  securitySchemes:
    ApiKeyAuth:
      type: apiKey
      in: header
      name: Authorization
      description: 用于验证的Token

4. 保存->测试/添加工具节点使用

## 🔧 修改方式
- 修改了bisheng/src/frontend/platform/src/pages/BuildPage/tools/EditTool.tsx的86、87、88、90、91行
