### PR TITLE
fix: 修复工作流会话完成一轮对话后页面异常滚动问题

### DIFF
--- a/src/frontend/platform/src/pages/BuildPage/flow/FlowChat/ChatInput.tsx
+++ b/src/frontend/platform/src/pages/BuildPage/flow/FlowChat/ChatInput.tsx
@@ -503,7 +503,7 @@ export default function ChatInput({ autoRun, clear, form, wsUrl, onBeforSend, on
                 </div>
             </div>
             {/* stop & 重置 */}
-            <div className="absolute w-full flex justify-center bottom-16">
+            <div className="absolute w-full flex justify-center left-0 bottom-16">
                 {!stop.show && <Button
                     className="rounded-full bg-[#fff] dark:bg-[#1B1B1B]"
                     variant="outline"


### PR DESCRIPTION
工作流发布后使用免登录链接打开，完成一轮对话后页面可以上下左右滚动，出现空白右侧及底部空白：
![WX20250707-104512@2x](https://github.com/user-attachments/assets/92346d9b-48e0-487d-9edc-b0501b5b838d)

排查是因为开启新会话这个按钮没有设置x轴定位导致超出页面，添加了left-0样式后正常