### PR TITLE
Fix Chat Deletion Issue by Adjusting Key Generation for Milvus Compatibility

### DIFF
--- a/src/backend/bisheng/api/services/knowledge_imp.py
+++ b/src/backend/bisheng/api/services/knowledge_imp.py
@@ -610,23 +610,33 @@ def retry_files(db_files: List[KnowledgeFile], new_files: Dict):
 
 
 def delete_vector(collection_name: str, partition_key: str):
-    embeddings = FakeEmbedding()
-    vectore_client = decide_vectorstores(collection_name, 'Milvus', embeddings)
-    if isinstance(vectore_client.col, Collection):
-        if partition_key:
-            pass
-        else:
-            res = vectore_client.col.drop(timeout=1)
-            logger.info('act=delete_milvus col={} res={}', collection_name, res)
+    try:
+        embeddings = FakeEmbedding()
+        vectore_client = decide_vectorstores(collection_name, 'Milvus', embeddings)
+        if isinstance(vectore_client.col, Collection):
+            if partition_key:
+                pass
+            else:
+                res = vectore_client.col.drop(timeout=1)
+                logger.info('act=delete_milvus col={} res={}', collection_name, res)
+    except Exception as e:
+        # 处理集合不存在或其他错误的情况
+        logger.warning(f'act=delete_milvus_failed col={collection_name} error={str(e)}')
+        # 即使出错也视为成功删除，因为目标是确保没有脏数据
 
 
 def delete_es(index_name: str):
-    embeddings = FakeEmbedding()
-    esvectore_client = decide_vectorstores(index_name, 'ElasticKeywordsSearch', embeddings)
+    try:
+        embeddings = FakeEmbedding()
+        esvectore_client = decide_vectorstores(index_name, 'ElasticKeywordsSearch', embeddings)
 
-    if esvectore_client:
-        res = esvectore_client.client.indices.delete(index=index_name, ignore=[400, 404])
-        logger.info(f'act=delete_es index={index_name} res={res}')
+        if esvectore_client:
+            res = esvectore_client.client.indices.delete(index=index_name, ignore=[400, 404])
+            logger.info(f'act=delete_es index={index_name} res={res}')
+    except Exception as e:
+        # 处理索引不存在或其他错误的情况
+        logger.warning(f'act=delete_es_failed index={index_name} error={str(e)}')
+        # 即使出错也视为成功删除，因为目标是确保没有脏数据
 
 
 def QA_save_knowledge(db_knowledge: Knowledge, QA: QAKnowledge):

--- a/src/backend/bisheng/services/session/service.py
+++ b/src/backend/bisheng/services/session/service.py
@@ -33,14 +33,14 @@ class SessionService(Service):
 
     def build_key(self, session_id, data_graph):
         json_hash = compute_dict_hash(data_graph)
-        return f"{session_id}{':' if session_id else ''}{json_hash}"
+        return f"{session_id}{'_' if session_id else ''}{json_hash}"
 
     def generate_key(self, session_id, data_graph):
         # Hash the JSON and combine it with the session_id to create a unique key
         if session_id is None:
             # generate a 5 char session_id to concatenate with the json_hash
             session_id = session_id_generator()
-        return self.build_key(session_id, data_graph=data_graph)
+        return self.build_key(session_id, data_graph=data_graph).lower()
 
     def update_session(self, session_id, value):
         self.cache_service.set(session_id, value)


### PR DESCRIPTION
This PR resolves the chat deletion issue caused by unsupported Milvus collection names due to session ID generation rules. The issue specifically occurs when making API requests to process a skill (process) with an empty session_id. The changes include:

Modified the build_key method to use underscores (_) instead of colons (:) in key generation, ensuring compatibility with Milvus collection name requirements (only alphanumeric characters and underscores are allowed).
Added lower() in the generate_key method to ensure the generated keys are lowercase, as Elasticsearch indices do not support uppercase characters.
Error Screenshots:

![image](https://github.com/user-attachments/assets/c44f7ffe-1759-444b-b26b-90dfaeab15d2)
![image](https://github.com/user-attachments/assets/7ff2af71-7217-4672-a559-56841c234b13)

These changes ensure seamless integration with Milvus and Elasticsearch while maintaining the uniqueness of session keys, particularly in cases where session_id is left empty during API requests.