### PR TITLE
fix: correct variable name in replace_param closure

### DIFF
--- a/src/backend/bisheng/worker/workflow/redis_callback.py
+++ b/src/backend/bisheng/worker/workflow/redis_callback.py
@@ -63,7 +63,7 @@ class RedisCallback(BaseCallback):
         def replace_param(one_params: List[Dict], one_node_id: str):
             for param in one_params:
                 param_key = param.get('key')
-                if param_key not in override[node_id]:
+                if param_key not in override[one_node_id]:
                     continue
                 param['value'] = override[one_node_id][param_key]
 


### PR DESCRIPTION
## Summary
- Change `override[node_id]` to `override[one_node_id]` in the membership check inside `replace_param`

## Problem
The inner function `replace_param(one_params, one_node_id)` uses `node_id` (from the outer `for node in nodes` loop) for the `if param_key not in override[node_id]` check, but uses `one_node_id` (the function parameter) for the assignment `override[one_node_id][param_key]`.

This mismatch means:
1. The check tests the **wrong node's** override data
2. The assignment writes to the **correct node's** override data

When multiple nodes have overlapping parameter keys, a parameter might be skipped (because `node_id` doesn't contain it) even though `one_node_id` does contain it — causing silent data loss in workflow parameter overrides.

## Test plan
- [ ] Test workflow execution with parameter overrides across multiple nodes
- [ ] Verify that each node's parameters are checked against its own override data

🤖 Generated with [Claude Code](https://claude.com/claude-code)