### PR TITLE
Feat/2.5.0

### DIFF
--- a/src/frontend/platform/src/pages/DepartmentPage/components/MemberTable.tsx
+++ b/src/frontend/platform/src/pages/DepartmentPage/components/MemberTable.tsx
@@ -68,11 +68,13 @@ interface MemberTableProps {
   }) => void
 }
 
+const EMPTY_DEPARTMENT_TREE: DepartmentTreeNode[] = []
+
 export function MemberTable({
   deptId,
   deptName,
   dept = null,
-  tree = [],
+  tree = EMPTY_DEPARTMENT_TREE,
   isArchived = false,
   onChanged,
   membersRefreshSignal = 0,

--- a/src/frontend/platform/src/pages/SystemPage/components/Departments.tsx
+++ b/src/frontend/platform/src/pages/SystemPage/components/Departments.tsx
@@ -220,6 +220,8 @@ export default function Departments() {
               <MemberTable
                 deptId={selectedDept.dept_id}
                 deptName={selectedDept.name}
+                dept={selectedDept}
+                tree={tree}
                 isArchived={selectedDept.status === "archived"}
                 onChanged={handleTreeChange}
                 membersRefreshSignal={membersRefreshSignal}

--- a/src/frontend/platform/src/test/systemDepartmentsArchivedDelete.test.tsx
+++ b/src/frontend/platform/src/test/systemDepartmentsArchivedDelete.test.tsx
@@ -21,13 +21,22 @@ vi.mock("@/pages/DepartmentPage/components/MemberTable", () => ({
   MemberTable: ({
     deptName,
     isArchived,
+    dept,
+    tree,
   }: {
     deptName: string;
     isArchived?: boolean;
+    dept?: DepartmentTreeNode | null;
+    tree?: DepartmentTreeNode[];
   }) => (
-    <button type="button" disabled={isArchived} data-testid="create-local-user">
-      {deptName}: bs:department.createLocalUser
-    </button>
+    <div>
+      <button type="button" disabled={isArchived} data-testid="create-local-user">
+        {deptName}: bs:department.createLocalUser
+      </button>
+      <div data-testid="member-table-context">
+        {dept?.dept_id ?? "none"}:{tree?.length ?? 0}
+      </div>
+    </div>
   ),
 }));
 
@@ -94,6 +103,14 @@ describe("System departments archived and deleted states", () => {
     render(<Departments />);
 
     expect(await screen.findByTestId("create-local-user")).toBeDisabled();
+  });
+
+  it("passes the selected department context into the member table", async () => {
+    render(<Departments />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("member-table-context")).toHaveTextContent("BS@archived:1");
+    });
   });
 
   it("switches away from a permanently deleted selected department", async () => {


### PR DESCRIPTION
The system department page reused the member table without passing the selected department tree context. MemberTable then fell back to a fresh empty array on every render, which retriggered the admin summary effect after each empty response.

Constraint: /sys shares DepartmentPage member components and may omit optional props.\nRejected: Remove admin summary loading | it is still needed for inherited department admin badges.\nConfidence: high\nScope-risk: narrow\nDirective: Keep optional array prop defaults referentially stable in React components used by effects.\nTested: npm test -- --run src/test/systemDepartmentsArchivedDelete.test.tsx src/test/departmentPageRefresh.test.tsx\nNot-tested: Manual browser verification on http://192.168.106.120:3003/sys