### PR TITLE
fix: Import bisheng_celery in worker init file

### DIFF
--- a/src/backend/bisheng/run_celery.py
+++ b/src/backend/bisheng/run_celery.py
@@ -1,4 +1,4 @@
-from bisheng.worker import bisheng_celery
+from bisheng.worker.main import bisheng_celery
 
 if __name__ == '__main__':
     bisheng_celery.start(

--- a/src/backend/bisheng/worker/__init__.py
+++ b/src/backend/bisheng/worker/__init__.py
@@ -1,5 +1,4 @@
 # register tasks
-from bisheng.worker.main import bisheng_celery
 from bisheng.worker.test.test import *
 from bisheng.worker.knowledge.file_worker import file_copy_celery, parse_knowledge_file_celery, \
     retry_knowledge_file_celery

--- a/src/backend/bisheng/worker/knowledge/file_worker.py
+++ b/src/backend/bisheng/worker/knowledge/file_worker.py
@@ -18,7 +18,7 @@ from bisheng.database.models.knowledge_file import (
 )
 from bisheng.interface.embeddings.custom import FakeEmbedding
 from bisheng.utils import generate_uuid
-from bisheng.worker import bisheng_celery
+from bisheng.worker.main import bisheng_celery
 from bisheng_langchain.vectorstores import ElasticKeywordsSearch, Milvus
 
 

--- a/src/backend/bisheng/worker/knowledge/qa.py
+++ b/src/backend/bisheng/worker/knowledge/qa.py
@@ -11,7 +11,7 @@ from bisheng.database.models.knowledge_file import (
 )
 from bisheng.interface.embeddings.custom import FakeEmbedding
 from bisheng.llm.domain import LLMService
-from bisheng.worker import bisheng_celery
+from bisheng.worker.main import bisheng_celery
 from bisheng_langchain.vectorstores import Milvus, ElasticKeywordsSearch
 
 

--- a/src/backend/bisheng/worker/knowledge/rebuild_knowledge_worker.py
+++ b/src/backend/bisheng/worker/knowledge/rebuild_knowledge_worker.py
@@ -14,7 +14,7 @@ from bisheng.database.models.knowledge_file import (
     KnowledgeFileStatus
 )
 from bisheng.interface.embeddings.custom import FakeEmbedding
-from bisheng.worker import bisheng_celery
+from bisheng.worker.main import bisheng_celery
 
 
 @bisheng_celery.task(acks_late=True)


### PR DESCRIPTION
我发现worker的task中存在比较多如下写法：
```python
from bisheng.worker import bisheng_celery
```
目前这种写法依赖task中存在`from bisheng.worker.main import bisheng_celery`的写法，而`bisheng/worker/__init__.py`中将所有task注册导致目前的写法正常。

目前，如果我将`bisheng/worker/test/test.py`和`bisheng/worker/workflow/tasks.py`中`from bisheng.worker.main import bisheng_celery`的写法注释掉，则task中的import bisheng_celery将会报错，例如file_worker中的代码显示：
<img width="641" height="132" alt="image" src="https://github.com/user-attachments/assets/e2f54037-3eb8-4076-b688-7f5fead82ae4" />

这是一种看起来比较奇怪的现象：`workflow/tasks.py`和`test/test.py`的import影响了`knowledge/file_worker.py`，究其原因是因为`bisheng/worker/__init__.py`中将所有task注册导致表现正常，我认为更合理的做法应该是将`from bisheng.worker.main import bisheng_celery`加到我修改地方，保证`from bisheng.worker import bisheng_celery`的写法正常

