### PR TITLE
fix:modify the default value of the extra field

### DIFF
--- a/src/backend/bisheng/database/models/gpts_tools.py
+++ b/src/backend/bisheng/database/models/gpts_tools.py
@@ -45,7 +45,7 @@ class GptsToolsTypeBase(SQLModelSerializable):
     id: Optional[int] = Field(default=None, index=True, primary_key=True)
     name: str = Field(default='', sa_column=Column(String(length=1024), index=True), description="工具类别名字")
     logo: Optional[str] = Field(default='', description="工具类别的logo文件地址")
-    extra: Optional[str] = Field(default='', sa_column=Column(String(length=2048)),
+    extra: Optional[str] = Field(default='{}', sa_column=Column(String(length=2048)),
                                  description="工具类别的配置信息，用来存储工具类别所需的配置信息")
     description: str = Field(default='', description="工具类别的描述")
     server_host: Optional[str] = Field(default='', description="自定义工具的访问根地址，必须以http或者https开头")


### PR DESCRIPTION
改配置为{}更合理，防止前端缺失传递参数时，造成后续的json解析错误

我们实际遇到了数据库中t_gpts_tools_type表extra字段存储''的情况，导致工作流无法正常运行，目前排查到因添加api工具时产生的错误，更新时毕昇代码中有一段如下逻辑：
```python
tool_extra = {"api_location":req.api_location,"parameter_name":req.parameter_name}
```
导致该字段值变为`{"api_location": null, "parameter_name": null}`，更新后api正常使用，工作流也变为正常

实际上这个字段既然存储json配置，我认为默认为{}更合理，可以避免参数缺失时的错误