### PR TITLE
fix: fix the frontend docker build bug in windows

### DIFF
--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -2,8 +2,18 @@ FROM node:18-alpine as frontend_build
 ARG BACKEND
 WORKDIR /app
 COPY . /app
-RUN cd /app/platform && npm install --force --registry=https://registry.npmmirror.com && npm run build
-RUN cd /app/client && npm install --force --registry=https://registry.npmmirror.com && npm run build
+
+
+RUN cd /app/platform && \
+    rm -rf node_modules package-lock.json && \
+    npm install --force --registry=https://registry.npmmirror.com && \
+    npm run build
+
+
+RUN cd /app/client && \
+    rm -rf node_modules package-lock.json && \
+    npm install --force --registry=https://registry.npmmirror.com && \
+    npm run build
 
 FROM nginx
 COPY --from=frontend_build /app/platform/build/ /usr/share/nginx/html/platform


### PR DESCRIPTION
the lock file and node_moudles could be cause some issue that in windows，because some npm package in the lock file is only support linux

修复了lock文件和node_moudles文件冲突导致的win下docker build失败的问题 