### PR TITLE
fix: remove stale dev upstream from nginx config

### DIFF
--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -8,7 +8,6 @@ map $http_upgrade $connection_upgrade {
 
 upstream backend_server {
 	server backend:7860;  # backend api
-	server 192.168.106.115:8098;
 }
 
 upstream minio_server {


### PR DESCRIPTION
## Summary
- Drop the hardcoded dev address `192.168.106.115:8098` from the `backend_server` upstream in `docker/nginx/conf.d/default.conf`. The compose service `backend:7860` is the only upstream that exists on a self-deployment.

## Why
On a fresh `docker compose up` self-deployment, nginx round-robins between the two upstreams and one of them (`192.168.106.115:8098`) is unreachable. Symptoms observed in `bisheng-frontend` logs:

```
[error] connect() failed (111: Connection refused) while connecting to upstream,
  upstream: http://192.168.106.115:8098/api/v1/web/config
[error] no live upstreams while connecting to upstream,
  upstream: http://backend_server/api/v1/user/get_captcha
```

Endpoints like `/api/v1/web/config`, `/api/v1/env`, `/api/v1/user/info`, `/api/v1/user/get_captcha` return intermittent 502s. The visible user-facing consequence is that the **registration link disappears from the login page**, because the frontend gates it on `appConfig.register`, which comes from `enable_registration` in `/api/v1/web/config` — when that request 502s, the flag stays falsy.

## Test plan
- [x] `docker exec bisheng-frontend nginx -t` passes
- [x] `docker exec bisheng-frontend nginx -s reload`, then `curl localhost:3001/api/v1/web/config` returns 200 consistently
- [x] No more `Connection refused` lines in `bisheng-frontend` nginx logs
- [x] Registration link reappears on the login page

🤖 Generated with [Claude Code](https://claude.com/claude-code)