### PR TITLE
修复使用pycharm运行时间循环一直存在，导致工作流无法运行的问题

### DIFF
--- a/src/backend/bisheng/utils/threadpool.py
+++ b/src/backend/bisheng/utils/threadpool.py
@@ -50,7 +50,7 @@ class ThreadPoolManager:
 
     def run_in_event_loop(self, coro, *args, **kwargs) -> concurrent.futures.Future:
         try:
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             logger.info('event loop {}', loop)
         except Exception:
             loop = asyncio.new_event_loop()


### PR DESCRIPTION
由于使用pycharm会默认起事件循环，事件循环一直会运行，无法开启新的线程运行工作流，并且官方推荐使用asyncio.get_running_loop()获取事件循环