### PR TITLE
ops: 把 114 deploy.sh 纳入 git 管理

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# BiSheng 114 dev-server deploy script (triggered by Drone CI on push to 2.5.0-PM)
+# Scope: code sync + deps refresh + restart backend & celery workers.
+# Out of scope: alembic migrations (manual), frontend restart (vite HMR),
+#               celery beat, Linsight worker.
+set -euo pipefail
+
+LOG=/tmp/bisheng-deploy.log
+{
+  echo "=== $(date '+%F %T') deploy start ==="
+
+  cd /opt/bisheng
+  git fetch origin 2.5.0-PM
+  git reset --hard origin/2.5.0-PM
+  # No 'git clean -fd' — keep untracked dev artefacts (rsync uploads etc).
+
+  cd src/backend
+  /root/.local/bin/uv sync --frozen
+
+  # Idempotent stop
+  pkill -f 'uvicorn bisheng.main' || true
+  pkill -f 'bisheng.worker.main.*knowledge_celery' || true
+  pkill -f 'bisheng.worker.main.*workflow_celery' || true
+  sleep 3
+
+  export BISHENG_PRO=true
+  nohup .venv/bin/uvicorn bisheng.main:app \
+    --host 0.0.0.0 --port 7860 --workers 1 --no-access-log \
+    >> /tmp/bisheng.log 2>&1 &
+  echo "backend started (pid=$!)"
+
+  nohup .venv/bin/celery -A bisheng.worker.main worker -l info \
+    -c 20 -P threads -Q knowledge_celery -n knowledge@%h \
+    >> /tmp/celery-knowledge.log 2>&1 &
+  echo "knowledge worker started (pid=$!)"
+
+  nohup .venv/bin/celery -A bisheng.worker.main worker -l info \
+    -c 100 -P threads -Q workflow_celery -n workflow@%h \
+    >> /tmp/celery-workflow.log 2>&1 &
+  echo "workflow worker started (pid=$!)"
+
+  for i in $(seq 1 30); do
+    if curl -sf http://127.0.0.1:7860/health > /dev/null; then
+      echo "health check passed (${i}s)"
+      break
+    fi
+    sleep 1
+  done
+
+  echo "=== $(date '+%F %T') deploy done ==="
+} 2>&1 | tee -a "$LOG"


### PR DESCRIPTION
## 背景

`/opt/bisheng/deploy.sh` 是 Drone CI 部署 114 服务器时调用的入口脚本（`.drone.yml` feat_cicd pipeline 的 `ssh deploy` step），但一直以来是 114 上的 **untracked 本地脚本**，未入仓库。

今天已经因此阻塞 CI 两次：
- 第一次：文件不知何时丢失 → CI exit 127（"deploy.sh: 没有那个文件或目录"）→ 人工 scp 回去
- 第二次：跑通一次后又丢失 → 同样报错 → 再次 scp 回去

possible 原因：rsync `--delete` / 误手 `rm` / 老版 `git clean -fd` 等任意外部操作都会让它消失，untracked 文件没有任何保护。

## 改动

新建 `deploy.sh` 到仓库根目录（内容与当前 114 上临时版一致）。

## 为什么 git-tracked 后就稳了

- deploy.sh 自己会跑 `git reset --hard origin/2.5.0-PM` → **每次部署都会把最新版脚本还原到磁盘**
- Linux 下执行中的 bash 脚本已被解析器读入内存，`git reset` 覆盖磁盘上的文件不影响当前执行
- 未来任何人/工具再把它删了，下次 CI 一跑就自动恢复

## 脚本职责（保持与临时版一致）

| 做 | 不做 |
|----|------|
| `git fetch + reset --hard origin/2.5.0-PM`（保留 untracked dev 文件） | 跑 alembic 迁移（破坏性 DDL 应人工审核）|
| `uv sync --frozen`（对齐依赖）| 重启前端（vite HMR）|
| kill & restart uvicorn + knowledge_celery(20) + workflow_celery(100) | 启动 celery beat |
| `curl /health` 探活 30s | 启动 Linsight worker |

## 验证

合并后任意 push 到 `2.5.0-PM` 都会触发 CI 跑这个脚本，不再因 deploy.sh 丢失而 exit 127。

🤖 Generated with [Claude Code](https://claude.com/claude-code)