### PR TITLE
fix: correct AlibabaPuHuiTi font path in style.css

### DIFF
--- a/src/frontend/client/src/style.css
+++ b/src/frontend/client/src/style.css
@@ -196,8 +196,7 @@ html {
 
 @font-face {
   font-family: AlibabaPuHuiTi-3-55-Regular;
-  /* src: url("assets/text-security-disc.woff") format("woff"); */
-  src: url("assets/AlibabaPuHuiTi-3-55-Regular.woff") format("woff");
+  src: url("$fonts/AlibabaPuHuiTi-3-55-Regular.woff") format("woff");
 }
 
 .text-token-text-primary {


### PR DESCRIPTION
Fixes #1915

## Problem

The `@font-face` rule for `AlibabaPuHuiTi-3-55-Regular` in `src/frontend/client/src/style.css` referenced the font file via `assets/AlibabaPuHuiTi-3-55-Regular.woff`, but the file actually lives in `public/fonts/`. This caused the font to fail to load.

## Solution

Updated the URL to use the `$fonts` alias (`$fonts/AlibabaPuHuiTi-3-55-Regular.woff`), which is configured in `vite.config.ts` to resolve to `public/fonts/`. This is consistent with all other `@font-face` declarations in the same file (Inter, Roboto Mono, etc.). Also removed the stale commented-out `text-security-disc.woff` line.

## Testing

- Verified the font file exists at `src/frontend/client/public/fonts/AlibabaPuHuiTi-3-55-Regular.woff`
- Confirmed `$fonts` alias is configured in `vite.config.ts` (line 309): `$fonts: path.resolve(__dirname, 'public/fonts')`
- The fix aligns with how all other fonts are loaded in the same file