### PR TITLE
fix: prevent NoneType crash in preper_reuse_connection

### DIFF
--- a/src/backend/bisheng/chat/manager.py
+++ b/src/backend/bisheng/chat/manager.py
@@ -571,8 +571,11 @@ class ChatManager:
             gragh_data = session.get(Flow, flow_id)
             if not gragh_data:
                 message = SkillDeletedError()
-            if gragh_data.status != 2:
+            elif gragh_data.status != 2:
                 message = SkillNotOnlineError()
+        if message:
+            self.reuse_connect(flow_id, chat_id, websocket)
+            return None, message
         gragh_data = gragh_data.data
         self.reuse_connect(flow_id, chat_id, websocket)
         return gragh_data, message


### PR DESCRIPTION
## Summary
- Fix `preper_reuse_connection` to return early when `gragh_data` is `None`
- Change `if` to `elif` for the status check to avoid accessing `.status` on `None`
- Ensure `reuse_connect` is still called even in the error case

## Problem
When a flow doesn't exist in the database (`gragh_data is None`), the code sets the error message but continues execution. Line `gragh_data.status != 2` then raises `AttributeError: 'NoneType' object has no attribute 'status'`, crashing the websocket handler.

## Test plan
- [ ] Verify that connecting to a non-existent flow returns proper error instead of crashing
- [ ] Verify that connecting to an offline flow returns `SkillNotOnlineError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)