### PR TITLE
Keep resource grants off organization tree

### DIFF
--- a/src/backend/bisheng/channel/domain/services/channel_service.py
+++ b/src/backend/bisheng/channel/domain/services/channel_service.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from datetime import timedelta, datetime
-from typing import List, Optional, Dict, Any
+from typing import TYPE_CHECKING, List, Optional, Dict, Any
 
 from bisheng.channel.domain.models.article_read_record import ArticleReadRecord
 from bisheng.channel.domain.models.channel import Channel, ChannelVisibilityEnum
@@ -46,7 +46,6 @@ from bisheng.common.errcode.channel import (
     ChannelPermissionDeniedError,
     ChannelCreateLimitExceededError,
     ChannelAdminLimitExceededError,
-    ChannelSubscribeLimitExceededError,
 )
 from bisheng.common.errcode.knowledge_space import SpacePermissionDeniedError, SpaceFileNameDuplicateError
 from bisheng.common.models.space_channel_member import (
@@ -59,11 +58,15 @@ from bisheng.common.models.space_channel_member import (
 from bisheng.common.repositories.interfaces.space_channel_member_repository import SpaceChannelMemberRepository
 from bisheng.core.external.bisheng_information_client.bisheng_information_manager import get_bisheng_information_client
 from bisheng.permission.domain.services.owner_service import OwnerService
+from bisheng.role.domain.services.quota_service import QuotaResourceType, QuotaService
 from bisheng.core.storage.minio.minio_manager import get_minio_storage
 from bisheng.knowledge.domain.models.knowledge_file import FileSource
 from bisheng.message.domain.services.message_service import MessageService
 from bisheng.user.domain.models.user import UserDao
 from bisheng.utils import generate_uuid, get_request_ip
+
+if TYPE_CHECKING:
+    from starlette.requests import Request
 
 logger = logging.getLogger(__name__)
 
@@ -71,8 +74,6 @@ logger = logging.getLogger(__name__)
 MAX_USER_CHANNEL_COUNT = 10
 # Maximum number of administrators per channel
 MAX_ADMIN_COUNT = 5
-# Maximum number of channels a user can subscribe to (excluding self-created channels)
-MAX_USER_SUBSCRIBE_COUNT = 20
 CHANNEL_ADMIN_ASSIGNMENT_MESSAGE = "assigned_channel_admin"
 
 
@@ -195,7 +196,6 @@ class ChannelService:
                     new_channel_info_sources.append(new_source)
 
                 if new_channel_info_sources:
-                    from bisheng.worker.information.article import sync_information_article
                     await self.channel_info_source_repository.batch_add(new_channel_info_sources)
 
         # Update latest_article_update_time for the new channel
@@ -749,13 +749,12 @@ class ChannelService:
             return SubscriptionStatusEnum.PENDING
 
         if not existing_membership or existing_membership.status == MembershipStatusEnum.REJECTED:
-            subscribed_channels = await self.space_channel_member_repository.find_channel_memberships(
+            await QuotaService.check_quota(
                 user_id=login_user.user_id,
-                roles=[UserRoleEnum.MEMBER, UserRoleEnum.ADMIN],
-                statuses=[MembershipStatusEnum.ACTIVE, MembershipStatusEnum.PENDING]
+                resource_type=QuotaResourceType.CHANNEL_SUBSCRIBE,
+                tenant_id=login_user.tenant_id,
+                login_user=login_user,
             )
-            if len(subscribed_channels) >= MAX_USER_SUBSCRIBE_COUNT:
-                raise ChannelSubscribeLimitExceededError()
 
         previous_status = existing_membership.status if existing_membership else None
         if existing_membership:

--- a/src/backend/bisheng/common/init_data.py
+++ b/src/backend/bisheng/common/init_data.py
@@ -51,6 +51,8 @@ async def init_default_data():
                         RoleAccess(role_id=DefaultRole, type=AccessType.WEB_MENU.value,
                                    third_id=WebMenuResource.APPS.value),
                         RoleAccess(role_id=DefaultRole, type=AccessType.WEB_MENU.value,
+                                   third_id=WebMenuResource.SUBSCRIPTION.value),
+                        RoleAccess(role_id=DefaultRole, type=AccessType.WEB_MENU.value,
                                    third_id=WebMenuResource.BUILD.value),
                         RoleAccess(role_id=DefaultRole, type=AccessType.WEB_MENU.value,
                                    third_id=WebMenuResource.KNOWLEDGE.value),

--- a/src/backend/bisheng/core/database/alembic/versions/v2_5_1_f032_workbench_subscription_web_menu_backfill.py
+++ b/src/backend/bisheng/core/database/alembic/versions/v2_5_1_f032_workbench_subscription_web_menu_backfill.py
@@ -1,0 +1,43 @@
+"""F032: backfill WEB_MENU ``subscription`` for roles with ``workstation``.
+
+Revision ID: f032_workbench_subscription_web_menu_backfill
+Revises: f031_startup_hotfix_fields
+Create Date: 2026-04-27
+
+Aligns historical roles with F028-style workbench keys: if a role already has
+the parent ``workstation`` WEB_MENU row but no ``subscription`` child, insert
+one so 首页/应用/订阅/知识空间四项与新建角色默认一致。
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = 'f032_workbench_subscription_web_menu_backfill'
+down_revision: Union[str, Sequence[str], None] = 'f031_startup_hotfix_fields'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+WEB_MENU = 99
+
+
+def upgrade() -> None:
+    op.execute(f"""
+        INSERT INTO roleaccess (role_id, third_id, type, tenant_id)
+        SELECT DISTINCT r.role_id, 'subscription', {WEB_MENU}, r.tenant_id
+        FROM roleaccess r
+        WHERE r.type = {WEB_MENU}
+          AND r.third_id = 'workstation'
+          AND NOT EXISTS (
+            SELECT 1 FROM roleaccess x
+            WHERE x.role_id = r.role_id
+              AND x.type = {WEB_MENU}
+              AND x.third_id = 'subscription'
+              AND (x.tenant_id <=> r.tenant_id)
+          )
+    """)
+
+
+def downgrade() -> None:
+    """No-op: cannot distinguish backfilled rows from manually granted ones."""
+    pass

--- a/src/backend/bisheng/core/external/bisheng_information_client/bisheng_information_manager.py
+++ b/src/backend/bisheng/core/external/bisheng_information_client/bisheng_information_manager.py
@@ -1,75 +1,15 @@
-from bisheng.core.config.settings import IntelligenceCenterConf
-from bisheng.core.context import BaseContextManager
 from bisheng.core.external.bisheng_information_client.client import BishengInformationClient
 
 
-class BishengInformationManager(BaseContextManager[BishengInformationClient]):
-    """Bisheng Information Manager
-
-    Inherited From BaseContextManagerProvided by Bisheng Information Client lifecycle management
-    Supports lazy loading and caching
-    """
-
-    name = 'bisheng_information_client'
-
-    def __init__(self, http_client, intelligence_center_conf: IntelligenceCenterConf):
-        super().__init__()
-        self.http_client = http_client
-        self.intelligence_center_conf = intelligence_center_conf
-
-    async def _async_initialize(self) -> BishengInformationClient:
-        """Async Initialization Bisheng Information Client"""
-
-        def get_api_key() -> str:
-            from bisheng.common.services.config_service import settings
-            return settings.get_intelligence_center_conf().api_key
-
-        return BishengInformationClient(self.http_client, self.intelligence_center_conf.base_url,
-                                        get_api_key)
-
-    def _sync_initialize(self) -> BishengInformationClient:
-        """Sync Initialization Bisheng Information Client"""
-
-        def get_api_key() -> str:
-            from bisheng.common.services.config_service import settings
-            return settings.get_intelligence_center_conf().api_key
-
-        return BishengInformationClient(self.http_client, self.intelligence_center_conf.base_url,
-                                        get_api_key)
-
-    async def _async_cleanup(self) -> None:
-        """Asynchronous Cleanup Bisheng Information Client"""
-        pass
-
-    def _sync_cleanup(self) -> None:
-        """Synchronous Cleanup Bisheng Information Client"""
-        pass
-
-
 async def get_bisheng_information_client() -> BishengInformationClient:
-    """Dapatkan Bisheng Information Client Instance"""
-    from bisheng.core.context.manager import app_context
-    try:
-        return await app_context.async_get_instance(BishengInformationManager.name)
-    except KeyError:
-        from bisheng.common.services.config_service import settings
-        from bisheng.core.external.http_client.http_client_manager import get_http_client
-        http_client = await get_http_client()
-        config = await settings.aget_intelligence_center_conf()
-        app_context.register_context(
-            BishengInformationManager(http_client, config)
-        )
-        return await app_context.async_get_instance(BishengInformationManager.name)
+    """Get a lightweight Bisheng Information Client with the latest config."""
+    from bisheng.common.services.config_service import settings
+    from bisheng.core.external.http_client.http_client_manager import get_http_client
+    http_client = await get_http_client()
+    return BishengInformationClient(http_client=http_client, get_conf=settings.get_intelligence_center_conf)
 
 
 def get_bisheng_information_client_sync() -> BishengInformationClient:
-    """Get Bisheng Information Client Instance"""
-    from bisheng.core.context.manager import app_context
-    try:
-        return app_context.sync_get_instance(BishengInformationManager.name)
-    except KeyError:
-        from bisheng.common.services.config_service import settings
-        app_context.register_context(
-            BishengInformationManager(None, settings.get_intelligence_center_conf())
-        )
-        return app_context.sync_get_instance(BishengInformationManager.name)
+    """Get a lightweight sync Bisheng Information Client with the latest config."""
+    from bisheng.common.services.config_service import settings
+    return BishengInformationClient(http_client=None, get_conf=settings.get_intelligence_center_conf)

--- a/src/backend/bisheng/core/external/bisheng_information_client/client.py
+++ b/src/backend/bisheng/core/external/bisheng_information_client/client.py
@@ -1,9 +1,10 @@
 from enum import Enum
-from typing import Callable, Optional, Union
+from typing import Callable, Optional
 
 import httpx
 from aiohttp import ClientTimeout
 
+from bisheng.core.config.settings import IntelligenceCenterConf
 from bisheng.common.errcode.channel import BishengInformationUnAuthorizedError, BishengInformationServiceError, \
     InformationSourceParseError, InformationSourceAuthError, InformationSourcePageError, \
     InformationSourceCrawlLimitError, InformationSourceSubscriptionLimitError, \
@@ -36,23 +37,25 @@ class InformationSourceSubscribeError(Exception):
 
 class BishengInformationClient(object):
 
-    def __init__(self, http_client: AsyncHttpClient, base_url: str,
-                 api_key: Union[str, Callable[[], str]], **kwargs):
+    def __init__(self, http_client: Optional[AsyncHttpClient],
+                 get_conf: Callable[[], IntelligenceCenterConf]):
         self.http_client = http_client
-        self.base_url = base_url
-        self._api_key = api_key
-
-        self.timeout = None
-
-        if kwargs.get("timeout"):
-            self.timeout = ClientTimeout(total=kwargs["timeout"])
+        self._get_conf = get_conf
 
     @property
-    def api_key(self) -> str:
-        """Get the API key, supporting both direct string and callable for dynamic retrieval."""
-        if callable(self._api_key):
-            return self._api_key()
-        return self._api_key
+    def conf(self) -> IntelligenceCenterConf:
+        return self._get_conf()
+
+    @staticmethod
+    def _build_timeout(conf: IntelligenceCenterConf) -> Optional[ClientTimeout]:
+        timeout = (conf.kwargs or {}).get("timeout")
+        if timeout:
+            return ClientTimeout(total=timeout)
+        return None
+
+    def _build_request_options(self) -> tuple[str, dict, Optional[ClientTimeout]]:
+        conf = self.conf
+        return conf.base_url.rstrip("/"), {"X-API-Key": conf.api_key}, self._build_timeout(conf)
 
     @staticmethod
     def _raise_limit_error(code: int) -> None:
@@ -131,10 +134,10 @@ class BishengInformationClient(object):
 
     async def add_website_information_source(self, url: str) -> InformationSourceResponse:
         """Add a new information source by URL."""
-        endpoint = f"{self.base_url}/information/add_website"
-        headers = {"X-API-Key": self.api_key}
+        base_url, headers, timeout = self._build_request_options()
+        endpoint = f"{base_url}/information/add_website"
         data = {"url": url}
-        response = await self.http_client.post(endpoint, body=data, headers=headers, timeout=self.timeout)
+        response = await self.http_client.post(endpoint, body=data, headers=headers, timeout=timeout)
 
         response_body = self._handle_response(
             response,
@@ -148,10 +151,10 @@ class BishengInformationClient(object):
 
     async def add_wechat_information_source(self, url: str) -> InformationSourceResponse:
         """Add a new WeChat information source by URL."""
-        endpoint = f"{self.base_url}/information/add_wechat"
-        headers = {"X-API-Key": self.api_key}
+        base_url, headers, timeout = self._build_request_options()
+        endpoint = f"{base_url}/information/add_wechat"
         data = {"url": url}
-        response = await self.http_client.post(endpoint, body=data, headers=headers, timeout=self.timeout)
+        response = await self.http_client.post(endpoint, body=data, headers=headers, timeout=timeout)
 
         response_body = self._handle_response(
             response,
@@ -166,8 +169,8 @@ class BishengInformationClient(object):
     async def search_information_sources(self, query: str, business_type: Optional[BusinessType] = None, page: int = 1,
                                          page_size: int = 20) -> tuple[list[InformationSourceResponse], int]:
         """Search information sources by keyword."""
-        endpoint = f"{self.base_url}/information/search"
-        headers = {"X-API-Key": self.api_key}
+        base_url, headers, timeout = self._build_request_options()
+        endpoint = f"{base_url}/information/search"
 
         params = {
             "keyword": query,
@@ -178,7 +181,7 @@ class BishengInformationClient(object):
         if business_type:
             params["business_type"] = business_type.value
 
-        response = await self.http_client.get(endpoint, headers=headers, params=params, timeout=self.timeout)
+        response = await self.http_client.get(endpoint, headers=headers, params=params, timeout=timeout)
         response_body = self._handle_response(response, "Failed to search information sources")
 
         information_sources_data = response_body.get("data", [])
@@ -188,10 +191,10 @@ class BishengInformationClient(object):
 
     async def get_information_source_by_ids(self, source_ids: list[str]) -> list[InformationSourceResponse]:
         """Get information sources by a list of source IDs."""
-        endpoint = f"{self.base_url}/information/source_by_ids"
-        headers = {"X-API-Key": self.api_key}
+        base_url, headers, timeout = self._build_request_options()
+        endpoint = f"{base_url}/information/source_by_ids"
         data = {"information_ids": source_ids}
-        response = await self.http_client.post(endpoint, body=data, headers=headers, timeout=self.timeout)
+        response = await self.http_client.post(endpoint, body=data, headers=headers, timeout=timeout)
         response_body = self._handle_response(response, "Failed to get information sources by ids")
 
         information_sources_data = response_body.get("data", [])
@@ -200,8 +203,8 @@ class BishengInformationClient(object):
     async def list_information_sources(self, business_type: BusinessType, page: int = 1, page_size: int = 20) -> tuple[
         list[InformationSourceResponse], int]:
         """List all information sources."""
-        endpoint = f"{self.base_url}/information/list"
-        headers = {"X-API-Key": self.api_key}
+        base_url, headers, timeout = self._build_request_options()
+        endpoint = f"{base_url}/information/list"
 
         params = {
             "business_type": business_type.value,
@@ -209,7 +212,7 @@ class BishengInformationClient(object):
             "page_size": page_size
         }
 
-        response = await self.http_client.get(endpoint, headers=headers, params=params, timeout=self.timeout)
+        response = await self.http_client.get(endpoint, headers=headers, params=params, timeout=timeout)
         response_body = self._handle_response(response, "Failed to list information sources")
 
         information_sources_data = response_body.get("data", [])
@@ -220,10 +223,10 @@ class BishengInformationClient(object):
 
     async def subscribe_information_source(self, source_ids: list[str]) -> None:
         """Subscribe to an information source by source_id."""
-        endpoint = f"{self.base_url}/information/subscribe"
-        headers = {"X-API-Key": self.api_key}
+        base_url, headers, timeout = self._build_request_options()
+        endpoint = f"{base_url}/information/subscribe"
         data = {"information_ids": source_ids}
-        response = await self.http_client.post(endpoint, body=data, headers=headers, timeout=self.timeout)
+        response = await self.http_client.post(endpoint, body=data, headers=headers, timeout=timeout)
         self._handle_response(
             response,
             "Failed to subscribe to information source",
@@ -232,10 +235,10 @@ class BishengInformationClient(object):
 
     async def unsubscribe_information_source(self, source_ids: list[str]) -> None:
         """Unsubscribe from an information source by source_id."""
-        endpoint = f"{self.base_url}/information/unsubscribe"
-        headers = {"X-API-Key": self.api_key}
+        base_url, headers, timeout = self._build_request_options()
+        endpoint = f"{base_url}/information/unsubscribe"
         data = {"information_ids": source_ids}
-        response = await self.http_client.post(endpoint, body=data, headers=headers, timeout=self.timeout)
+        response = await self.http_client.post(endpoint, body=data, headers=headers, timeout=timeout)
         self._handle_response(
             response,
             "Failed to unsubscribe from information source",
@@ -244,10 +247,10 @@ class BishengInformationClient(object):
 
     async def crawl_website(self, url: str) -> CrawlWebsiteResponse:
         """Crawl a website by URL."""
-        endpoint = f"{self.base_url}/information/crawl"
-        headers = {"X-API-Key": self.api_key}
+        base_url, headers, timeout = self._build_request_options()
+        endpoint = f"{base_url}/information/crawl"
         data = {"url": url}
-        response = await self.http_client.post(endpoint, body=data, headers=headers, timeout=self.timeout)
+        response = await self.http_client.post(endpoint, body=data, headers=headers, timeout=timeout)
         response_body = self._handle_response(
             response,
             "Failed to crawl website",
@@ -262,8 +265,8 @@ class BishengInformationClient(object):
                                  min_create_time: int = None, page: int = 1, page_size: int = 20) \
             -> InformationArticlesResponse:
         """Get articles of an information source by source_id."""
-        endpoint = f"{self.base_url}/information/articles/{information_id}"
-        headers = {"X-API-Key": self.api_key}
+        base_url, headers, timeout = self._build_request_options()
+        endpoint = f"{base_url}/information/articles/{information_id}"
 
         params = {
             "return_information": return_information,
@@ -272,8 +275,9 @@ class BishengInformationClient(object):
         }
         if min_create_time:
             params["min_create_time"] = min_create_time
+        timeout_value = timeout.total if timeout else None
         with httpx.Client() as client:
-            response = client.get(endpoint, headers=headers, params=params)
+            response = client.get(endpoint, headers=headers, params=params, timeout=timeout_value)
         response_body = self._handle_response(response, "Failed to get information articles")
         return InformationArticlesResponse(information=response_body.get("data", {}).get("information"),
                                            articles=response_body.get("data", {}).get("articles", []),

--- a/src/backend/bisheng/department/api/endpoints/department.py
+++ b/src/backend/bisheng/department/api/endpoints/department.py
@@ -53,6 +53,7 @@ async def global_members_search(
 ):
     """全组织按用户名搜索成员（主属部门路径）；可见范围与 :meth:`DepartmentService.aget_tree` 一致。
 
+    含未启用账号（``User.delete=1``），与部门成员列表一致，便于管理员搜索定位。
     使用 ``/search/...`` 前缀，避免与 ``GET /{dept_id}`` 单段路径冲突（否则 ``global-members`` 会被当成 dept_id）。
     """
     try:

--- a/src/backend/bisheng/department/domain/services/department_service.py
+++ b/src/backend/bisheng/department/domain/services/department_service.py
@@ -1182,11 +1182,14 @@ class DepartmentService:
                     labels.append(self_nm)
                 return '/'.join(labels) if labels else (self_nm or '')
 
+            # Do not filter User.delete: 部门成员列表 aget_members 包含未启用用户，
+            # 全组织搜索需一致，否则无法按姓名定位已禁用成员。
             base_group = (
                 select(
                     User.user_id,
                     User.user_name,
                     func.min(Department.id).label('dept_int_id'),
+                    func.max(User.delete).label('user_deleted'),
                 )
                 .join(
                     UserDepartment,
@@ -1195,7 +1198,6 @@ class DepartmentService:
                 )
                 .join(Department, Department.id == UserDepartment.department_id)
                 .where(
-                    User.delete == 0,
                     Department.status == 'active',
                     col(Department.id).in_(visible_ids),
                     User.user_name.like(f'%{kw}%'),
@@ -1228,12 +1230,14 @@ class DepartmentService:
             d = dept_by_id.get(int(r.dept_int_id))
             if not d:
                 continue
+            udel = int(getattr(r, 'user_deleted', 0) or 0)
             data.append(
                 {
                     'user_id': int(r.user_id),
                     'user_name': r.user_name,
                     'primary_department_dept_id': d.dept_id,
                     'primary_department_path': _primary_dept_display_path(d),
+                    'enabled': udel == 0,
                 }
             )
         return {'data': data, 'total': int(total)}

--- a/src/backend/bisheng/role/domain/services/quota_service.py
+++ b/src/backend/bisheng/role/domain/services/quota_service.py
@@ -15,7 +15,7 @@ import functools
 import logging
 from typing import Optional, Union
 
-from bisheng.common.errcode.role import QuotaExceededError, QuotaConfigInvalidError
+from bisheng.common.errcode.role import QuotaConfigInvalidError
 from bisheng.common.errcode.tenant_quota import (
     TenantQuotaExceededError,
     TenantRoleQuotaExceededError,
@@ -60,7 +60,14 @@ _RESOURCE_COUNT_TEMPLATES: dict[str, str] = {
     # KI-01 fix: channel has no `status` column either; removed filter to
     # avoid silent 0 counts via _count_resource's try/except.
     'channel': "SELECT COUNT(*) FROM channel WHERE {col}=:{param}",
-    'channel_subscribe': "SELECT COUNT(*) FROM channel WHERE {col}=:{param}",
+    'channel_subscribe': (
+        "SELECT COUNT(*) FROM space_channel_member scm "
+        "INNER JOIN channel c ON c.id=scm.business_id "
+        "WHERE scm.business_type='CHANNEL' "
+        "AND scm.user_role IN ('MEMBER','ADMIN') "
+        "AND scm.status IN ('ACTIVE','PENDING') "
+        "AND {qualified_col}=:{param}"
+    ),
     'workflow': "SELECT COUNT(*) FROM flow WHERE {col}=:{param} AND flow_type=10 AND status!=0",
     'assistant': "SELECT COUNT(*) FROM flow WHERE {col}=:{param} AND flow_type=5 AND status!=0",
     # KI-01 fix: actual table is `t_gpts_tools` (t_ prefix); `gpts_tools`
@@ -509,7 +516,14 @@ class QuotaService:
             return 0
 
         param = 'id_val'
-        sql = template.format(col=col, param=param)
+        qualified_col = (
+            'scm.user_id'
+            if resource_type == 'channel_subscribe' and col == 'user_id'
+            else 'c.tenant_id'
+            if resource_type == 'channel_subscribe' and col == 'tenant_id'
+            else col
+        )
+        sql = template.format(col=col, qualified_col=qualified_col, param=param)
         try:
             async with get_async_db_session() as session:
                 result = await session.execute(text(sql), {param: val})

--- a/src/backend/bisheng/sso_sync/domain/services/login_sync_service.py
+++ b/src/backend/bisheng/sso_sync/domain/services/login_sync_service.py
@@ -264,9 +264,9 @@ class LoginSyncService:
                 new_delete = 1 if payload.account_disabled is True else 0
                 ds = cls._disable_source_for_row(row_source, new_delete)
                 new_user = User(
-                    user_name=attrs.name or ext,
-                    email=attrs.email,
-                    phone_number=attrs.phone,
+                    user_name=(attrs.name.strip() if attrs.name else '') or ext,
+                    email=cls._normalize_contact_field(attrs.email),
+                    phone_number=cls._normalize_contact_field(attrs.phone),
                     external_id=ext,
                     source=row_source,
                     password='',
@@ -287,8 +287,12 @@ class LoginSyncService:
                         f'failed to create user for external_id={ext}: {e}'
                     )
         else:
+            # WeCom (and Gateway) send explicit ``account_disabled``; when False,
+            # the row below must flip ``delete`` back to 0. Unconditional forbid
+            # here blocked re-enable after 企微禁用 → 再启用 (delete stayed 1).
             if int(getattr(user, 'delete', 0) or 0) == 1:
-                raise UserForbiddenError.http_exception()
+                if payload.account_disabled is None:
+                    raise UserForbiddenError.http_exception()
             cls._apply_user_attrs(user, attrs)
             cls._touch_user_sync_time(user)
             await UserDao.aupdate_user(user)
@@ -305,15 +309,29 @@ class LoginSyncService:
             raise UserForbiddenError.http_exception()
         return user
 
+    @staticmethod
+    def _normalize_contact_field(val: Optional[str]) -> Optional[str]:
+        """Strip; empty string → None. ``None`` means omit (do not overwrite in apply)."""
+        if val is None:
+            return None
+        s = val.strip()
+        return s if s else None
+
     @classmethod
     def _apply_user_attrs(cls, user: User, attrs) -> None:
         """Apply present HR attributes without clearing omitted fields."""
-        if attrs.name and user.user_name != attrs.name:
-            user.user_name = attrs.name
-        if attrs.email is not None and user.email != attrs.email:
-            user.email = attrs.email
-        if attrs.phone is not None and user.phone_number != attrs.phone:
-            user.phone_number = attrs.phone
+        if attrs.name:
+            nm = attrs.name.strip()
+            if nm and user.user_name != nm:
+                user.user_name = nm
+        if attrs.email is not None:
+            ne = cls._normalize_contact_field(attrs.email)
+            if user.email != ne:
+                user.email = ne
+        if attrs.phone is not None:
+            np = cls._normalize_contact_field(attrs.phone)
+            if user.phone_number != np:
+                user.phone_number = np
 
     @classmethod
     def _touch_user_sync_time(cls, user: User) -> None:

--- a/src/backend/bisheng/sso_sync/domain/services/wecom_gateway_absent_reconcile.py
+++ b/src/backend/bisheng/sso_sync/domain/services/wecom_gateway_absent_reconcile.py
@@ -3,16 +3,37 @@
 from __future__ import annotations
 
 import logging
-from typing import Set
+from typing import List, Set, Tuple
 
-from sqlalchemy import update
+from sqlalchemy import delete, update
 from sqlmodel import select
 
 from bisheng.core.database import get_async_db_session
+from bisheng.database.models.department import UserDepartment
+from bisheng.database.models.department_admin_grant import DepartmentAdminGrant
+from bisheng.department.domain.services.department_change_handler import (
+    DepartmentChangeHandler,
+)
 from bisheng.sso_sync.domain.constants import WECOM_SOURCE
 from bisheng.user.domain.models.user import User, UserDao
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_int_ids(rows) -> List[int]:
+    """Normalize ``select(User.user_id)`` rows to plain ints across drivers."""
+    out: List[int] = []
+    for row in rows or []:
+        if row is None:
+            continue
+        if isinstance(row, (list, tuple)):
+            out.append(int(row[0]))
+            continue
+        try:
+            out.append(int(row[0]))
+        except (TypeError, KeyError, IndexError):
+            out.append(int(row))
+    return out
 
 
 async def disable_wecom_users_absent_from_import(
@@ -21,8 +42,11 @@ async def disable_wecom_users_absent_from_import(
     """Disable active WeCom users not present in the current Gateway batch.
 
     The Gateway endpoint sends a full user snapshot. Any existing WeCom user
-    omitted from that snapshot has left the upstream org and must be disabled.
-    Token versions are bumped so existing sessions are forced out.
+    omitted from that snapshot has left the upstream org: soft-disable the
+    account, **remove all department memberships** (PRD 8c — no longer in the
+    personnel list), revoke persisted SSO admin grants, and drop OpenFGA
+    member/admin tuples. Token versions are bumped so existing sessions are
+    forced out.
     """
     imported = {
         str(one).strip()
@@ -38,20 +62,51 @@ async def disable_wecom_users_absent_from_import(
         if imported:
             stmt = stmt.where(~User.external_id.in_(imported))
 
-        rows = (await session.exec(stmt)).all()
-        user_ids = [
-            int(row[0] if isinstance(row, tuple) else row)
-            for row in rows
-        ]
+        result = await session.exec(stmt)
+        user_ids = _normalize_int_ids(result.all())
         if not user_ids:
             return 0
 
-        await session.exec(
+        ud_result = await session.exec(
+            select(UserDepartment.department_id, UserDepartment.user_id).where(
+                UserDepartment.user_id.in_(user_ids),
+            ),
+        )
+        dept_user_pairs: List[Tuple[int, int]] = []
+        for row in ud_result.all():
+            try:
+                dept_id = int(row[0])
+                uid = int(row[1])
+            except (TypeError, ValueError, IndexError):
+                continue
+            dept_user_pairs.append((dept_id, uid))
+
+        await session.execute(
             update(User)
             .where(User.user_id.in_(user_ids))
-            .values(delete=1, disable_source='wecom_absent')
+            .values(delete=1, disable_source='wecom_absent'),
+        )
+        await session.execute(
+            delete(UserDepartment).where(UserDepartment.user_id.in_(user_ids)),
+        )
+        await session.execute(
+            delete(DepartmentAdminGrant).where(
+                DepartmentAdminGrant.user_id.in_(user_ids),
+            ),
         )
         await session.commit()
+
+    ops: list = []
+    seen: set[Tuple[int, int]] = set()
+    for dept_id, uid in dept_user_pairs:
+        key = (dept_id, uid)
+        if key in seen:
+            continue
+        seen.add(key)
+        ops.extend(DepartmentChangeHandler.on_member_removed(dept_id, uid))
+        ops.extend(DepartmentChangeHandler.on_admin_removed(dept_id, [uid]))
+    if ops:
+        await DepartmentChangeHandler.execute_async(ops)
 
     disabled = 0
     for user_id in user_ids:

--- a/src/backend/bisheng/utils/http_middleware.py
+++ b/src/backend/bisheng/utils/http_middleware.py
@@ -28,6 +28,7 @@ TENANT_CHECK_EXEMPT_PATHS = (
     # tenant context from cookies; the service layer installs
     # ROOT_TENANT_ID + bypass_tenant_filter explicitly.
     '/api/v1/internal/sso/login-sync',
+    '/api/v1/internal/sso/gateway-wecom-org-sync',
     '/api/v1/departments/sync',
     # v2.5.1 F015: HMAC-signed relink + resolve-conflict endpoints.
     '/api/v1/internal/departments/relink',

--- a/src/backend/bisheng/worker/knowledge/file_worker.py
+++ b/src/backend/bisheng/worker/knowledge/file_worker.py
@@ -87,10 +87,10 @@ def file_copy_celery(param: json) -> str:
 
 
 def copy_normal(
-        one: KnowledgeFile,
-        source_knowledge: Knowledge,
-        target_knowledge: Knowledge,
-        op_user_id: int,
+    one: KnowledgeFile,
+    source_knowledge: Knowledge,
+    target_knowledge: Knowledge,
+    op_user_id: int,
 ):
     one_dict = one.model_dump()
     one_dict.pop("id")
@@ -167,10 +167,10 @@ def copy_normal(
 
 
 def copy_vector(
-        source_konwledge: Knowledge,
-        target_knowledge: Knowledge,
-        source_file_id: int,
-        target_file_id: int,
+    source_konwledge: Knowledge,
+    target_knowledge: Knowledge,
+    source_file_id: int,
+    target_file_id: int,
 ):
     # migrate vectordb
     embedding = FakeEmbeddings()
@@ -276,12 +276,12 @@ def parse_knowledge_file_celery(file_id: int, preview_cache_key: str = None, cal
         f"parse_knowledge_file_celery start preview_cache_key={preview_cache_key}, callback_url={callback_url}")
     try:
         # After the warehousing is successful, it is judged whether the file information still exists, and if not, it is deleted.
-        _, knowledge = _parse_knowledge_file(file_id, preview_cache_key, callback_url)
+        knowledge = _parse_knowledge_file(file_id, preview_cache_key, callback_url)
     except Exception as e:
         logger.error("parse_knowledge_file_celery error: {}", str(e))
     finally:
         db_file = KnowledgeFileDao.get_file_by_ids([file_id])
-        if not db_file:
+        if not db_file and knowledge:
             logger.debug(f"delete_knowledge_file_celery file_id={file_id}")
             # If it does not exist, it may have been deleted during the parsing process,
             # and the data of the vector database needs to be deleted.
@@ -292,7 +292,7 @@ def _parse_knowledge_file(file_id: int, preview_cache_key: str = None, callback_
     db_file = KnowledgeFileDao.get_file_by_ids([file_id])
     if not db_file:
         logger.error("file_id={} not found in db", file_id)
-        return
+        return None
     db_file = db_file[0]
     if db_file.status not in [KnowledgeFileStatus.PROCESSING.value, KnowledgeFileStatus.WAITING.value]:
         logger.error(
@@ -300,11 +300,11 @@ def _parse_knowledge_file(file_id: int, preview_cache_key: str = None, callback_
             file_id,
             db_file.status,
         )
-        return
+        return None
     db_knowledge = KnowledgeDao.query_by_id(db_file.knowledge_id)
     if not db_knowledge:
         logger.error("knowledge_id={} not found", db_file.knowledge_id)
-        return
+        return None
     if db_file.status == KnowledgeFileStatus.WAITING.value:
         db_file.status = KnowledgeFileStatus.PROCESSING.value
         KnowledgeFileDao.update_file_status([db_file.id], KnowledgeFileStatus.PROCESSING)
@@ -317,7 +317,7 @@ def _parse_knowledge_file(file_id: int, preview_cache_key: str = None, callback_
                       callback_url=callback_url,
                       preview_cache_keys=[preview_cache_key])
     logger.debug("parse_knowledge_file_celery_over", file_id)
-    return db_file, db_knowledge
+    return db_knowledge
 
 
 @bisheng_celery.task(acks_late=True)
@@ -335,12 +335,12 @@ def retry_knowledge_file_celery(file_id: int, preview_cache_key: str = None, cal
                                             KnowledgeFileFailedError(exception=e).to_json_str())
         return
     try:
-        _parse_knowledge_file(file_id, preview_cache_key, callback_url)
+        knowledge = _parse_knowledge_file(file_id, preview_cache_key, callback_url)
     except Exception as e:
         logger.error("retry_knowledge_file_celery error: {}", str(e))
     finally:
         db_file = KnowledgeFileDao.get_file_by_ids([file_id])
-        if not db_file:
+        if not db_file and knowledge:
             logger.debug(f"delete_knowledge_file_celery file_id={file_id}")
             # If it does not exist, it may have been deleted during the parsing process, and the data of the vector database needs to be deleted.
             delete_vector_files([db_file[0].id], knowledge)

--- a/src/backend/test/test_channel_subscribe_quota.py
+++ b/src/backend/test/test_channel_subscribe_quota.py
@@ -1,0 +1,59 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_subscribe_channel_uses_role_quota_service():
+    from bisheng.channel.domain.models.channel import ChannelVisibilityEnum
+    from bisheng.channel.domain.schemas.channel_manager_schema import (
+        SubscribeChannelRequest,
+        SubscriptionStatusEnum,
+    )
+    from bisheng.channel.domain.services.channel_service import ChannelService
+    from bisheng.common.models.space_channel_member import (
+        BusinessTypeEnum,
+        MembershipStatusEnum,
+        UserRoleEnum,
+    )
+    from bisheng.role.domain.services.quota_service import QuotaResourceType
+
+    channel = SimpleNamespace(id='channel-1', visibility=ChannelVisibilityEnum.PUBLIC)
+    channel_repository = SimpleNamespace(
+        find_channels_by_ids=AsyncMock(return_value=[channel]),
+    )
+    member_repository = SimpleNamespace(
+        find_membership=AsyncMock(return_value=None),
+        add_member=AsyncMock(),
+    )
+    service = ChannelService(
+        channel_repository=channel_repository,
+        space_channel_member_repository=member_repository,
+        channel_info_source_repository=SimpleNamespace(),
+    )
+    login_user = SimpleNamespace(user_id=42, tenant_id=7, is_admin=lambda: False)
+
+    with patch(
+        'bisheng.channel.domain.services.channel_service.QuotaService.check_quota',
+        new=AsyncMock(return_value=True),
+    ) as mock_check:
+        status = await service.subscribe_channel(
+            SubscribeChannelRequest(channel_id='channel-1'),
+            login_user,
+        )
+
+    assert status == SubscriptionStatusEnum.SUBSCRIBED
+    mock_check.assert_awaited_once_with(
+        user_id=42,
+        resource_type=QuotaResourceType.CHANNEL_SUBSCRIBE,
+        tenant_id=7,
+        login_user=login_user,
+    )
+    member_repository.add_member.assert_awaited_once_with(
+        business_id='channel-1',
+        business_type=BusinessTypeEnum.CHANNEL,
+        user_id=42,
+        role=UserRoleEnum.MEMBER,
+        status=MembershipStatusEnum.ACTIVE,
+    )

--- a/src/backend/test/test_quota_service.py
+++ b/src/backend/test/test_quota_service.py
@@ -291,6 +291,14 @@ class TestKI01SqlTemplateSchema:
                 f'channel table has no status column; {key} template must not filter by it: {tmpl!r}'
             )
 
+    def test_channel_subscribe_counts_memberships(self):
+        from bisheng.role.domain.services.quota_service import _RESOURCE_COUNT_TEMPLATES
+        tmpl = _RESOURCE_COUNT_TEMPLATES['channel_subscribe']
+        assert 'FROM space_channel_member' in tmpl
+        assert 'INNER JOIN channel' in tmpl
+        assert "scm.status IN ('ACTIVE','PENDING')" in tmpl
+        assert '{qualified_col}' in tmpl
+
     def test_tool_uses_t_prefix_table_name(self):
         from bisheng.role.domain.services.quota_service import _RESOURCE_COUNT_TEMPLATES
         tmpl = _RESOURCE_COUNT_TEMPLATES['tool']

--- a/src/backend/test/test_sso_login_sync_service.py
+++ b/src/backend/test/test_sso_login_sync_service.py
@@ -28,6 +28,7 @@ def _payload(
     external_user_id='u1', primary='D1', secondary=None,
     ts=1000, name='Alice', email='a@x.com', phone=None,
     tenant_mapping=None,
+    account_disabled=None,
 ):
     from bisheng.sso_sync.domain.schemas.payloads import (
         LoginSyncRequest, UserAttrsDTO,
@@ -39,6 +40,7 @@ def _payload(
         user_attrs=UserAttrsDTO(name=name, email=email, phone=phone),
         ts=ts,
         tenant_mapping=tenant_mapping,
+        account_disabled=account_disabled,
     )
 
 
@@ -297,6 +299,25 @@ class TestDisabledSsoUser:
             await LoginSyncService.execute(_payload(), request_ip='1.2.3.4')
         assert getattr(exc_info.value, 'status_code', 0) == \
             UserForbiddenError.Code
+
+    async def test_wecom_explicit_re_enable_clears_delete(self, patches):
+        """Gateway sends account_disabled=false after 企微 re-enable; bisheng must flip delete."""
+        from bisheng.sso_sync.domain.services.login_sync_service import (
+            LoginSyncService,
+        )
+        m = patches.module
+        row = _user(user_id=7, delete=1, source='wecom', external_id='u1')
+        row.disable_source = 'wecom_org_sync'
+        m.UserDao.aget_by_source_external_id = AsyncMock(return_value=row)
+        primary = _dept('D1', id=11)
+        patches.assert_chain.return_value = {'D1': primary}
+
+        await LoginSyncService.execute(
+            _payload(account_disabled=False), request_ip='1.2.3.4',
+        )
+
+        assert row.delete == 0
+        assert row.disable_source is None
 
 
 # =========================================================================

--- a/src/frontend/client/package-lock.json
+++ b/src/frontend/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bishengchat",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bishengchat",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "ISC",
       "dependencies": {
         "@ariakit/react": "^0.4.15",

--- a/src/frontend/client/src/api/knowledge.ts
+++ b/src/frontend/client/src/api/knowledge.ts
@@ -379,7 +379,7 @@ function deriveFileType(raw: any): FileType {
     }
 }
 
-function extractKnowledgeFileError(raw: any): string | undefined {
+export function extractKnowledgeFileError(raw: any): string | undefined {
     const directMessage = raw?.error_message;
     if (typeof directMessage === "string" && directMessage.trim()) {
         return directMessage.trim();
@@ -393,6 +393,21 @@ function extractKnowledgeFileError(raw: any): string | undefined {
     const trimmedRemark = remark.trim();
     try {
         const parsed = JSON.parse(trimmedRemark);
+        const statusMessage = parsed?.status_message;
+        if (typeof statusMessage === "string" && statusMessage.trim()) {
+            const replacedMessage = statusMessage.replace(/\{([^{}]+)\}/g, (placeholder, key) => {
+                const value = parsed?.data?.data?.[key];
+                if (value === undefined || value === null) {
+                    return placeholder;
+                }
+                return String(value);
+            }).trim();
+
+            if (replacedMessage && replacedMessage !== statusMessage.trim()) {
+                return replacedMessage;
+            }
+        }
+
         const nestedMessage =
             parsed?.data?.exception ??
             parsed?.exception ??
@@ -402,8 +417,8 @@ function extractKnowledgeFileError(raw: any): string | undefined {
             return nestedMessage.trim();
         }
 
-        if (typeof parsed?.status_message === "string" && parsed.status_message.trim()) {
-            return parsed.status_message.trim();
+        if (typeof statusMessage === "string" && statusMessage.trim()) {
+            return statusMessage.trim();
         }
 
         if (typeof parsed?.old_name === "string" || typeof parsed?.new_name === "string") {

--- a/src/frontend/client/src/api/permission.ts
+++ b/src/frontend/client/src/api/permission.ts
@@ -204,16 +204,6 @@ export async function getKnowledgeSpaceGrantUsers(
   return getResourceGrantUsers("knowledge_space", resourceId, params, config);
 }
 
-export async function getDepartmentTree(
-  config?: { signal?: AbortSignal }
-): Promise<any[]> {
-  const res = await request.get(
-    `/api/v1/departments/tree`,
-    withPermissionRequestOptions(config)
-  );
-  return unwrapArray(res);
-}
-
 export async function getResourceGrantDepartments(
   resourceType: ResourceType,
   resourceId: string,

--- a/src/frontend/client/src/api/request.ts
+++ b/src/frontend/client/src/api/request.ts
@@ -143,6 +143,11 @@ customAxios.interceptors.response.use(
         return Promise.reject(error);
       }
 
+      // Drop the auth-state sentinel so the next /api/user/me success
+      // (after re-login or SSO bounce) is detected as a fresh session and
+      // wipes cached chat preferences.
+      try { localStorage.removeItem('bs:auth-state'); } catch { /* ignore */ }
+
       const thirdPartyLoginUrl = localStorage.getItem('THIRD_PARTY_LOGIN_URL');
       if (thirdPartyLoginUrl) {
         window.location.href = thirdPartyLoginUrl;

--- a/src/frontend/client/src/components/ChannelMemberDialog.tsx
+++ b/src/frontend/client/src/components/ChannelMemberDialog.tsx
@@ -334,12 +334,12 @@ export function ChannelMemberDialog({
             <Dialog open={open} onOpenChange={onOpenChange}>
                 <DialogContent
                     overlayClassName="z-[100]"
-                    className="z-[100] flex h-[600px] w-[700px] max-h-[600px] max-w-[700px] flex-col gap-0 overflow-hidden rounded-[10px] p-0 touch-mobile:fixed touch-mobile:inset-0 touch-mobile:h-[100dvh] touch-mobile:max-h-[100dvh] touch-mobile:w-full touch-mobile:max-w-none touch-mobile:translate-x-0 touch-mobile:translate-y-0 touch-mobile:rounded-none"
+                    className="z-[100] flex h-[600px] w-[700px] max-h-[600px] max-w-[700px] flex-col gap-0 overflow-hidden rounded-[10px] p-0 max-[768px]:fixed max-[768px]:inset-0 max-[768px]:h-[100dvh] max-[768px]:max-h-[100dvh] max-[768px]:w-full max-[768px]:max-w-none max-[768px]:translate-x-0 max-[768px]:translate-y-0 max-[768px]:rounded-none"
                     onOpenAutoFocus={(event) => event.preventDefault()}
                     close={false}
                 >
-                    <DialogHeader className="flex h-[48px] shrink-0 flex-row items-center justify-between gap-3 space-y-0 border-b border-[#ECECEC] px-6 py-0 touch-mobile:h-auto touch-mobile:min-h-[56px] touch-mobile:px-4 sm:text-left">
-                        <DialogTitle className="m-0 inline-flex items-center text-[16px] font-semibold leading-[24px] text-[#1D2129] touch-mobile:text-[20px] touch-mobile:font-medium touch-mobile:leading-7 touch-mobile:text-[#212121]">
+                    <DialogHeader className="flex h-[48px] shrink-0 flex-row items-center justify-between gap-3 space-y-0 border-b border-[#ECECEC] px-6 py-0 max-[768px]:h-auto max-[768px]:min-h-[56px] max-[768px]:px-4 sm:text-left">
+                        <DialogTitle className="m-0 inline-flex items-center text-[16px] font-semibold leading-[24px] text-[#1D2129] max-[768px]:text-[20px] max-[768px]:font-medium max-[768px]:leading-7 max-[768px]:text-[#212121]">
                             {localize("com_subscription.management_member")}
                         </DialogTitle>
                         <DialogClose className="inline-flex size-8 shrink-0 items-center justify-center rounded-md p-0 text-[#86909C] opacity-90 outline-none ring-offset-background transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
@@ -348,7 +348,7 @@ export function ChannelMemberDialog({
                         </DialogClose>
                     </DialogHeader>
 
-                    <div className="flex min-h-0 flex-1 flex-col px-6 pb-0 pt-6 touch-mobile:px-4 touch-mobile:pt-6">
+                    <div className="flex min-h-0 flex-1 flex-col px-6 pb-0 pt-6 max-[768px]:px-4 max-[768px]:pt-6">
                         <div className="relative mb-6">
                             <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-[#8B8FA8]" />
                             <input
@@ -409,7 +409,7 @@ export function ChannelMemberDialog({
                         </div>
                     </div>
 
-                    <div className="flex h-auto shrink-0 items-center justify-end border-t border-[#ECECEC] px-6 py-5 text-[14px] touch-mobile:px-4 touch-mobile:py-4">
+                    <div className="flex h-auto shrink-0 items-center justify-end border-t border-[#ECECEC] px-6 py-5 text-[14px] max-[768px]:px-4 max-[768px]:py-4">
                         <div className="flex items-center gap-2">
                             <span className="shrink-0 leading-none text-[14px]">
                                 <span className="text-[#4E5969]">{localize("com_subscription.member_pagination_1")}</span>

--- a/src/frontend/client/src/components/Chat/AiChatInput.tsx
+++ b/src/frontend/client/src/components/Chat/AiChatInput.tsx
@@ -304,7 +304,7 @@ const AiChatInput = memo(
 
         const hasSelectionTags = ((selectedOrgKbs && selectedOrgKbs.length > 0) || (chatFiles && chatFiles.length > 0)) && !isLingsi;
         return (
-            <div className="px-4 sm:px-0 pb-4 touch-mobile:px-0 touch-mobile:pb-3 shrink-0 relative">
+            <div className="px-4 sm:px-0 pb-2 touch-mobile:px-0 touch-mobile:pb-2 shrink-0 relative">
                 {/* Drag-drop overlay */}
                 {isDragging && <DragDropOverlay />}
 
@@ -321,7 +321,7 @@ const AiChatInput = memo(
                     </div>
                 </div>}
 
-                <div className={`relative pb-3 flex w-full flex-col bg-surface-tertiary overflow-hidden touch-mobile:bg-[#f4f5f7] ${size === 'mini' ? 'rounded-xl' : 'rounded-3xl touch-mobile:rounded-2xl'}`}>
+                <div className={`relative flex w-full flex-col items-start gap-[10px] overflow-hidden bg-surface-tertiary p-2 touch-mobile:bg-[#f4f5f7] ${size === 'mini' ? 'rounded-xl' : 'rounded-3xl touch-mobile:rounded-2xl'}`}>
                     {/* File upload area: file list only. Trigger moves to "+" menu
                         when we're in v2.5 agent mode; legacy flow keeps built-in icon. */}
                     {showUpload && (() => {
@@ -394,21 +394,21 @@ const AiChatInput = memo(
                         tabIndex={0}
                         data-testid="ai-chat-input"
                         data-scrolling={isTextareaScrollable && isTextareaScrolling ? "true" : "false"}
-                        rows={2}
-                        style={{ height: 84, overflowY: isTextareaScrollable ? "auto" : "hidden" }}
+                        rows={1}
+                        style={{ height: 52, overflowY: isTextareaScrollable ? "auto" : "hidden" }}
                         className={cn(
                             "m-0 w-full resize-none bg-transparent text-sm pb-0 pl-4 pr-6",
-                            hasSelectionTags ? "pt-0" : "pt-3",
+                            hasSelectionTags ? "pt-0" : "pt-2",
                             "placeholder-black/50 dark:placeholder-white/50",
                             "max-h-[240px] scrollbar-gutter-stable",
-                            size === 'mini' ? 'min-h-0' : 'min-h-20',
+                            size === 'mini' ? 'min-h-0' : 'min-h-12',
                             removeFocusRings,
                             "transition-[max-height] duration-200",
                             isTextareaScrollable && "scroll-on-scroll"
                         )}
                     />
 
-                    <div className="relative h-8">
+                    <div className="relative h-7">
                         {/* Send / Stop / Voice buttons — matching ChatForm styles */}
                         <div className="absolute bottom-0 right-3 flex gap-2 items-center">
                             {/* Voice input (Speech to Text) */}
@@ -507,7 +507,6 @@ const AiChatInput = memo(
                             )}
                             {tools && !agentMode && onSearchTypeChange && (
                                 <ChatToolDown
-                                    linsi={isLingsi}
                                     config={bsConfig}
                                     searchType={searchType}
                                     setSearchType={(type) => {

--- a/src/frontend/client/src/components/Chat/ChatView.tsx
+++ b/src/frontend/client/src/components/Chat/ChatView.tsx
@@ -12,6 +12,7 @@ import { Spinner } from '~/components/svg';
 import { useAuthContext } from '~/hooks/AuthContext';
 import { useGetBsConfig } from '~/hooks/queries/data-provider';
 import useAiChat from '~/hooks/useAiChat';
+import useChatModelMemo from '~/hooks/useChatModelMemo';
 import useLocalize from '~/hooks/useLocalize';
 import store from '~/store';
 import { addConversation, cn, generateUUID } from '~/utils';
@@ -43,30 +44,19 @@ const ChatView = ({ id = '', index = 0, shareToken = '' }: { id?: string, index?
   const [searchType, setSearchType] = useRecoilState(store.searchType);
 
   // v2.5 interaction memory — per-user localStorage snapshots for the input
-  // bar (model, kb selection, tools). Rules:
-  //  - model: default = latest backend model; if user-saved model was deleted,
-  //    fall back to latest again
+  // bar. The model selection is shared across chat surfaces (ChatView and
+  // AiAssistantPanel), so it lives in useChatModelMemo. KB / tools are
+  // ChatView-only and handled in the effect below. Rules:
   //  - KB space: default empty; remember user toggles
   //  - org KB: default per bsConfig.orgKbs[].default_checked; remember toggles
   //  - tools: default per bsConfig.tools[].default_checked; remember toggles
+  useChatModelMemo(user, bsConfig as any);
+
   const memoReadyRef = useRef(false);
   useEffect(() => {
     if (!bsConfig || !user?.id) return;
     if (memoReadyRef.current) return;
     const prefix = `bs:${user.id}:`;
-
-    // Model: stored id wins if still present; otherwise latest configured model.
-    try {
-      const savedModelId = localStorage.getItem(`${prefix}chatModel`);
-      const models = (bsConfig as any)?.models || [];
-      let target = savedModelId
-        ? models.find((m: any) => String(m.id) === savedModelId)
-        : null;
-      if (!target && models.length) target = models[models.length - 1];
-      if (target) {
-        setChatModel({ id: Number(target.id), name: target.displayName || target.name });
-      }
-    } catch { /* ignore */ }
 
     // Org KBs + knowledge spaces (unified selectedOrgKbs atom).
     // Priority: non-empty localStorage > admin-configured default_checked.
@@ -117,15 +107,10 @@ const ChatView = ({ id = '', index = 0, shareToken = '' }: { id?: string, index?
     } catch { /* ignore */ }
 
     memoReadyRef.current = true;
-  }, [bsConfig, user?.id, setChatModel, setSelectedOrgKbs, setSelectedAgentTools, setAgentToolsInitialized]);
+  }, [bsConfig, user?.id, setSelectedOrgKbs, setSelectedAgentTools, setAgentToolsInitialized]);
 
 
   // Persist on change (after initial hydrate completes).
-  useEffect(() => {
-    if (!memoReadyRef.current || !user?.id || !chatModel.id) return;
-    localStorage.setItem(`bs:${user.id}:chatModel`, String(chatModel.id));
-  }, [chatModel.id, user?.id]);
-
   useEffect(() => {
     if (!memoReadyRef.current || !user?.id) return;
     localStorage.setItem(`bs:${user.id}:selectedOrgKbs`, JSON.stringify(selectedOrgKbs));

--- a/src/frontend/client/src/components/Chat/ChatView.tsx
+++ b/src/frontend/client/src/components/Chat/ChatView.tsx
@@ -59,24 +59,23 @@ const ChatView = ({ id = '', index = 0, shareToken = '' }: { id?: string, index?
     const prefix = `bs:${user.id}:`;
 
     // Org KBs + knowledge spaces (unified selectedOrgKbs atom).
-    // Priority: non-empty localStorage > admin-configured default_checked.
-    // A stored `[]` is treated as "not saved" so admin defaults still apply
-    // (the "start new conversation" button writes [], and we don't want that
-    // to permanently lock defaults out). When the KB feature is disabled by
-    // admin, clear the state regardless.
+    // Priority: any localStorage entry (including empty) wins so the user's
+    // explicit clear is preserved across refresh; admin-configured
+    // default_checked only applies on first session (key absent). When the
+    // KB feature is disabled by admin, clear the state regardless.
     try {
       if ((bsConfig as any)?.knowledgeBase?.enabled === false) {
         setSelectedOrgKbs([]);
       } else {
         const raw = localStorage.getItem(`${prefix}selectedOrgKbs`);
         let saved: any[] | null = null;
-        if (raw) {
+        if (raw !== null) {
           try {
             const v = JSON.parse(raw);
             if (Array.isArray(v)) saved = v;
           } catch { /* ignore parse errors */ }
         }
-        if (saved && saved.length > 0) {
+        if (saved !== null) {
           setSelectedOrgKbs(saved);
         } else {
           const defaults = ((bsConfig as any)?.orgKbs || [])
@@ -87,27 +86,37 @@ const ChatView = ({ id = '', index = 0, shareToken = '' }: { id?: string, index?
       }
     } catch { /* ignore */ }
 
-    // Agent tool groups (parent-level). Same priority rule: non-empty local
-    // wins; empty/missing falls through so AgentToolSelector can seed from
-    // admin-configured default_checked.
+    // Agent tool groups (parent-level). Same priority rule: any localStorage
+    // entry (including empty) is treated as the user's choice; admin
+    // default_checked only seeds the first session via AgentToolSelector
+    // when no key exists yet.
     try {
       const raw = localStorage.getItem(`${prefix}selectedAgentTools`);
       let saved: any[] | null = null;
-      if (raw) {
+      if (raw !== null) {
         try {
           const v = JSON.parse(raw);
           if (Array.isArray(v)) saved = v;
         } catch { /* ignore parse errors */ }
       }
-      if (saved && saved.length > 0) {
+      if (saved !== null) {
         setSelectedAgentTools(saved);
         setAgentToolsInitialized(true);
       }
-      // else: leave initialized=false so AgentToolSelector applies defaults.
+      // else: key absent → leave initialized=false so AgentToolSelector
+      // applies admin defaults on first session.
+    } catch { /* ignore */ }
+
+    // Web search toggle. ChatForm clears searchType on conversation change,
+    // but its effect runs before this one (children commit first), so the
+    // hydrated value wins on initial mount and survives refresh / new tab.
+    try {
+      const saved = localStorage.getItem(`${prefix}searchType`);
+      if (saved !== null) setSearchType(saved);
     } catch { /* ignore */ }
 
     memoReadyRef.current = true;
-  }, [bsConfig, user?.id, setSelectedOrgKbs, setSelectedAgentTools, setAgentToolsInitialized]);
+  }, [bsConfig, user?.id, setSelectedOrgKbs, setSelectedAgentTools, setAgentToolsInitialized, setSearchType]);
 
 
   // Persist on change (after initial hydrate completes).
@@ -120,6 +129,11 @@ const ChatView = ({ id = '', index = 0, shareToken = '' }: { id?: string, index?
     if (!memoReadyRef.current || !user?.id || !agentToolsInitialized) return;
     localStorage.setItem(`bs:${user.id}:selectedAgentTools`, JSON.stringify(selectedAgentTools));
   }, [selectedAgentTools, user?.id, agentToolsInitialized]);
+
+  useEffect(() => {
+    if (!memoReadyRef.current || !user?.id) return;
+    localStorage.setItem(`bs:${user.id}:searchType`, searchType ?? '');
+  }, [searchType, user?.id]);
 
   // Core chat state — replaces old ChatContext + useSSE + useChatHelpers
   const {

--- a/src/frontend/client/src/components/Chat/Messages/Content/CitationDocumentPreviewDrawer.tsx
+++ b/src/frontend/client/src/components/Chat/Messages/Content/CitationDocumentPreviewDrawer.tsx
@@ -165,12 +165,12 @@ export default function CitationDocumentPreviewDrawer({
   }, [canRenderPreview, isNarrowLayout]);
 
   useEffect(() => {
-    if (!canRenderPreview || !isNarrowLayout) return;
+    if (!canRenderPreview || !isNarrowLayout || !isFullBleedMobile) return;
     setChatMobileNavHidden(true);
     return () => {
       setChatMobileNavHidden(false);
     };
-  }, [canRenderPreview, isNarrowLayout, setChatMobileNavHidden]);
+  }, [canRenderPreview, isNarrowLayout, isFullBleedMobile, setChatMobileNavHidden]);
 
   useEffect(() => {
     let active = true;

--- a/src/frontend/client/src/components/Chat/Messages/Content/CitationReferencesDrawer.tsx
+++ b/src/frontend/client/src/components/Chat/Messages/Content/CitationReferencesDrawer.tsx
@@ -392,7 +392,7 @@ export default function CitationReferencesDrawer({
   const isDesktopPreviewInline = isDesktopInlinePanel && desktopView === 'document-preview' && !!documentPreview;
 
   useEffect(() => {
-    if (!isNarrowLayout || !isOpen) {
+    if (!isNarrowLayout || !isOpen || !isFullBleedMobile) {
       return;
     }
 
@@ -400,7 +400,7 @@ export default function CitationReferencesDrawer({
     return () => {
       setChatMobileNavHidden(false);
     };
-  }, [isNarrowLayout, isOpen, setChatMobileNavHidden]);
+  }, [isNarrowLayout, isOpen, isFullBleedMobile, setChatMobileNavHidden]);
 
   useEffect(() => {
     if (!isOpen && !panelOnly) {

--- a/src/frontend/client/src/components/Chat/Messages/ToolCallDisplay.tsx
+++ b/src/frontend/client/src/components/Chat/Messages/ToolCallDisplay.tsx
@@ -357,7 +357,7 @@ const ToolCallDisplay: FC<ToolCallDisplayProps> = memo(({ toolCall }) => {
                                     <span
                                         key={kb.id || `${kb.name}-${i}`}
                                         className={cn(
-                                            "inline-flex items-center justify-center gap-1.5 rounded-[4px] px-2 py-[2px] text-[13px]",
+                                            "inline-flex items-center justify-center gap-1.5 rounded-[4px] px-2 py-[4px] text-[13px]",
                                             kb.error
                                                 ? "bg-red-50 text-red-600 dark:bg-red-950/30 dark:text-red-300"
                                                 : "bg-[#F7F8FA] text-[#4E5969]",

--- a/src/frontend/client/src/components/KnowledgeSpaceMemberDialog.tsx
+++ b/src/frontend/client/src/components/KnowledgeSpaceMemberDialog.tsx
@@ -302,12 +302,12 @@ export function KnowledgeSpaceMemberDialog({
             <Dialog open={open} onOpenChange={onOpenChange}>
                 <DialogContent
                     overlayClassName="z-[100]"
-                    className="z-[100] flex h-[600px] w-[700px] max-h-[600px] max-w-[700px] flex-col gap-0 overflow-hidden rounded-[10px] p-0 touch-mobile:fixed touch-mobile:inset-0 touch-mobile:h-[100dvh] touch-mobile:max-h-[100dvh] touch-mobile:w-full touch-mobile:max-w-none touch-mobile:translate-x-0 touch-mobile:translate-y-0 touch-mobile:rounded-none"
+                    className="z-[100] flex h-[600px] w-[700px] max-h-[600px] max-w-[700px] flex-col gap-0 overflow-hidden rounded-[10px] p-0 max-[768px]:fixed max-[768px]:inset-0 max-[768px]:h-[100dvh] max-[768px]:max-h-[100dvh] max-[768px]:w-full max-[768px]:max-w-none max-[768px]:translate-x-0 max-[768px]:translate-y-0 max-[768px]:rounded-none"
                     onOpenAutoFocus={(event) => event.preventDefault()}
                     close={false}
                 >
-                    <DialogHeader className="flex h-[48px] shrink-0 flex-row items-center justify-between gap-3 space-y-0 border-b border-[#ECECEC] px-6 py-0 touch-mobile:h-auto touch-mobile:min-h-[56px] touch-mobile:px-4 sm:text-left">
-                        <DialogTitle className="m-0 inline-flex items-center text-left text-[16px] font-semibold leading-[24px] text-[#1D2129] touch-mobile:text-[20px] touch-mobile:font-medium touch-mobile:leading-7 touch-mobile:text-[#212121]">
+                    <DialogHeader className="flex h-[48px] shrink-0 flex-row items-center justify-between gap-3 space-y-0 border-b border-[#ECECEC] px-6 py-0 max-[768px]:h-auto max-[768px]:min-h-[56px] max-[768px]:px-4 sm:text-left">
+                        <DialogTitle className="m-0 inline-flex items-center text-left text-[16px] font-semibold leading-[24px] text-[#1D2129] max-[768px]:text-[20px] max-[768px]:font-medium max-[768px]:leading-7 max-[768px]:text-[#212121]">
                             {localize("com_subscription.management_member")}
                         </DialogTitle>
                         <DialogClose className="inline-flex size-8 shrink-0 items-center justify-center rounded-md p-0 text-[#86909C] opacity-90 outline-none ring-offset-background transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
@@ -316,7 +316,7 @@ export function KnowledgeSpaceMemberDialog({
                         </DialogClose>
                     </DialogHeader>
 
-                    <div className="flex min-h-0 flex-1 flex-col px-6 pt-6 pb-0 touch-mobile:px-4 touch-mobile:pt-6">
+                    <div className="flex min-h-0 flex-1 flex-col px-6 pt-6 pb-0 max-[768px]:px-4 max-[768px]:pt-6">
                         <div className="relative mb-3">
                             <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-[#C9CDD4]" />
                             <input

--- a/src/frontend/client/src/components/permission/PermissionGrantTab.test.tsx
+++ b/src/frontend/client/src/components/permission/PermissionGrantTab.test.tsx
@@ -2,7 +2,6 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import {
   authorizeResource,
-  getDepartmentTree,
   getGrantableRelationModels,
   getResourcePermissions,
   getResourceGrantDepartments,
@@ -21,7 +20,6 @@ jest.mock("~/Providers", () => ({
 
 jest.mock("~/api/permission", () => ({
   authorizeResource: jest.fn(),
-  getDepartmentTree: jest.fn(),
   getGrantableRelationModels: jest.fn(),
   getResourcePermissions: jest.fn(),
   getResourceGrantDepartments: jest.fn(),
@@ -30,7 +28,6 @@ jest.mock("~/api/permission", () => ({
 }));
 
 const mockedAuthorizeResource = jest.mocked(authorizeResource);
-const mockedGetDepartmentTree = jest.mocked(getDepartmentTree);
 const mockedGetGrantableRelationModels = jest.mocked(getGrantableRelationModels);
 const mockedGetResourcePermissions = jest.mocked(getResourcePermissions);
 const mockedGetResourceGrantDepartments = jest.mocked(getResourceGrantDepartments);
@@ -49,16 +46,6 @@ describe("PermissionGrantTab", () => {
         relation: "viewer",
         permissions: [],
         is_system: true,
-      },
-    ]);
-    mockedGetDepartmentTree.mockResolvedValue([
-      {
-        id: 7,
-        dept_id: "dept-7",
-        name: "测试部门",
-        parent_id: null,
-        member_count: 3,
-        children: [],
       },
     ]);
     mockedGetResourceGrantUsers.mockResolvedValue([]);

--- a/src/frontend/client/src/components/permission/SubjectSearchDepartment.test.tsx
+++ b/src/frontend/client/src/components/permission/SubjectSearchDepartment.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 
-import { getDepartmentTree, getResourceGrantDepartments } from "~/api/permission";
+import { getResourceGrantDepartments } from "~/api/permission";
 import type { SelectedSubject } from "~/api/permission";
 import { SubjectSearchDepartment } from "./SubjectSearchDepartment";
 
@@ -9,17 +9,15 @@ jest.mock("~/hooks", () => ({
 }));
 
 jest.mock("~/api/permission", () => ({
-  getDepartmentTree: jest.fn(),
   getResourceGrantDepartments: jest.fn(),
 }));
 
-const mockedGetDepartmentTree = jest.mocked(getDepartmentTree);
 const mockedGetResourceGrantDepartments = jest.mocked(getResourceGrantDepartments);
 
 describe("SubjectSearchDepartment", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedGetDepartmentTree.mockResolvedValue([
+    mockedGetResourceGrantDepartments.mockResolvedValue([
       {
         id: 1,
         dept_id: "dept-1",
@@ -34,15 +32,6 @@ describe("SubjectSearchDepartment", () => {
             children: [],
           },
         ],
-      },
-    ]);
-    mockedGetResourceGrantDepartments.mockResolvedValue([
-      {
-        id: 3,
-        dept_id: "dept-3",
-        name: "应用授权部门",
-        parent_id: null,
-        children: [],
       },
     ]);
   });
@@ -61,13 +50,19 @@ describe("SubjectSearchDepartment", () => {
       <SubjectSearchDepartment
         value={value}
         onChange={jest.fn()}
+        resourceType="workflow"
+        resourceId="wf-1"
         includeChildren
         onIncludeChildrenChange={jest.fn()}
       />,
     );
 
     await waitFor(() => {
-      expect(mockedGetDepartmentTree).toHaveBeenCalledTimes(1);
+      expect(mockedGetResourceGrantDepartments).toHaveBeenCalledWith(
+        "workflow",
+        "wf-1",
+        { signal: expect.any(AbortSignal) },
+      );
     });
 
     fireEvent.change(screen.getByPlaceholderText("com_permission.search_department"), {
@@ -95,13 +90,15 @@ describe("SubjectSearchDepartment", () => {
           },
         ]}
         onChange={onChange}
+        resourceType="workflow"
+        resourceId="wf-1"
         includeChildren
         onIncludeChildrenChange={onIncludeChildrenChange}
       />,
     );
 
     await waitFor(() => {
-      expect(mockedGetDepartmentTree).toHaveBeenCalledTimes(1);
+      expect(mockedGetResourceGrantDepartments).toHaveBeenCalledTimes(1);
     });
 
     fireEvent.change(screen.getByPlaceholderText("com_permission.search_department"), {
@@ -132,6 +129,8 @@ describe("SubjectSearchDepartment", () => {
       <SubjectSearchDepartment
         value={[]}
         onChange={jest.fn()}
+        resourceType="workflow"
+        resourceId="wf-1"
         includeChildren
         onIncludeChildrenChange={jest.fn()}
         disabledIds={[1]}
@@ -146,6 +145,16 @@ describe("SubjectSearchDepartment", () => {
   });
 
   it("uses resource-scoped department candidates when a resource is provided", async () => {
+    mockedGetResourceGrantDepartments.mockResolvedValue([
+      {
+        id: 3,
+        dept_id: "dept-3",
+        name: "应用授权部门",
+        parent_id: null,
+        children: [],
+      },
+    ]);
+
     render(
       <SubjectSearchDepartment
         value={[]}
@@ -166,6 +175,5 @@ describe("SubjectSearchDepartment", () => {
       "wf-1",
       { signal: expect.any(AbortSignal) },
     );
-    expect(mockedGetDepartmentTree).not.toHaveBeenCalled();
   });
 });

--- a/src/frontend/client/src/components/permission/SubjectSearchDepartment.tsx
+++ b/src/frontend/client/src/components/permission/SubjectSearchDepartment.tsx
@@ -1,6 +1,6 @@
 import { Checkbox } from "~/components/ui/Checkbox";
 import { Input } from "~/components/ui/Input";
-import { getDepartmentTree, getResourceGrantDepartments } from "~/api/permission";
+import { getResourceGrantDepartments } from "~/api/permission";
 import type { ResourceType, SelectedSubject } from "~/api/permission";
 import { ChevronDown, ChevronRight, Building2, Search } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -18,8 +18,8 @@ interface DepartmentNode {
 interface SubjectSearchDepartmentProps {
   value: SelectedSubject[];
   onChange: (v: SelectedSubject[]) => void;
-  resourceType?: ResourceType;
-  resourceId?: string;
+  resourceType: ResourceType;
+  resourceId: string;
   includeChildren: boolean;
   onIncludeChildrenChange: (v: boolean) => void;
   disabledIds?: number[];
@@ -76,13 +76,9 @@ export function SubjectSearchDepartment({
 
   useEffect(() => {
     const controller = new AbortController();
-    const request =
-      resourceType && resourceId
-        ? getResourceGrantDepartments(resourceType, resourceId, { signal: controller.signal })
-        : getDepartmentTree({ signal: controller.signal });
 
     setLoading(true);
-    request
+    getResourceGrantDepartments(resourceType, resourceId, { signal: controller.signal })
       .then((res) => {
         if (!controller.signal.aborted && res) setTree(res);
       })

--- a/src/frontend/client/src/hooks/AuthContext.tsx
+++ b/src/frontend/client/src/hooks/AuthContext.tsx
@@ -93,9 +93,9 @@ const AuthContextProvider = ({
   });
   const logoutUser = useLogoutUserMutation({
     onSuccess: (data) => {
-      // Drop the session sentinel so the next authenticated hit (even same
-      // account, same tab) is treated as a fresh session and clears `bs:*`.
-      try { sessionStorage.removeItem('bs:session-user'); } catch { /* ignore */ }
+      // Drop the auth-state sentinel so the next /api/user/me success is
+      // detected as a fresh login and wipes cached chat preferences.
+      try { localStorage.removeItem('bs:auth-state'); } catch { /* ignore */ }
       const thirdPartyLogoutUrl = localStorage.getItem('THIRD_PARTY_LOGOUT_URL');
       if (thirdPartyLogoutUrl) {
         window.location.href = thirdPartyLogoutUrl;
@@ -109,7 +109,7 @@ const AuthContextProvider = ({
       });
     },
     onError: (error) => {
-      try { sessionStorage.removeItem('bs:session-user'); } catch { /* ignore */ }
+      try { localStorage.removeItem('bs:auth-state'); } catch { /* ignore */ }
       doSetError((error as Error).message);
       const thirdPartyLogoutUrl = localStorage.getItem('THIRD_PARTY_LOGOUT_URL');
       if (thirdPartyLogoutUrl) {
@@ -166,20 +166,27 @@ const AuthContextProvider = ({
     if (userQuery.data) {
       setUser(userQuery.data);
       setIsAuthenticated(true);
-      // Session sentinel: any path that brings `user` into the app — normal
-      // login, 2FA, SSO, third-party SSO landing — ends up here once
-      // /api/user/me succeeds. sessionStorage survives same-tab reloads but
-      // dies on new tab / browser restart / explicit logout, so a mismatch
-      // means "fresh authenticated session for this user" → wipe cached
-      // chat preferences so admin-configured defaults re-apply.
+      // Auth-state sentinel: stored in localStorage (shared across tabs)
+      // so refresh and new-tab don't trigger a wipe. Cleared on logout and
+      // on 401 in the response interceptor; SSO landing leaves it absent
+      // until the first /api/user/me succeeds. Mismatch (absent or different
+      // uid — including a leftover bs:* set from a prior user) is treated
+      // as "fresh login" → wipe cached chat preferences and legacy global
+      // keys so admin-configured defaults re-apply.
       try {
         const uid = String(userQuery.data.id ?? '');
-        if (uid && sessionStorage.getItem('bs:session-user') !== uid) {
+        if (uid && localStorage.getItem('bs:auth-state') !== uid) {
           for (let i = localStorage.length - 1; i >= 0; i--) {
             const k = localStorage.key(i);
             if (k && k.startsWith('bs:')) localStorage.removeItem(k);
           }
-          sessionStorage.setItem('bs:session-user', uid);
+          // One-time cleanup of legacy global keys that used to be persisted
+          // via atomWithLocalStorage. Their atoms no longer write to these
+          // keys; remove any stale values so the keys don't linger forever.
+          ['chatModel', 'modelType', 'searchType', 'isSearch'].forEach((k) => {
+            localStorage.removeItem(k);
+          });
+          localStorage.setItem('bs:auth-state', uid);
         }
       } catch { /* ignore storage errors */ }
     } else if (userQuery.isError) {

--- a/src/frontend/client/src/hooks/Chat/useChatFunctions.ts
+++ b/src/frontend/client/src/hooks/Chat/useChatFunctions.ts
@@ -58,7 +58,6 @@ export default function useChatFunctions({
   const setShowStopButton = useSetRecoilState(store.showStopButtonByIndex(index));
   const setFilesToDelete = useSetFilesToDelete();
   const isTemporary = useRecoilValue(store.isTemporary);
-  const modelType = useRecoilValue(store.modelType);
   const chatModel = useRecoilValue(store.chatModel);
   const searchType = useRecoilValue(store.searchType);
   // const netSearch = useRecoilValue(store.netSearch);
@@ -91,7 +90,7 @@ export default function useChatFunctions({
     }
 
     const endpoint = 'Deepseek';
-    const custom_model = modelType || 'deepseek-chat';
+    const custom_model = 'deepseek-chat';
     const search_enabled = searchType && searchType === 'netSearch' || false;
 
     const use_knowledge_base = {

--- a/src/frontend/client/src/hooks/Chat/useChatFunctions.ts
+++ b/src/frontend/client/src/hooks/Chat/useChatFunctions.ts
@@ -59,7 +59,6 @@ export default function useChatFunctions({
   const setFilesToDelete = useSetFilesToDelete();
   const isTemporary = useRecoilValue(store.isTemporary);
   const chatModel = useRecoilValue(store.chatModel);
-  const searchType = useRecoilValue(store.searchType);
   // const netSearch = useRecoilValue(store.netSearch);
   const selectedOrgKbs = useRecoilValue(store.selectedOrgKbs);
   // const model = useShouGangModel()
@@ -91,7 +90,6 @@ export default function useChatFunctions({
 
     const endpoint = 'Deepseek';
     const custom_model = 'deepseek-chat';
-    const search_enabled = searchType && searchType === 'netSearch' || false;
 
     const use_knowledge_base = {
       knowledges: selectedOrgKbs,
@@ -191,7 +189,6 @@ export default function useChatFunctions({
       endpoint: '', // 临时修改
       endpointType: 'custom',
       model: chatModel.id + '',
-      search_enabled,
       use_knowledge_base,
     });
     const responseSender = chatModel.name // getSender({ ...endpointOption });

--- a/src/frontend/client/src/hooks/useAiChat.ts
+++ b/src/frontend/client/src/hooks/useAiChat.ts
@@ -186,7 +186,6 @@ export default function useAiChat(initialConversationId: string = "new", isLings
                 endpoint: "",
                 endpointType: "custom",
                 model: chatModel.id + "",
-                search_enabled: searchType === "netSearch",
                 use_knowledge_base: {
                     personal_knowledge_enabled: false,
                     organization_knowledge_ids: orgKbs,
@@ -442,7 +441,6 @@ export default function useAiChat(initialConversationId: string = "new", isLings
                 endpoint: "",
                 endpointType: "custom",
                 model: chatModel.id + "",
-                search_enabled: searchType === "netSearch",
                 use_knowledge_base: {
                     organization_knowledge_ids: (bsConfig as any)?.knowledgeBase?.enabled === false
                         ? []

--- a/src/frontend/client/src/hooks/useChatModelMemo.ts
+++ b/src/frontend/client/src/hooks/useChatModelMemo.ts
@@ -1,0 +1,58 @@
+import { useEffect, useRef } from 'react';
+import { useRecoilState } from 'recoil';
+import store from '~/store';
+
+interface UserLike {
+  id: number | string;
+}
+
+interface ModelLike {
+  id: number | string;
+  name?: string;
+  displayName?: string;
+}
+
+interface BsConfigLike {
+  models?: ModelLike[];
+}
+
+/**
+ * Hydrate / persist the chatModel atom under the user-scoped
+ * `bs:{uid}:chatModel` localStorage key. Falls back to the latest configured
+ * model when nothing is saved or the saved id no longer exists. Used by every
+ * chat surface that lets the user pick a model so the selection survives
+ * page refresh and new tabs (and gets wiped on re-login alongside the rest
+ * of `bs:*`).
+ */
+export default function useChatModelMemo(
+  user: UserLike | null | undefined,
+  bsConfig: BsConfigLike | undefined,
+) {
+  const [chatModel, setChatModel] = useRecoilState(store.chatModel);
+  const hydratedRef = useRef(false);
+
+  useEffect(() => {
+    if (!bsConfig || !user?.id) return;
+    if (hydratedRef.current) return;
+    try {
+      const savedModelId = localStorage.getItem(`bs:${user.id}:chatModel`);
+      const models = bsConfig.models || [];
+      let target: ModelLike | undefined | null = savedModelId
+        ? models.find((m) => String(m.id) === savedModelId)
+        : null;
+      if (!target && models.length) target = models[models.length - 1];
+      if (target) {
+        setChatModel({
+          id: Number(target.id),
+          name: target.displayName || target.name || '',
+        });
+      }
+    } catch { /* ignore */ }
+    hydratedRef.current = true;
+  }, [bsConfig, user?.id, setChatModel]);
+
+  useEffect(() => {
+    if (!hydratedRef.current || !user?.id || !chatModel.id) return;
+    localStorage.setItem(`bs:${user.id}:chatModel`, String(chatModel.id));
+  }, [chatModel.id, user?.id]);
+}

--- a/src/frontend/client/src/layouts/MainLayout.tsx
+++ b/src/frontend/client/src/layouts/MainLayout.tsx
@@ -432,7 +432,6 @@ export default function MainLayout() {
               isAppsArea &&
               !isAppChatRoute &&
               !isAppsExploreRoute &&
-              !mobileSidebarOpen &&
               'pt-9',
             )}
           >

--- a/src/frontend/client/src/pages/Subscription/AiChat/AiAssistantPanel.tsx
+++ b/src/frontend/client/src/pages/Subscription/AiChat/AiAssistantPanel.tsx
@@ -16,6 +16,7 @@ import {
     TooltipProvider,
     TooltipTrigger,
 } from "~/components/ui/Tooltip2";
+import { useAuthContext } from "~/hooks/AuthContext";
 import { useGetBsConfig } from "~/hooks/queries/data-provider";
 import store from "~/store";
 import type { AiChatInputFeatures } from "~/components/Chat/AiChatInput";
@@ -23,6 +24,7 @@ import AiChatInput from "~/components/Chat/AiChatInput";
 import AiChatMessages from "~/components/Chat/AiChatMessages";
 import useAiChat from "~/hooks/useAiChat";
 import useChannelChat from "~/hooks/useChannelChat";
+import useChatModelMemo from "~/hooks/useChatModelMemo";
 import useFileChat from "~/hooks/useFileChat";
 import { useConfirm } from "~/Providers";
 import { ChannelClearIcon } from "~/components/icons/channels";
@@ -91,10 +93,16 @@ export function AiAssistantPanel({
     } = activeChat;
 
     const { data: bsConfig } = useGetBsConfig();
+    const { user } = useAuthContext();
     const [chatModel, setChatModel] = useRecoilState(store.chatModel);
     const [selectedOrgKbs, setSelectedOrgKbs] = useRecoilState(store.selectedOrgKbs);
     const [searchType, setSearchType] = useRecoilState(store.searchType);
     const [inputText, setInputText] = useState("");
+
+    // Hydrate / persist chatModel under bs:{uid}:chatModel so model selection
+    // on Subscription / Article / FilePreview pages survives refresh and gets
+    // wiped on re-login alongside the rest of bs:*.
+    useChatModelMemo(user, bsConfig as any);
 
     const confirm = useConfirm();
 

--- a/src/frontend/client/src/pages/Subscription/ChannelShareDialog.tsx
+++ b/src/frontend/client/src/pages/Subscription/ChannelShareDialog.tsx
@@ -27,7 +27,7 @@ export function ChannelShareDialog({
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent className="!flex h-[80vh] max-h-[800px] w-[calc(100vw-80px)] max-w-[800px] min-w-0 flex-col gap-0 overflow-hidden p-5">
+            <DialogContent className="!flex h-[80vh] max-h-[800px] w-[calc(100vw-80px)] max-w-[800px] min-w-0 flex-col gap-0 overflow-hidden p-5 max-[768px]:fixed max-[768px]:inset-0 max-[768px]:h-[100dvh] max-[768px]:max-h-[100dvh] max-[768px]:w-full max-[768px]:max-w-none max-[768px]:translate-x-0 max-[768px]:translate-y-0 max-[768px]:rounded-none max-[768px]:p-4">
                 <DialogHeader className="shrink-0">
                     <DialogTitle>
                         {localize("com_subscription.management_member")}{resourceName}

--- a/src/frontend/client/src/pages/appChat/ChatView.tsx
+++ b/src/frontend/client/src/pages/appChat/ChatView.tsx
@@ -61,6 +61,9 @@ export default function ChatView({ data, cid, v, readOnly, isGuestMode = false }
         .map((item) => String(item || "").trim())
         .find(Boolean) || localize('com_ui_new_chat');
 
+    /** 与侧栏「分享应用」一致：仅 can_share === true 时展示对话顶栏分享入口 */
+    const hideShare = data?.can_share !== true;
+
     useEffect(() => {
         setChatMobileHeader({
             title: headerTitle,
@@ -68,10 +71,10 @@ export default function ChatView({ data, cid, v, readOnly, isGuestMode = false }
             flowId: data?.id || '',
             flowType: data?.flow_type || 15,
             readOnly: !!readOnly,
-            hideShare: false,
+            hideShare,
         });
         return () => setChatMobileHeader(null);
-    }, [setChatMobileHeader, headerTitle, cid, data?.id, data?.flow_type, readOnly]);
+    }, [setChatMobileHeader, headerTitle, cid, data?.id, data?.flow_type, readOnly, hideShare]);
     /** 无消息且无需展示开场白 / 引导问题 / 工作流表单时显示主区域空状态 */
     const showChatEmptyState =
         conversations.length === 0 &&
@@ -87,6 +90,7 @@ export default function ChatView({ data, cid, v, readOnly, isGuestMode = false }
     return <div className="relative h-full flex flex-col">
         <HeaderTitle
             readOnly={readOnly}
+            hideShare={hideShare}
             conversation={{ title: headerTitle, flowId: data.id, conversationId: cid, flowType: data.flow_type }}
         />
         <div className="min-h-0 flex-1 flex flex-col bg-[position:0_100%] bg-repeat-x bg-[length:10px_432px]">

--- a/src/frontend/client/src/pages/appChat/SideNav.tsx
+++ b/src/frontend/client/src/pages/appChat/SideNav.tsx
@@ -84,8 +84,8 @@ export function SideNav() {
         const searchParams = new URLSearchParams(location.search);
         const from = searchParams.get('from');
         const entry = searchParams.get('entry');
-        // Explicit app-center source should always return to app center.
-        if (from === 'center') {
+        // App center entries (home list / explore) should always return to app center.
+        if (from === 'center' || from === 'explore') {
             navigate('/apps');
             return;
         }

--- a/src/frontend/client/src/pages/knowledge/SpaceDetail/KnowledgeSpaceShareDialog.tsx
+++ b/src/frontend/client/src/pages/knowledge/SpaceDetail/KnowledgeSpaceShareDialog.tsx
@@ -226,7 +226,7 @@ export function KnowledgeSpaceShareDialog({
     return (
         <>
             <Dialog open={open} onOpenChange={onOpenChange}>
-                <DialogContent className="!flex h-[80vh] max-h-[800px] w-[calc(100vw-80px)] max-w-[800px] min-w-0 flex-col gap-0 overflow-hidden p-5">
+                <DialogContent className="!flex h-[80vh] max-h-[800px] w-[calc(100vw-80px)] max-w-[800px] min-w-0 flex-col gap-0 overflow-hidden p-5 max-[768px]:fixed max-[768px]:inset-0 max-[768px]:h-[100dvh] max-[768px]:max-h-[100dvh] max-[768px]:w-full max-[768px]:max-w-none max-[768px]:translate-x-0 max-[768px]:translate-y-0 max-[768px]:rounded-none max-[768px]:p-4">
                     <DialogHeader className="shrink-0">
                         <DialogTitle>{dialogTitle}</DialogTitle>
                     </DialogHeader>
@@ -238,7 +238,7 @@ export function KnowledgeSpaceShareDialog({
             </Dialog>
 
             <Dialog open={grantDialogOpen} onOpenChange={setGrantDialogOpen}>
-                <DialogContent className="!flex h-[80vh] max-h-[800px] w-[calc(100vw-80px)] max-w-[800px] min-w-0 flex-col gap-0 overflow-hidden p-5">
+                <DialogContent className="!flex h-[80vh] max-h-[800px] w-[calc(100vw-80px)] max-w-[800px] min-w-0 flex-col gap-0 overflow-hidden p-5 max-[768px]:fixed max-[768px]:inset-0 max-[768px]:h-[100dvh] max-[768px]:max-h-[100dvh] max-[768px]:w-full max-[768px]:max-w-none max-[768px]:translate-x-0 max-[768px]:translate-y-0 max-[768px]:rounded-none max-[768px]:p-4">
                     <DialogHeader className="shrink-0">
                         <DialogTitle>
                             {localize("com_permission.tab_grant")} - {resourceName}

--- a/src/frontend/client/src/pages/knowledge/hooks/useFileUpload.test.ts
+++ b/src/frontend/client/src/pages/knowledge/hooks/useFileUpload.test.ts
@@ -1,4 +1,4 @@
-import { FileStatus, FileType, type KnowledgeFile } from "~/api/knowledge";
+import { extractKnowledgeFileError, FileStatus, FileType, type KnowledgeFile } from "~/api/knowledge";
 import {
   extractDuplicateFileEntries,
   mergeVisibleRegisteredFiles,
@@ -69,5 +69,20 @@ describe("useFileUpload helpers", () => {
       files: [newWaitingFile, existingFile],
       addedCount: 1,
     });
+  });
+
+  test("extractKnowledgeFileError replaces status_message placeholders from nested data", () => {
+    const remark = JSON.stringify({
+      status_code: 10953,
+      status_message: "File parsing failed: {exception}",
+      data: {
+        exception: "File parsing failed: {exception}",
+        data: {
+          exception: "rebuild error",
+        },
+      },
+    });
+
+    expect(extractKnowledgeFileError({ remark })).toBe("File parsing failed: rebuild error");
   });
 });

--- a/src/frontend/client/src/pages/standaloneChat/StandaloneChatPage.tsx
+++ b/src/frontend/client/src/pages/standaloneChat/StandaloneChatPage.tsx
@@ -26,7 +26,7 @@ const FLOW_TYPE_MAP = {
 
 // Minimal auth context for guest mode — provides "not authenticated" values
 // without making any API calls or triggering 401 redirects.
-const noop = () => {};
+const noop = () => { };
 const guestAuthValue = {
   user: undefined,
   token: undefined,
@@ -101,7 +101,7 @@ function StandaloneChatInner({ mode, flowType }: StandaloneChatPageProps) {
   return (
     <StandaloneChatContext.Provider value={contextValue}>
       <div className={cn('flex', isGuestMode ? 'bg-white' : 'bg-[#F9F9F9]')} style={{ height: '100dvh' }}>
-        <div className="relative z-0 flex h-full w-full overflow-hidden">
+        <div className="relative z-0 flex h-full w-full overflow-hidden bg-[#F4F5F7] p-2">
 
           {/* Desktop sidebar */}
           {!isTabletOrMobile && (
@@ -146,7 +146,7 @@ function StandaloneChatInner({ mode, flowType }: StandaloneChatPageProps) {
           <div
             className={cn(
               'relative flex h-full max-w-full min-w-0 flex-1 flex-col overflow-hidden',
-              'p-2 touch-mobile:p-0',
+              'p-0',
             )}
           >
             {isTabletOrMobile && (

--- a/src/frontend/client/src/routes/AppRoot.tsx
+++ b/src/frontend/client/src/routes/AppRoot.tsx
@@ -63,8 +63,8 @@ export default function AppRoot() {
         const searchParams = new URLSearchParams(location.search);
         const from = searchParams.get('from');
         const entry = searchParams.get('entry');
-        // Explicit app-center source should always return to app center.
-        if (from === 'center') {
+        // App center entries (home list / explore) should always return to app center.
+        if (from === 'center' || from === 'explore') {
             navigate('/apps');
             return;
         }
@@ -122,7 +122,7 @@ export default function AppRoot() {
             {/* Page header banner */}
             <Banner onHeightChange={setBannerHeight} />
             <div className="flex w-full overflow-hidden bg-[#F9F9F9] p-4 touch-mobile:p-0" style={{ height: `calc(100dvh - ${bannerHeight}px)` }}>
-                <div className="relative z-0 flex h-full w-full overflow-hidden">
+                <div className="relative z-0 flex h-full w-full overflow-hidden bg-[#F4F5F7] p-2">
 
                     {/* Desktop/Tablet sidebar */}
                     {!isTabletOrMobile && (

--- a/src/frontend/client/src/store/modeltype.ts
+++ b/src/frontend/client/src/store/modeltype.ts
@@ -1,4 +1,3 @@
-import { atomWithLocalStorage } from '~/store/utils';
 import { atom } from 'recoil';
 
 export type SelectedOrgKb = {
@@ -24,13 +23,22 @@ export type SelectedAgentTool = {
   children: SelectedAgentToolChild[];
 };
 
-const modelType = atomWithLocalStorage('modelType', '');
-// DEPRECATED (kept for backward compat with legacy chat flow). New code uses
-// selectedAgentTools below; will be removed alongside the legacy SSE format.
-const searchType = atomWithLocalStorage('searchType', '');
-const isSearch = atomWithLocalStorage('isSearch', false);
+const searchType = atom<string>({
+  key: 'searchType',
+  default: '',
+});
 
-const chatModel = atomWithLocalStorage('chatModel', { id: 0, name: '' });
+const isSearch = atom<boolean>({
+  key: 'isSearch',
+  default: false,
+});
+
+// Persistence is handled by ChatView under `bs:{uid}:chatModel` so the value
+// is user-scoped and gets cleared on re-login alongside the rest of `bs:*`.
+const chatModel = atom<{ id: number; name: string }>({
+  key: 'chatModel',
+  default: { id: 0, name: '' },
+});
 
 const selectedOrgKbs = atom<SelectedOrgKb[]>({
   key: 'selectedOrgKbs',
@@ -68,7 +76,6 @@ const chatStatesMap = atom<Record<string, any>>({
 });
 
 export default {
-  modelType,
   searchType,
   isSearch,
   chatModel,

--- a/src/frontend/platform/package-lock.json
+++ b/src/frontend/platform/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bisheng",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bisheng",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "dependencies": {
         "@headlessui/react": "^2.0.4",
         "@radix-ui/react-accordion": "^1.2.0",

--- a/src/frontend/platform/src/components/bs-comp/permission/PermissionListTab.tsx
+++ b/src/frontend/platform/src/components/bs-comp/permission/PermissionListTab.tsx
@@ -6,10 +6,10 @@ import {
   DropdownMenuTrigger,
 } from "@/components/bs-ui/dropdownMenu"
 import { useToast } from "@/components/bs-ui/toast/use-toast"
-import { getDepartmentTreeApi } from "@/controllers/API/department"
 import {
   authorizeResource,
   getGrantableRelationModelsApi,
+  getResourceGrantDepartmentsApi,
   getResourcePermissions,
   type RelationModel,
 } from "@/controllers/API/permission"
@@ -74,12 +74,14 @@ export function PermissionListTab({
   const listScrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
-    captureAndAlertRequestErrorHoc(getDepartmentTreeApi()).then((res) => {
+    captureAndAlertRequestErrorHoc(
+      getResourceGrantDepartmentsApi(resourceType, resourceId),
+    ).then((res) => {
       if (res && Array.isArray(res)) {
         setDeptPathById(buildDepartmentPathLabelMap(res))
       }
     })
-  }, [refreshKey])
+  }, [refreshKey, resourceId, resourceType])
 
   const loadData = useCallback(async () => {
     setLoading(true)

--- a/src/frontend/platform/src/components/bs-comp/permission/SubjectSearchDepartment.tsx
+++ b/src/frontend/platform/src/components/bs-comp/permission/SubjectSearchDepartment.tsx
@@ -16,6 +16,7 @@ interface SubjectSearchDepartmentProps {
   onChange: (v: SelectedSubject[]) => void
   resourceType?: ResourceType
   resourceId?: string
+  allowOrganizationTree?: boolean
   includeChildren?: boolean
   onIncludeChildrenChange?: (v: boolean) => void
   showIncludeChildrenToggle?: boolean
@@ -70,6 +71,7 @@ export function SubjectSearchDepartment({
   onChange,
   resourceType,
   resourceId,
+  allowOrganizationTree = false,
   includeChildren = false,
   onIncludeChildrenChange = () => undefined,
   showIncludeChildrenToggle = true,
@@ -84,15 +86,24 @@ export function SubjectSearchDepartment({
   const disabledIdSet = new Set(disabledIds)
 
   useEffect(() => {
-    setLoading(true)
     const request = resourceType && resourceId
       ? getResourceGrantDepartmentsApi(resourceType, resourceId)
-      : getDepartmentTreeApi()
+      : allowOrganizationTree
+        ? getDepartmentTreeApi()
+        : null
+
+    if (!request) {
+      setTree([])
+      setLoading(false)
+      return
+    }
+
+    setLoading(true)
     captureAndAlertRequestErrorHoc(request).then((res) => {
       if (res) setTree(res)
       setLoading(false)
     })
-  }, [resourceId, resourceType])
+  }, [allowOrganizationTree, resourceId, resourceType])
 
   const selectedIds = new Set(value.map((s) => s.id))
   const selectedDepartmentsById = useMemo(

--- a/src/frontend/platform/src/controllers/API/department.ts
+++ b/src/frontend/platform/src/controllers/API/department.ts
@@ -110,6 +110,8 @@ export interface GlobalMemberSearchRow {
   user_name: string
   primary_department_dept_id: string
   primary_department_path: string
+  /** false = 账号未启用（User.delete=1），与部门成员列表一致 */
+  enabled?: boolean
 }
 
 export async function searchGlobalMembersApi(params: {

--- a/src/frontend/platform/src/controllers/API/permission.ts
+++ b/src/frontend/platform/src/controllers/API/permission.ts
@@ -1,6 +1,5 @@
 import type { GrantItem, PermissionEntry, RevokeItem } from "@/components/bs-comp/permission/types"
 import axios from "@/controllers/request"
-import { getDepartmentTreeApi } from "@/controllers/API/department"
 
 export type RebacSchemaType = {
   type: string
@@ -47,8 +46,6 @@ export type PermissionTemplateSection = {
   title: string
   columns: PermissionTemplateColumn[]
 }
-
-export const getDepartmentTree = getDepartmentTreeApi
 
 export async function getRebacSchemaApi(): Promise<{
   schema_version: string

--- a/src/frontend/platform/src/controllers/API/userGroups.ts
+++ b/src/frontend/platform/src/controllers/API/userGroups.ts
@@ -11,7 +11,7 @@ export type UserGroupV2 = {
   visibility: string;
   remark?: string | null;
   member_count?: number;
-  create_user?: number | null;
+  create_user?: number | string | null;
   create_user_name?: string | null;
   create_time?: string;
   update_time?: string;

--- a/src/frontend/platform/src/pages/BuildPage/assistant/editAssistant/Header.tsx
+++ b/src/frontend/platform/src/pages/BuildPage/assistant/editAssistant/Header.tsx
@@ -35,7 +35,6 @@ export default function Header({ loca, onSave, onLine, onTabChange, canEdit: can
     const canEdit = canEditProp ?? (assistantId ? hasPermissionId(permissions, assistantId, 'edit_app') : false)
     const canPublish = assistantId ? hasPermissionId(permissions, assistantId, 'publish_app') : false
     const canUnpublish = assistantId ? hasPermissionId(permissions, assistantId, 'unpublish_app') : false
-    {/* Edit assistant */ }
     const [editShow, setEditShow] = useState(false);
     const [permDialogOpen, setPermDialogOpen] = useState(false);
 
@@ -101,14 +100,15 @@ export default function Header({ loca, onSave, onLine, onTabChange, canEdit: can
                 </Button>
             )}
             <Button variant="outline" className="px-10" type="button" disabled={!canEdit} onClick={onSave}>{t('build.save')}</Button>
-            <Button
-                type="submit"
-                className="px-10"
-                disabled={assistantState.status === OnlineState.OnLine ? !canUnpublish : !canPublish}
-                onClick={() => onLine(assistantState.status === OnlineState.OffLine)}
-            >
-                {assistantState.status === OnlineState.OnLine ? t('build.offline') : t('build.online')}
-            </Button>
+            {(assistantState.status === OnlineState.OnLine ? canUnpublish : canPublish) ? (
+                <Button
+                    type="submit"
+                    className="px-10"
+                    onClick={() => onLine(assistantState.status === OnlineState.OffLine)}
+                >
+                    {assistantState.status === OnlineState.OnLine ? t('build.offline') : t('build.online')}
+                </Button>
+            ) : null}
             {canManage && assistantState?.id ? (
                 <PermissionDialog
                     open={permDialogOpen}

--- a/src/frontend/platform/src/pages/BuildPage/flow/Header.tsx
+++ b/src/frontend/platform/src/pages/BuildPage/flow/Header.tsx
@@ -425,11 +425,17 @@ const Header = ({ flow, nodes, onTabChange, preFlow, onPreFlowChange, onImportFl
                         )}
                     >{t('skills.saveVersion', { ns: 'bs' })}</ActionButton>
                 }
-                {isOnlineVersion ? <Button size="sm" className={`h-8 px-6`} disabled={!canUnpublish} onClick={handleOfflineClick}>
-                    {t('takeOffline')}
-                </Button> : <Button size="sm" className={`h-8 px-6`} disabled={!canPublish} onClick={handleOnlineClick}>
-                    {t('goOnline')}
-                </Button>}
+                {isOnlineVersion
+                    ? (canUnpublish ? (
+                        <Button size="sm" className="h-8 px-6" onClick={handleOfflineClick}>
+                            {t('takeOffline')}
+                        </Button>
+                    ) : null)
+                    : (canPublish ? (
+                        <Button size="sm" className="h-8 px-6" onClick={handleOnlineClick}>
+                            {t('goOnline')}
+                        </Button>
+                    ) : null)}
                 <Popover open={open && canEdit} onOpenChange={(next) => canEdit && setOpen(next)}>
                     <PopoverTrigger asChild >
                         <Button size="icon" variant="outline" disabled={!canEdit} className={`${!dark && 'bg-[#fff]'} size-8`}>

--- a/src/frontend/platform/src/pages/DepartmentPage/components/MemberTable.tsx
+++ b/src/frontend/platform/src/pages/DepartmentPage/components/MemberTable.tsx
@@ -471,7 +471,8 @@ export function MemberTable({
                     <TableRow
                       key={`${r.user_id}-${r.primary_department_dept_id}`}
                       className={cname(
-                        onRequestLocateMember && "cursor-pointer hover:bg-accent/60"
+                        onRequestLocateMember && "cursor-pointer hover:bg-accent/60",
+                        r.enabled === false && "opacity-90"
                       )}
                       onClick={() => {
                         setMemberScope("dept")
@@ -481,7 +482,16 @@ export function MemberTable({
                         })
                       }}
                     >
-                      <TableCell className="font-medium">{r.user_name}</TableCell>
+                      <TableCell className="font-medium">
+                        <span className="inline-flex flex-wrap items-center gap-1.5">
+                          {r.user_name}
+                          {r.enabled === false && (
+                            <Badge variant="secondary" className="font-normal">
+                              {t("bs:department.disabled")}
+                            </Badge>
+                          )}
+                        </span>
+                      </TableCell>
                       <TableCell
                         className="max-w-md truncate text-muted-foreground"
                         title={r.primary_department_path}

--- a/src/frontend/platform/src/pages/KnowledgePage/AdjustFilesUpload.tsx
+++ b/src/frontend/platform/src/pages/KnowledgePage/AdjustFilesUpload.tsx
@@ -342,25 +342,30 @@ export default function AdjustFilesUpload() {
   return (
     <div className="relative h-full flex flex-col">
       {/* Top return bar */}
-      <div className="pt-4 px-4">
-        <div className="flex items-center mb-4">
-          <Button
-            variant="outline"
-            size="icon"
-            className="bg-[#fff] size-8"
-            onClick={() => navigate(-1)}
-          >
-            <ChevronLeft />
-          </Button>
-          <span className="text-foreground text-sm font-black pl-4">{t('backToKnowledgeDetail')}</span>
+      <div className="relative px-4 pt-4">
+        <div className="absolute left-4 top-1/2 z-10 -translate-y-1/4">
+          <div className="flex shrink-0 items-center gap-3 whitespace-nowrap">
+            <Button
+              variant="outline"
+              size="icon"
+              className="size-9 rounded-md border-[#e4e8ee] bg-white shadow-sm hover:bg-background"
+              onClick={() => navigate(-1)}
+            >
+              <ChevronLeft className="size-4" />
+            </Button>
+            <span className="text-sm font-medium text-[#0f172a]">{t('backToKnowledgeDetail')}</span>
+          </div>
         </div>
-
-        {/* Adjustment mode step progress */}
-        <StepProgress
-          align="center"
-          currentStep={currentStep}
-          labels={getAdjustStepLabels(t)}
-        />
+        <div className="mx-auto max-w-[1180px]">
+          <div className="min-w-0 overflow-hidden">
+            <StepProgress
+              align="center"
+              currentStep={currentStep}
+              labels={getAdjustStepLabels(t)}
+              className="my-0 min-w-0 px-0"
+            />
+          </div>
+        </div>
       </div>
 
       {/* Step content area */}

--- a/src/frontend/platform/src/pages/KnowledgePage/components/DepartmentSpaceDialog.tsx
+++ b/src/frontend/platform/src/pages/KnowledgePage/components/DepartmentSpaceDialog.tsx
@@ -137,6 +137,7 @@ export function DepartmentSpaceDialog({
             <SubjectSearchDepartment
               value={selected}
               onChange={setSelected}
+              allowOrganizationTree
               includeChildren={false}
               onIncludeChildrenChange={() => undefined}
               showIncludeChildrenToggle={false}

--- a/src/frontend/platform/src/pages/KnowledgePage/components/FileUploadSplitStrategy.tsx
+++ b/src/frontend/platform/src/pages/KnowledgePage/components/FileUploadSplitStrategy.tsx
@@ -2,7 +2,6 @@ import { DelIcon } from '@/components/bs-icons';
 import { Button } from '@/components/bs-ui/button';
 import { Input } from '@/components/bs-ui/input';
 import { generateUUID } from '@/components/bs-ui/utils';
-import { GripVertical } from 'lucide-react';
 import { useState } from 'react';
 import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd';
 import { useTranslation } from 'react-i18next';
@@ -23,6 +22,14 @@ const predefinedRules = [
   { regexKey: '。', mode: 'after' },
   { regexKey: '\\.', mode: 'after' }
 ];
+
+const DragHandleIcon = () => (
+  <div className="grid h-4 w-4 grid-cols-2 gap-x-[3px] gap-y-[1px] text-[#94a3b8]">
+    {Array.from({ length: 6 }).map((_, index) => (
+      <span key={index} className="h-[2px] w-[2px] rounded-full bg-current" />
+    ))}
+  </div>
+);
 
 const FileUploadSplitStrategy = ({ data: strategies, onChange: setStrategies }) => {
   const { t } = useTranslation('knowledge');
@@ -67,7 +74,7 @@ const FileUploadSplitStrategy = ({ data: strategies, onChange: setStrategies }) 
   };
 
   return (
-    <div className='grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.08fr)]'>
+    <div className='grid gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(360px,0.96fr)]'>
       <div className="flex min-w-0 flex-col gap-5">
         <div className="space-y-3">
           <h3 className="text-sm font-medium text-[#374151]">{t('recommendedRules')}</h3>
@@ -91,20 +98,21 @@ const FileUploadSplitStrategy = ({ data: strategies, onChange: setStrategies }) 
         <div className="space-y-3">
           <h3 className="text-sm font-medium text-[#374151]">{t('addCustomRule')}</h3>
           <div className="flex items-center gap-3">
-            <div className="flex min-w-0 flex-1 items-center gap-1">
+            <div className="flex min-w-0 flex-1 items-center gap-2">
               <span className="shrink-0 text-sm text-[#0f172a]">{t('in')}</span>
               <Input
                 value={customRegex}
                 onChange={(e) => setCustomRegex(e.target.value)}
                 placeholder={t('enterRegex')}
-                className='h-8 flex-1 border-[#ebecf0] bg-white'
+                boxClassName="min-w-0 flex-1"
+                className='h-8 min-w-0 w-full border-[#ebecf0] bg-white'
               />
-              <div className="inline-flex shrink-0 items-center rounded-md bg-[#f8f8f8] p-1">
+              <div className="inline-flex h-8 shrink-0 items-center rounded-[6px] bg-[#f8f8f8] p-[3px]">
                 {['before', 'after'].map((item) => (
                   <button
                     key={item}
                     type="button"
-                    className={`rounded-[4px] px-3 py-1 text-sm transition-colors ${position === item ? 'bg-primary/15 font-medium text-primary' : 'text-[#818181]'}`}
+                    className={`rounded-[4px] px-3 py-[2px] text-sm leading-[22px] transition-colors ${position === item ? 'bg-primary/15 font-medium text-primary' : 'text-[#818181]'}`}
                     onClick={() => setPosition(item)}
                   >
                     {item === 'before' ? t('before') : t('after')}
@@ -112,10 +120,10 @@ const FileUploadSplitStrategy = ({ data: strategies, onChange: setStrategies }) 
                 ))}
               </div>
               <span className="shrink-0 text-sm text-[#0f172a]">{t('split')}</span>
+              <Button onClick={handleAddCustomStrategy} className="h-8 shrink-0 rounded-md border-[#ebecf0] bg-white px-4 text-[#070038]" variant="outline">
+                {t('add')}
+              </Button>
             </div>
-            <Button onClick={handleAddCustomStrategy} className="h-8 shrink-0 rounded-md border-[#ebecf0] bg-white px-4 text-[#070038]" variant="outline">
-              {t('add')}
-            </Button>
           </div>
         </div>
       </div>
@@ -136,19 +144,19 @@ const FileUploadSplitStrategy = ({ data: strategies, onChange: setStrategies }) 
                         <div
                           ref={provided.innerRef}
                           {...provided.draggableProps}
-                          className="group my-1 flex items-center gap-2 rounded-[4px] border border-[#e4e8ee] bg-[#f2f5f8] px-2 py-1 text-sm"
+                          className="group my-1 flex h-8 items-center gap-2 rounded-[4px] border border-[#e4e8ee] bg-[#f2f5f8] px-[5px] py-px text-sm"
                         >
                           <div
                             {...provided.dragHandleProps}
                             className="flex h-5 w-5 shrink-0 cursor-grab items-center justify-center text-[#94a3b8] active:cursor-grabbing"
                           >
-                            <GripVertical className="size-4" />
+                            <DragHandleIcon />
                           </div>
                           <div className='flex min-w-0 flex-1 items-center gap-3 overflow-hidden'>
-                            <span className="shrink-0 text-sm text-[#0f172a]">
+                            <span className="shrink-0 text-sm leading-5 text-[#0f172a]">
                               {strategy.position === 'before' ? `✂️${strategy.regex}` : `${strategy.regex}✂️`}
                             </span>
-                            <span className='min-w-0 truncate text-xs text-[#4e5969]'>{strategy.rule}</span>
+                            <span className='min-w-0 truncate text-sm text-[#4e5969]'>{strategy.rule}</span>
                           </div>
                           <div className="flex items-center">
                             <DelIcon

--- a/src/frontend/platform/src/pages/KnowledgePage/components/FileUploadStep2.tsx
+++ b/src/frontend/platform/src/pages/KnowledgePage/components/FileUploadStep2.tsx
@@ -314,6 +314,7 @@ const FileUploadStep2 = forwardRef(({
             <div className="fixed bottom-0 left-0 right-0 z-30 flex justify-center gap-4 border-t border-[#e4e8ee] bg-white px-4 py-4 sm:left-[184px]">
                 <Button
                     variant="outline"
+                    className="min-w-[88px]"
                     onClick={() => {
                         onPrev()
                         step === 2 && setShowPreview(false)
@@ -323,6 +324,7 @@ const FileUploadStep2 = forwardRef(({
                 </Button>
                 <Button
                     disabled={previewFailed || isSubmitting || strategies.length === 0}
+                    className="min-w-[88px]"
                     onClick={internalHandleNext}
                 >
                     {isSubmitting ? (

--- a/src/frontend/platform/src/pages/KnowledgePage/components/RuleFile.tsx
+++ b/src/frontend/platform/src/pages/KnowledgePage/components/RuleFile.tsx
@@ -70,18 +70,13 @@ export default function RuleFile({
         fontFamily: '"PingFang SC", "Hiragino Sans GB", "Microsoft YaHei UI", "Microsoft YaHei", "Noto Sans SC", sans-serif',
         fontWeight: 500
     }), []);
-    const renderTooltipWithImage = useCallback((textKey: string, imageSrc: string, imageAltKey: string, imageClassName = "w-[320px]") => (
-        <div className="space-y-1">
-            <p className="text-sm leading-5 text-white">
-                {t(textKey)}
-            </p>
-            <div className="overflow-hidden rounded-[10px] border border-white/15 bg-white p-1">
-                <img
-                    src={imageSrc}
-                    alt={t(imageAltKey)}
-                    className={`block max-w-full rounded-[8px] ${imageClassName}`}
-                />
-            </div>
+    const renderTooltipWithImage = useCallback((imageSrc: string, imageAltKey: string, imageClassName = "w-[320px]") => (
+        <div className="overflow-hidden rounded-[10px] border border-white/15 bg-white p-1">
+            <img
+                src={imageSrc}
+                alt={t(imageAltKey)}
+                className={`block max-w-full rounded-[8px] ${imageClassName}`}
+            />
         </div>
     ), [t]);
 
@@ -282,36 +277,42 @@ export default function RuleFile({
                             <div className="flex flex-wrap gap-8">
                                 <div className="flex items-center gap-3">
                                     <Label className="whitespace-nowrap text-sm text-gray-600 min-w-[90px]">{t('splitLength')}</Label>
-                                    <div className="relative group">
+                                    <div className="flex h-9 overflow-hidden rounded-md border border-input bg-white">
                                         <Input
                                             type="number"
                                             step="100"
                                             min={0}
                                             value={internalValues.chunkSize}
                                             onChange={(e) => handleSettingChange('chunkSize', e)}
-                                            className="w-[150px] bg-white border-gray-200 h-9"
+                                            boxClassName="w-[150px]"
+                                            className="h-full rounded-none border-0 bg-transparent shadow-none focus-visible:ring-0"
                                             onBlur={(e) => {
                                                 if (!e.target.value) handleSettingChange('chunkSize', { target: { value: '1000' } });
                                             }}
                                         />
-                                        <span className="absolute right-8 top-1/2 -translate-y-1/2 text-xs text-gray-400 pointer-events-none">{t('characters')}</span>
+                                        <div className="pointer-events-none flex items-center border-l border-[#ebecf0] bg-white px-3 text-sm text-[#9ca3af]">
+                                            {t('characters')}
+                                        </div>
                                     </div>
                                 </div>
                                 <div className="flex items-center gap-3">
                                     <Label className="whitespace-nowrap text-sm text-gray-600 min-w-[90px]">{t('chunkOverlap')}</Label>
-                                    <div className="relative">
+                                    <div className="flex h-9 overflow-hidden rounded-md border border-input bg-white">
                                         <Input
                                             type="number"
                                             step="10"
                                             min={0}
                                             value={internalValues.chunkOverlap}
                                             onChange={(e) => handleSettingChange('chunkOverlap', e)}
-                                            className="w-[150px] bg-white border-gray-200 h-9"
+                                            boxClassName="w-[150px]"
+                                            className="h-full rounded-none border-0 bg-transparent shadow-none focus-visible:ring-0"
                                             onBlur={(e) => {
                                                 if (!e.target.value) handleSettingChange('chunkOverlap', { target: { value: '0' } });
                                             }}
                                         />
-                                        <span className="absolute right-8 top-1/2 -translate-y-1/2 text-xs text-gray-400 pointer-events-none">{t('characters')}</span>
+                                        <div className="pointer-events-none flex items-center border-l border-[#ebecf0] bg-white px-3 text-sm text-[#9ca3af]">
+                                            {t('characters')}
+                                        </div>
                                     </div>
                                 </div>
                             </div>
@@ -324,7 +325,7 @@ export default function RuleFile({
                                         <Label htmlFor="splitLength" className="whitespace-nowrap text-sm text-gray-600 min-w-[90px]">
                                             {t('splitLength')}
                                         </Label>
-                                        <div className="relative">
+                                        <div className="flex h-9 overflow-hidden rounded-md border border-input bg-white">
                                             <Input
                                                 id="splitLength"
                                                 type="number"
@@ -333,12 +334,15 @@ export default function RuleFile({
                                                 value={internalValues.chunkSize}
                                                 onChange={(e) => handleSettingChange('chunkSize', e)}
                                                 placeholder={t('splitSizePlaceholder')}
-                                                className="w-[150px] bg-white h-9"
+                                                boxClassName="w-[150px]"
+                                                className="h-full rounded-none border-0 bg-transparent shadow-none focus-visible:ring-0"
                                                 onBlur={(e) => {
                                                     if (!e.target.value) handleSettingChange('chunkSize', { target: { value: '1000' } });
                                                 }}
                                             />
-                                            <span className="absolute right-8 top-1/2 -translate-y-1/2 text-xs text-gray-400 pointer-events-none">{t('characters')}</span>
+                                            <div className="pointer-events-none flex items-center border-l border-[#ebecf0] bg-white px-3 text-sm text-[#9ca3af]">
+                                                {t('characters')}
+                                            </div>
                                         </div>
                                     </div>
 
@@ -346,7 +350,7 @@ export default function RuleFile({
                                         <Label htmlFor="chunkOverlap" className="whitespace-nowrap text-sm text-gray-600 min-w-[90px]">
                                             {t('chunkOverlap')}
                                         </Label>
-                                        <div className="relative">
+                                        <div className="flex h-9 overflow-hidden rounded-md border border-input bg-white">
                                             <Input
                                                 id="chunkOverlap"
                                                 type="number"
@@ -355,12 +359,15 @@ export default function RuleFile({
                                                 value={internalValues.chunkOverlap}
                                                 onChange={(e) => handleSettingChange('chunkOverlap', e)}
                                                 placeholder={t('chunkOverlapPlaceholder')}
-                                                className="w-[150px] bg-white h-9"
+                                                boxClassName="w-[150px]"
+                                                className="h-full rounded-none border-0 bg-transparent shadow-none focus-visible:ring-0"
                                                 onBlur={(e) => {
                                                     if (!e.target.value) handleSettingChange('chunkOverlap', { target: { value: '0' } });
                                                 }}
                                             />
-                                            <span className="absolute right-8 top-1/2 -translate-y-1/2 text-xs text-gray-400 pointer-events-none">{t('characters')}</span>
+                                            <div className="pointer-events-none flex items-center border-l border-[#ebecf0] bg-white px-3 text-sm text-[#9ca3af]">
+                                                {t('characters')}
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
@@ -378,7 +385,7 @@ export default function RuleFile({
                                             {t('splitLevel')}
                                         </Label>
                                         <div className="flex items-center gap-2">
-                                            <div className="relative">
+                                            <div className="flex h-9 overflow-hidden rounded-md border border-input bg-white">
                                                 <Input
                                                     id="hierarchyLevel"
                                                     type="number"
@@ -386,13 +393,20 @@ export default function RuleFile({
                                                     max={5}
                                                     value={internalValues.hierarchyLevel}
                                                     onChange={(e) => handleSettingChange('hierarchyLevel', e)}
-                                                    className="w-[100px] bg-white h-9"
+                                                    boxClassName="w-[120px]"
+                                                    className="h-full rounded-none border-0 bg-transparent shadow-none focus-visible:ring-0"
                                                 />
-                                                <span className="absolute right-8 top-1/2 -translate-y-1/2 text-sm text-gray-500 pointer-events-none">{t('layer')}</span>
+                                                <div className="pointer-events-none flex items-center border-l border-[#ebecf0] bg-white px-3 text-sm text-[#9ca3af]">
+                                                    {t('layer')}
+                                                </div>
                                             </div>
                                             <QuestionTooltip
                                                 className="text-[#999]"
-                                                content={renderTooltipWithImage('splitLevelTooltip', splitLevelTooltipImageSrc, 'splitLevelTooltipImageAlt', 'w-[480px]')}
+                                                content={renderTooltipWithImage(
+                                                    splitLevelTooltipImageSrc,
+                                                    'splitLevelTooltipImageAlt',
+                                                    'w-[480px]'
+                                                )}
                                             />
                                         </div>
                                     </div>
@@ -402,7 +416,7 @@ export default function RuleFile({
                                             {t('maxChunkSize')}
                                         </Label>
                                         <div className="flex items-center gap-2">
-                                            <div className="relative">
+                                            <div className="flex h-9 overflow-hidden rounded-md border border-input bg-white">
                                                 <Input
                                                     id="maxChunkSize"
                                                     type="number"
@@ -410,11 +424,13 @@ export default function RuleFile({
                                                     min={0}
                                                     value={internalValues.maxChunkSize}
                                                     onChange={(e) => handleSettingChange('maxChunkSize', e)}
-                                                    className="w-[150px] bg-white h-9"
+                                                    boxClassName="w-[150px]"
+                                                    className="h-full rounded-none border-0 bg-transparent shadow-none focus-visible:ring-0"
                                                 />
-                                                <span className="absolute right-8 top-1/2 -translate-y-1/2 text-xs text-gray-400 pointer-events-none">{t('characters')}</span>
+                                                <div className="pointer-events-none flex items-center border-l border-[#ebecf0] bg-white px-3 text-sm text-[#9ca3af]">
+                                                    {t('characters')}
+                                                </div>
                                             </div>
-                                            <QuestionTooltip className="text-[#999]" content={t('maxChunkSizeTooltip')} />
                                         </div>
                                     </div>
                                 </div>
@@ -429,7 +445,7 @@ export default function RuleFile({
                                         {t('appendTitle')}
                                         <QuestionTooltip
                                             className="text-[#999]"
-                                            content={renderTooltipWithImage('appendTitleTooltip', appendTitleTooltipImageSrc, 'appendTitleTooltipImageAlt')}
+                                            content={renderTooltipWithImage(appendTitleTooltipImageSrc, 'appendTitleTooltipImageAlt')}
                                         />
                                     </Label>
                                 </div>

--- a/src/frontend/platform/src/pages/SystemPage/components/EditRole.tsx
+++ b/src/frontend/platform/src/pages/SystemPage/components/EditRole.tsx
@@ -403,8 +403,8 @@ export default function EditRole({ id, name, groupId, knowledgeSpaceFileLimit, o
   const [form, setForm] = useState({
     name,
     useSkills: [], useLibs: [], useAssistant: [], useFlows: [], useTools: [], useMenu: [MenuType.BUILD, MenuType.KNOWLEDGE],
-    // 工作台菜单：订阅默认关闭，知识空间默认开启
-    useWorkbenchMenu: [MenuType.KNOWLEDGE_SPACE],
+    // 工作台子菜单：订阅与知识空间默认与 Roles 页新建角色一致（均开启）
+    useWorkbenchMenu: [MenuType.SUBSCRIPTION, MenuType.KNOWLEDGE_SPACE],
     manageLibs: [], manageAssistants: [], manageSkills: [], manageFlows: [], manageTools: [], useBoards: [], manageBoards: [],
     allowCreateBoard: false,
     knowledgeSpaceFileLimit,

--- a/src/frontend/platform/src/pages/SystemPage/components/Roles.tsx
+++ b/src/frontend/platform/src/pages/SystemPage/components/Roles.tsx
@@ -85,10 +85,12 @@ function formatKnowledgeSpaceGbInput(n: number): string {
   if (r < KB_SPACE_FILE_GB_MIN || r > KB_SPACE_FILE_GB_MAX) return "500"
   return Number.isInteger(r) ? String(r) : r.toFixed(1)
 }
+/** 工作台四项（首页 / 应用 / 订阅 / 知识空间）新建角色默认全开，与 PRD 一致 */
 const DEFAULT_ENABLED_MENU_IDS = [
   WORKBENCH_PARENT_ID,
   "home",
   "apps",
+  "subscription",
   "knowledge_space",
   ADMIN_PARENT_ID,
   "knowledge",

--- a/src/frontend/platform/src/pages/SystemPage/components/UserGroup.tsx
+++ b/src/frontend/platform/src/pages/SystemPage/components/UserGroup.tsx
@@ -93,7 +93,14 @@ export default function UserGroups() {
     const canDeleteGroup = (ug: UserGroupV2) => {
         if (user?.role === "admin") return true
         const isTenantScopedAdmin = user?.is_department_admin || user?.is_child_admin
-        if (isTenantScopedAdmin && ug.create_user === user?.user_id) return true
+        const creatorId = Number(ug.create_user)
+        const currentUserId = Number(user?.user_id)
+        if (
+            isTenantScopedAdmin
+            && Number.isFinite(creatorId)
+            && Number.isFinite(currentUserId)
+            && creatorId === currentUserId
+        ) return true
         return false
     }
 

--- a/src/frontend/platform/src/pages/SystemPage/components/UserGroup.tsx
+++ b/src/frontend/platform/src/pages/SystemPage/components/UserGroup.tsx
@@ -29,6 +29,23 @@ import EditUserGroup from "./EditUserGroup";
 import { locationContext } from "@/contexts/locationContext";
 import { userContext } from "@/contexts/userContext";
 
+export const canDeleteUserGroup = (user: any, ug: UserGroupV2) => {
+    if (user?.role === "admin") return true
+    const isUserGroupManager =
+        user?.can_manage_user_groups
+        || user?.is_department_admin
+        || user?.is_child_admin
+    const creatorId = Number(ug.create_user)
+    const currentUserId = Number(user?.user_id)
+    if (
+        isUserGroupManager
+        && Number.isFinite(creatorId)
+        && Number.isFinite(currentUserId)
+        && creatorId === currentUserId
+    ) return true
+    return false
+}
+
 export default function UserGroups() {
     const { t } = useTranslation()
     const { user } = useContext(userContext)
@@ -88,20 +105,6 @@ export default function UserGroups() {
                 }
             },
         })
-    }
-
-    const canDeleteGroup = (ug: UserGroupV2) => {
-        if (user?.role === "admin") return true
-        const isTenantScopedAdmin = user?.is_department_admin || user?.is_child_admin
-        const creatorId = Number(ug.create_user)
-        const currentUserId = Number(user?.user_id)
-        if (
-            isTenantScopedAdmin
-            && Number.isFinite(creatorId)
-            && Number.isFinite(currentUserId)
-            && creatorId === currentUserId
-        ) return true
-        return false
     }
 
     const checkSameName = (name: string) => {
@@ -242,7 +245,7 @@ export default function UserGroups() {
                                     <Button variant="link" disabled={loading} onClick={() => setUserGroup({ ...ug })}
                                         className="px-0 pl-6">{t('edit')}
                                     </Button>
-                                    <Button variant="link" disabled={loading || !canDeleteGroup(ug)} onClick={() => handleDelete(ug)} className="text-red-500 px-0 pl-6">{t('delete')}</Button>
+                                    <Button variant="link" disabled={loading || !canDeleteUserGroup(user, ug)} onClick={() => handleDelete(ug)} className="text-red-500 px-0 pl-6">{t('delete')}</Button>
                                 </TableCell>
                             </TableRow>
                         ))}

--- a/src/frontend/platform/src/test/permissionListTab.test.tsx
+++ b/src/frontend/platform/src/test/permissionListTab.test.tsx
@@ -1,20 +1,17 @@
 import { PermissionListTab } from "@/components/bs-comp/permission/PermissionListTab";
-import { getDepartmentTreeApi } from "@/controllers/API/department";
 import {
   authorizeResource,
   getGrantableRelationModelsApi,
+  getResourceGrantDepartmentsApi,
   getResourcePermissions,
 } from "@/controllers/API/permission";
 import { fireEvent, render, screen, waitFor } from "@/test/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@/controllers/API/department", () => ({
-  getDepartmentTreeApi: vi.fn(),
-}));
-
 vi.mock("@/controllers/API/permission", () => ({
   authorizeResource: vi.fn(),
   getGrantableRelationModelsApi: vi.fn(),
+  getResourceGrantDepartmentsApi: vi.fn(),
   getResourcePermissions: vi.fn(),
 }));
 
@@ -39,7 +36,7 @@ vi.mock("@/components/bs-ui/dropdownMenu", () => ({
   ),
 }));
 
-const mockedGetDepartmentTreeApi = vi.mocked(getDepartmentTreeApi);
+const mockedGetResourceGrantDepartmentsApi = vi.mocked(getResourceGrantDepartmentsApi);
 const mockedGetGrantableRelationModelsApi = vi.mocked(getGrantableRelationModelsApi);
 const mockedGetResourcePermissions = vi.mocked(getResourcePermissions);
 const mockedAuthorizeResource = vi.mocked(authorizeResource);
@@ -48,7 +45,7 @@ describe("PermissionListTab", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockedAuthorizeResource.mockResolvedValue(null as any);
-    mockedGetDepartmentTreeApi.mockResolvedValue([]);
+    mockedGetResourceGrantDepartmentsApi.mockResolvedValue([]);
     mockedGetGrantableRelationModelsApi.mockResolvedValue([
       {
         id: "viewer",
@@ -86,6 +83,10 @@ describe("PermissionListTab", () => {
     });
     expect(mockedGetGrantableRelationModelsApi).toHaveBeenCalledTimes(1);
     expect(mockedGetGrantableRelationModelsApi).toHaveBeenCalledWith(
+      "knowledge_space",
+      "3215",
+    );
+    expect(mockedGetResourceGrantDepartmentsApi).toHaveBeenCalledWith(
       "knowledge_space",
       "3215",
     );
@@ -239,6 +240,20 @@ describe("PermissionListTab", () => {
   });
 
   it("deletes department include-children grants across subtree and exact variants", async () => {
+    mockedGetResourceGrantDepartmentsApi.mockResolvedValue([
+      {
+        id: 7,
+        dept_id: "BS@7",
+        name: "研发部",
+        parent_id: null,
+        path: "/7/",
+        sort_order: 0,
+        source: "local",
+        status: "active",
+        member_count: 0,
+        children: [],
+      },
+    ] as any);
     mockedGetResourcePermissions.mockResolvedValue([
       {
         subject_type: "department",

--- a/src/frontend/platform/src/test/userGroups.test.ts
+++ b/src/frontend/platform/src/test/userGroups.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { paginateAllUserGroupMembers } from "@/controllers/API/userGroups";
+import { canDeleteUserGroup } from "@/pages/SystemPage/components/UserGroup";
 
 describe("paginateAllUserGroupMembers", () => {
   it("loads every page until total is reached", async () => {
@@ -48,5 +49,34 @@ describe("paginateAllUserGroupMembers", () => {
 
     expect(fetchPage).toHaveBeenCalledTimes(2);
     expect(rows.map((r) => r.user_id)).toEqual([1]);
+  });
+});
+
+describe("canDeleteUserGroup", () => {
+  it("allows user-group managers to delete groups they created", () => {
+    expect(
+      canDeleteUserGroup(
+        { role: "user", can_manage_user_groups: true, user_id: 5 },
+        { id: 1, group_name: "g", visibility: "public", create_user: 5 },
+      ),
+    ).toBe(true);
+  });
+
+  it("normalizes creator ids before comparing", () => {
+    expect(
+      canDeleteUserGroup(
+        { role: "user", can_manage_user_groups: true, user_id: 5 },
+        { id: 1, group_name: "g", visibility: "public", create_user: "5" },
+      ),
+    ).toBe(true);
+  });
+
+  it("does not allow scoped managers to delete groups created by others", () => {
+    expect(
+      canDeleteUserGroup(
+        { role: "user", can_manage_user_groups: true, user_id: 5 },
+        { id: 1, group_name: "g", visibility: "public", create_user: 6 },
+      ),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
Resource permission dialogs were still using the organization department tree in list/display paths, which made successful resource grants surface department-operation permission errors for users who can manage a resource but cannot manage the org tree.

The permission components now use resource-scoped grant-subject department endpoints for knowledge spaces, knowledge libraries, tools, assistants, and workflow apps. The only remaining organization-tree usage is explicitly opted in for department-space creation.

Constraint: Resource managers should not need organization-management permission just to view or grant resource department subjects

Rejected: Loosen /departments/tree authorization | would widen organization visibility beyond the resource authorization use case

Confidence: high

Scope-risk: narrow

Directive: Do not reintroduce /departments/tree through permission API wrappers or resource permission components

Tested: npm test -- permissionListTab.test.tsx knowledgeSpaceGrantSubjects.test.tsx in src/frontend/platform

Tested: npm test -- SubjectSearchDepartment.test.tsx PermissionGrantTab.test.tsx PermissionListTab.test.tsx --watchAll=false in src/frontend/client