### PR TITLE
fix: prevent TypeError from dict.get() returning None in evaluation

### DIFF
--- a/src/backend/bisheng/api/services/evaluation.py
+++ b/src/backend/bisheng/api/services/evaluation.py
@@ -229,8 +229,8 @@ class EvaluationService:
                         'type': 'file',
                         'id': node.id
                     })
-            if len(input_keys_response.get("input_keys")):
-                input_item = input_keys_response.get("input_keys")[0]
+            if len(input_keys_response.get("input_keys", [])):
+                input_item = input_keys_response["input_keys"][0]
                 del input_item["id"]
                 return input_item
         finally:
@@ -390,7 +390,7 @@ async def add_evaluation_task(evaluation_id: int):
         for index, one in enumerate(question):
             row_data = {}
             for field, title, unit_type in columns:
-                value = result.get(field)[index]
+                value = result[field][index]
                 if unit_type != 1:
                     tmp_dict[field] += value
                 if unit_type == 3:
@@ -400,7 +400,7 @@ async def add_evaluation_task(evaluation_id: int):
 
         total_row_data = {}
         for field, title, unit_type in columns:
-            value = tmp_dict.get(field)
+            value = tmp_dict[field]
             if unit_type == 3:
                 value = f'{(value / len(row_list)) * 100:.2f}%'
                 total_dict[field] = value


### PR DESCRIPTION
## Summary
- Replace `result.get(field)[index]` with `result[field][index]`
- Replace `tmp_dict.get(field)` with `tmp_dict[field]` to use `defaultdict(int)` factory
- Replace `input_keys_response.get("input_keys")[0]` with safe indexing

## Problem
Three instances of unsafe `dict.get()` usage causing `TypeError: 'NoneType' object is not subscriptable`:

1. `result.get(field)[index]` — `get()` returns `None` when key is missing, then `None[index]` crashes
2. `tmp_dict.get(field)` — bypasses `defaultdict(int)` factory and returns `None` instead of `0`, then `None / len(row_list)` crashes during percentage calculation
3. `input_keys_response.get("input_keys")[0]` — same pattern, crashes when key missing

## Test plan
- [ ] Run evaluation task and verify it completes without TypeError
- [ ] Verify total row percentage calculation produces correct values

🤖 Generated with [Claude Code](https://claude.com/claude-code)