### PR TITLE
fix: send error response before raising in task exception handler

### DIFF
--- a/src/backend/bisheng/chat/manager.py
+++ b/src/backend/bisheng/chat/manager.py
@@ -391,11 +391,11 @@ class ChatManager:
                             erro_resp = ChatResponse(**base_param)
                             context = context_dict.get(future_key)
                             if context.get('status') == 'init':
-                                raise LLMExecutionError(exception=e, error=str(e))
+                                error_cls = LLMExecutionError
                             elif context.get('has_file'):
-                                raise DocumentParseError(exception=e, error=str(e))
+                                error_cls = DocumentParseError
                             else:
-                                raise InputDataParseError(exception=e, error=str(e))
+                                error_cls = InputDataParseError
 
                             context['status'] = 'init'
                             await self.send_json(context.get('flow_id'), context.get('chat_id'),
@@ -403,6 +403,7 @@ class ChatManager:
                             erro_resp.type = 'close'
                             await self.send_json(context.get('flow_id'), context.get('chat_id'),
                                                  erro_resp)
+                            raise error_cls(exception=e, error=str(e))
         except WebSocketDisconnect as e:
             logger.info(f'act=rcv_client_disconnect {str(e)}')
         except BaseErrorCode as e:


### PR DESCRIPTION
## Summary
- Move error response sending before the `raise` statement in the task exception handler
- Determine the error type first, send the websocket response, then raise

## Problem
In `handle_websocket`, the task completion exception handler had this structure:
```python
if context.get('status') == 'init':
    raise LLMExecutionError(...)
elif context.get('has_file'):
    raise DocumentParseError(...)
else:
    raise InputDataParseError(...)

# UNREACHABLE CODE below - all branches above raise
context['status'] = 'init'
await self.send_json(...)  # never executed
```

Every branch of the if/elif/else chain ends with `raise`, so the error response sending code (lines 400-405) was **unreachable dead code**. Users never received error responses via websocket when a background task failed.

## Test plan
- [ ] Trigger a task failure and verify the error response is sent to the client before the websocket closes
- [ ] Verify the correct exception type is still raised after sending the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)