### PR TITLE
fix: resolve InMemoryCache deadlock and stale cache checks

### DIFF
--- a/src/backend/bisheng/core/cache/flow.py
+++ b/src/backend/bisheng/core/cache/flow.py
@@ -40,7 +40,7 @@ class InMemoryCache(BaseCache):
             expiration_time (int, optional): Time in seconds after which a cached item expires. Default is 1 hour.
         """
         self._cache = OrderedDict()
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
         self.max_size = max_size
         self.expiration_time = expiration_time
 
@@ -111,8 +111,8 @@ class InMemoryCache(BaseCache):
         Args:
             key: The key of the item to remove.
         """
-        # with self._lock:
-        self._cache.pop(key, None)
+        with self._lock:
+            self._cache.pop(key, None)
 
     def clear(self):
         """
@@ -122,8 +122,8 @@ class InMemoryCache(BaseCache):
             self._cache.clear()
 
     def __contains__(self, key):
-        """Check if the key is in the cache."""
-        return key in self._cache
+        """Check if the key is in the cache and not expired."""
+        return self.get(key) is not None
 
     def __getitem__(self, key):
         """Retrieve an item from the cache using the square bracket notation."""


### PR DESCRIPTION
## Summary
- Replace `threading.Lock` with `RLock` to prevent deadlock in `get_or_set()` which calls `self.get()`/`self.set()` while holding the lock
- Uncomment the lock in `delete()` to ensure thread-safe cache eviction
- Fix `__contains__` to check expiration, preventing stale cache hits where `key in cache` returns `True` but `cache[key]` returns `None`

## Problem
`InMemoryCache` uses `threading.Lock()` (non-reentrant). The `get_or_set()` method acquires the lock and then calls `self.get()` or `self.set()`, which also try to acquire the same lock, causing a **permanent deadlock**.

Additionally, `delete()` has its lock commented out, making it thread-unsafe. The `__contains__` method doesn't check expiration, so it returns `True` for expired items while `get()` returns `None` for the same key.

## Test plan
- [ ] Verify `get_or_set()` no longer deadlocks under concurrent access
- [ ] Verify `delete()` is thread-safe with the lock re-enabled
- [ ] Verify `'key' in cache` returns `False` for expired items

🤖 Generated with [Claude Code](https://claude.com/claude-code)