### PR TITLE
feat: add patch bash

### DIFF
--- a/src/backend/patch_code.sh
+++ b/src/backend/patch_code.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# 使用方式1： bash patch_code.sh conda环境名
+# 脚本将尝试进入conda环境
+
+# 使用方式2： bash patch_code.sh
+# 不使用conda环境，请确认执行脚本前，已经进入项目python环境中
+
+# 将 Windows 路径转换为 Git Bash 路径
+win_to_gitbash_path() {
+    local path="$1"
+
+    # 检查是否是 Windows 路径格式（包含反斜杠 '\'）
+    if [[ "$path" == *\\* ]]; then
+        # 替换盘符 C:\ -> /c/
+        path=$(echo "$path" | sed -E 's/^([A-Za-z]):\\/\L\/\1\//')
+
+        # 将反斜杠 \ 替换为正斜杠 /
+        path=$(echo "$path" | sed 's/\\/\//g')
+    fi
+
+    echo "$path"
+}
+
+# 检查命令是否存在
+check_command() {
+  if ! command -v $1  &> /dev/null; then
+    echo "检测到命令缺失，请先安装：$1"
+    exit 1
+  fi
+}
+
+
+patch_code_file() {
+  patch_file="$1"
+  code_file="$2"
+  search_pattern="$3"
+  if [ -f "$code_file" ]; then
+      # 执行 grep 并捕获输出
+      if output=$(grep -n "$search_pattern" "$code_file" 2>&1); then
+          echo "源代码可能已经存在该补丁，请勿重复应用，跳过：$code_file"
+      else
+          echo "准备打补丁"
+          patch -p1 < "$patch_file" "$code_file"
+          echo "补丁应用成功"
+      fi
+  else
+      echo "补丁文件没找到，可能你的环境未安装相应依赖： $code_file"
+  fi
+}
+
+
+
+check_command patch
+check_command dirname
+
+cpath="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [ "$#" -ge 1 ]; then
+  echo "尝试进入conda环境"
+  check_command conda
+  we_conda_path=$(conda info --base)
+  . "$we_conda_path/etc/profile.d/conda.sh"
+  conda activate $1
+else
+    echo "没有传递conda环境名称，将使用默认python环境"
+    echo "请确认执行脚本前，已经进入项目python环境中"
+fi
+
+check_command python
+
+
+#python_path=$(python -c 'import os; print(os.environ["CONDA_PREFIX"])')
+python_path=$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')
+python_path=$(win_to_gitbash_path "$python_path")
+
+echo "检测到python环境依赖目录：$python_path"
+
+patch_code_file "$cpath/bisheng/patches/fastapi_jwt_auth.patch" "$python_path/fastapi_jwt_auth/config.py" str_min_length
+patch_code_file "$cpath/bisheng/patches/langchain_openai.patch" "$python_path/langchain_openai/chat_models/base.py" "additional_kwargs\['reasoning_content'\]"
+
+


### PR DESCRIPTION
# 说明

目前[文档](https://dataelem.feishu.cn/wiki/SGvowhsNtiLefpk7qcTcZknMnWJ)中的说明，需要自己拼接路径的方式我觉得有点麻烦，我实现自动查找文件与补丁应用，linux与windows通用。

脚本实现功能：
- 兼容linux与windows环境
- 自动进入conda环境，非conda环境需要提前进入对应环境
- 自动获取环境中补丁文件
- 检测环境中必要的命令是否存在
- 检测补丁是否已经应用，重复执行脚本跳过补丁

下面以windows为例介绍下两种方式的：

# 使用方式1：使用conda环境
在`src/backend`目录下，进入git-bash，执行如下命令
```
bash patch_code.sh conda环境名
```

# 使用方式2：非conda环境中
在`src/backend`目录下，进入git-bash，**提前项目使用的python环境中**，执行命令：
```
bash patch_code.sh
```

# 测试情况
我自己在linux环境下测试没什么问题，邀请别人使用windows环境测试也没问题