### PR TITLE
fix(auditlog): tenant_id 放开为 NULL-able，修复登录 500

### DIFF
--- a/src/backend/bisheng/core/database/alembic/versions/v2_5_1_f013_auditlog_tenant_id_nullable.py
+++ b/src/backend/bisheng/core/database/alembic/versions/v2_5_1_f013_auditlog_tenant_id_nullable.py
@@ -1,0 +1,74 @@
+"""F013: Relax auditlog.tenant_id to NULL-able.
+
+Revision ID: f013_auditlog_tenant_id_nullable
+Revises: f012_merge_heads
+Create Date: 2026-04-19
+
+Background:
+  F001 multi-tenant migration added ``tenant_id INT NOT NULL DEFAULT 1`` to
+  every business table, including ``auditlog``. F014/F015 later updated the
+  ``AuditLog`` ORM model to ``Optional[int]`` with ``nullable=True`` —
+  reflecting that audit events can be system-level (login, config change)
+  without a target tenant — but shipped no ``ALTER`` to the DB.
+
+  The mismatch breaks user login on any DB upgraded from v2.5.0:
+  ``AuditLogService.user_login`` builds ``AuditLog(tenant_id=None, ...)``,
+  SQLAlchemy emits explicit ``NULL`` (bypassing the DB default 1), and
+  MySQL rejects with error 1048 "Column 'tenant_id' cannot be null" — the
+  login endpoint returns 500 even though password check and token_version
+  refresh already succeeded.
+
+Scope:
+  Only ``auditlog.tenant_id`` is touched. Other business tables keep
+  ``tenant_id NOT NULL DEFAULT 1`` — they describe tenant-owned resources
+  and the F001 constraint is correct for them. ``auditlog`` is the
+  exception because it also records tenant-free system events.
+
+Idempotent: checks current nullability via information_schema before ALTER.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = 'f013_auditlog_tenant_id_nullable'
+down_revision: Union[str, Sequence[str], None] = 'f012_merge_heads'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _is_nullable(table: str, column: str) -> bool:
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            """
+            SELECT IS_NULLABLE FROM information_schema.COLUMNS
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND TABLE_NAME = :t
+              AND COLUMN_NAME = :c
+            """
+        ),
+        {'t': table, 'c': column},
+    )
+    row = result.first()
+    return row is not None and row[0] == 'YES'
+
+
+def upgrade() -> None:
+    if _is_nullable('auditlog', 'tenant_id'):
+        return
+    op.execute(
+        sa.text('ALTER TABLE auditlog MODIFY COLUMN tenant_id INT NULL')
+    )
+
+
+def downgrade() -> None:
+    # Downgrade would require the column to be NOT NULL with a default.
+    # Backfill NULL rows to 1 first, then re-add the constraint.
+    op.execute(
+        sa.text('UPDATE auditlog SET tenant_id = 1 WHERE tenant_id IS NULL')
+    )
+    op.execute(
+        sa.text("ALTER TABLE auditlog MODIFY COLUMN tenant_id INT NOT NULL DEFAULT 1")
+    )


### PR DESCRIPTION
## 背景

F001 多租户迁移给所有业务表加了 `tenant_id INT NOT NULL DEFAULT 1`。F014/F015 后续把 `AuditLog` ORM 改成 `Optional[int] + nullable=True`（因为系统事件如登录、配置变更没有 target 租户），但**漏了配套 ALTER**。

## 症状

登录接口执行到 `AuditLogService.user_login` → `AuditLog(tenant_id=None)` 时，SQLAlchemy 显式发 `NULL`（绕过 DB 默认值 1），MySQL 抛：

```
(pymysql.err.IntegrityError) (1048, "Column 'tenant_id' cannot be null")
```

整个 login 返回 500 —— **密码校验、F012 token_version 刷新等 happy path 前面步骤都已通过**，只是最后写 auditlog 这一步失败。

## 修复

新增 alembic 迁移 `v2_5_1_f013_auditlog_tenant_id_nullable.py`：

```sql
ALTER TABLE auditlog MODIFY COLUMN tenant_id INT NULL
```

幂等：通过 information_schema 预检，已 NULL 则跳过。

## 为什么只改 auditlog

其他业务表（flow / knowledge / assistant / ...）的 `tenant_id NOT NULL DEFAULT 1` 保持不变——它们描述租户归属资源，F001 约束对它们是正确的。auditlog 是唯一例外：它也记录跨租户的系统级事件（登录、全局配置变更等），本来就应该允许 tenant_id 为 NULL，与 ORM 模型的 `Optional[int]` 语义对齐。

## 验证

114 上手动 ALTER 已完成，admin/Bisheng@top1 登录恢复：

```
HTTP 200 - 200 SUCCESS
user: admin, tenant_id: 1, access_token present
```

本迁移仅把 114 已手动完成的 schema 变更固化进版本控制，让其他 deploy 在 `alembic upgrade head` 时自动处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)