### PR TITLE
feat: add celery worker name

### DIFF
--- a/src/backend/entrypoint.sh
+++ b/src/backend/entrypoint.sh
@@ -8,9 +8,9 @@ if [ $start_mode = "api" ]; then
 elif [ $start_mode = "worker" ]; then
     echo "Starting Celery worker..."
     # 处理知识库相关任务的worker
-    nohup celery -A bisheng.worker.main worker -l info -c 20 -P threads -Q knowledge_celery &
+    nohup celery -A bisheng.worker.main worker -l info -c 20 -P threads -Q knowledge_celery -n knowledge@%h &
     # 工作流执行worker
-    celery -A bisheng.worker.main worker -l info -c 100 -P threads -Q workflow_celery
+    celery -A bisheng.worker.main worker -l info -c 100 -P threads -Q workflow_celery -n workflow@%h
 else
     echo "Invalid start mode. Use 'api' or 'celery'."
     exit 1


### PR DESCRIPTION
Specify celery worker's hostname to differentiate knowledge worker and workflow worker for better debugging in tools like flower.