### PR TITLE
fix: add timeout to HTTP requests that could hang indefinitely

### DIFF
--- a/src/backend/bisheng/core/cache/utils.py
+++ b/src/backend/bisheng/core/cache/utils.py
@@ -384,7 +384,7 @@ def file_download(file_path: str):
             file_content = minio_client.get_object_sync(bucket_name, object_name)
         else:
             # download file from http url
-            r = requests.get(file_path, verify=False)
+            r = requests.get(file_path, verify=False, timeout=30)
             if r.status_code != 200:
                 raise ValueError('Check the url of your file; returned status code %s' % r.status_code)
             # OthersContent-Dispositionheader to find the filename

--- a/src/backend/bisheng/utils/docx_temp.py
+++ b/src/backend/bisheng/utils/docx_temp.py
@@ -1560,7 +1560,7 @@ class DocxTemplateRender(object):
 def test_replace_string(template_file, kv_dict: dict, file_name: str):
     # If the file is a web path, download it to a temporary file, and use that
     if not os.path.isfile(template_file) and _is_valid_url(template_file):
-        r = requests.get(template_file)
+        r = requests.get(template_file, timeout=30)
 
         if r.status_code != 200:
             raise ValueError("Check the url of your file; returned status code %s" % r.status_code)


### PR DESCRIPTION
## Summary
- Add `timeout=30` to `requests.get()` calls in `core/cache/utils.py` and `utils/docx_temp.py`

## Problem
Two `requests.get()` calls have no `timeout` parameter. If the remote server hangs or is unreachable, the request blocks indefinitely, consuming a server thread/worker forever. In a production environment with limited workers, a few hung downloads can exhaust the entire worker pool.

## Test plan
- [ ] Verify file downloads still work normally
- [ ] Verify that requests to unreachable URLs time out after 30 seconds instead of hanging forever

🤖 Generated with [Claude Code](https://claude.com/claude-code)