### PR TITLE
fix: prevent undefined.match() error when loading historical messages

### DIFF
--- a/src/frontend/client/src/components/Chat/Messages/Content/MessageContent.tsx
+++ b/src/frontend/client/src/components/Chat/Messages/Content/MessageContent.tsx
@@ -82,15 +82,17 @@ const DisplayMessage = ({ text, isCreatedByUser, message, showCursor, webContent
     [message.messageId, latestMessage?.messageId],
   );
 
+  const safeText = text ?? '';
+
   let content: React.ReactElement;
   if (!isCreatedByUser) {
     content = (
-      <Markdown content={text} webContent={webContent} showCursor={showCursorState} isLatestMessage={isLatestMessage} />
+      <Markdown content={safeText} webContent={webContent} showCursor={showCursorState} isLatestMessage={isLatestMessage} />
     );
   } else if (enableUserMsgMarkdown) {
-    content = <MarkdownLite content={text} />;
+    content = <MarkdownLite content={safeText} />;
   } else {
-    content = <>{text}</>;
+    content = <>{safeText}</>;
   }
 
   return (
@@ -98,7 +100,7 @@ const DisplayMessage = ({ text, isCreatedByUser, message, showCursor, webContent
       <div
         className={cn(
           isSubmitting ? 'submitting' : '',
-          showCursorState && !!text.length ? 'result-streaming' : '',
+          showCursorState && !!safeText.length ? 'result-streaming' : '',
           'markdown prose message-content dark:prose-invert light w-full break-words',
           isCreatedByUser && !enableUserMsgMarkdown && 'whitespace-pre-wrap',
           isCreatedByUser ? 'dark:text-gray-20' : 'dark:text-gray-100',
@@ -131,6 +133,12 @@ const MessageContent = ({
   const { messageId } = message;
 
   const { thinkingContent, regularContent } = useMemo(() => {
+    if (!text) {
+      return {
+        thinkingContent: '',
+        regularContent: '',
+      };
+    }
     const thinkingMatch = text.match(/:::thinking([\s\S]*?):::/);
     let regularContent = text;
     if (thinkingMatch) {
@@ -145,6 +153,9 @@ const MessageContent = ({
   }, [text]);
 
   const webContent = useMemo(() => {
+    if (!text) {
+      return [];
+    }
     const webMatch = text.match(/:::web([\s\S]*?):::/);
     const str = webMatch ? webMatch[1].trim() : ''
     const webContent = str ? JSON.parse(str) : []

--- a/src/frontend/client/src/components/Chat/Messages/Content/Parts/ExecuteCode.tsx
+++ b/src/frontend/client/src/components/Chat/Messages/Content/Parts/ExecuteCode.tsx
@@ -17,6 +17,12 @@ interface ParsedArgs {
 
 export function useParseArgs(args: string): ParsedArgs {
   return useMemo(() => {
+    if (!args) {
+      return {
+        lang: '',
+        code: '',
+      };
+    }
     const langMatch = args.match(/"lang"\s*:\s*"(\w+)"/);
     const codeMatch = args.match(/"code"\s*:\s*"(.+?)(?="\s*,\s*"args"|$)/s);
 

--- a/src/frontend/client/src/pages/appChat/components/MessageBs.tsx
+++ b/src/frontend/client/src/pages/appChat/components/MessageBs.tsx
@@ -44,7 +44,10 @@ export default function MessageBs({ logo, title, data, onUnlike = () => { }, onS
     { logo: React.ReactNode, title: string, data: ChatMessageType, onUnlike?: any, onSource?: any }) {
 
     const [message, reasoningLog] = useMemo(() => {
-        const msg = typeof data.message === 'string' ? data.message : data.message.msg
+        const msg = typeof data.message === 'string' ? data.message : data.message?.msg
+        if (!msg) {
+            return ['', '']
+        }
         const regex = /<think>(.*?)<\/think>/s;
         const match = msg.match(regex);
         if (match) {

--- a/src/frontend/client/src/utils/index.ts
+++ b/src/frontend/client/src/utils/index.ts
@@ -267,7 +267,9 @@ export const generateUUID = (length: number) => {
 
 // 取后缀名
 export function getFileExtension(filename) {
+  if (!filename) return '';
   const basename = filename.split(/[\\/]/).pop(); // 去除路径
+  if (!basename) return '';
   const match = basename.match(/\.([^.]+)$/);
   return (match ? match[1] : '').toUpperCase();
 }


### PR DESCRIPTION
<img width="1193" height="806" alt="c55f270abfe74736459daecdb30a94d6" src="https://github.com/user-attachments/assets/496eec5f-2787-48c1-83d7-25d0edde02bf" />

完善了一些边界检查
当思考的消息由于某些原因（中断），没有具体内容时，会报这个错误