### PR TITLE
fix(approval): and-mode node never completes because same_node_tasks …

### DIFF
--- a/src/backend/bisheng/approval/domain/services/approval_center_service.py
+++ b/src/backend/bisheng/approval/domain/services/approval_center_service.py
@@ -732,7 +732,13 @@ class ApprovalCenterService:
             self.__class__._dispatch_outbox(outbox.id)
             return
 
-        all_same_node_approved = all(one.status == ApprovalTaskStatus.APPROVED for one in same_node_tasks)
+        # same_node_tasks was fetched before the current task was updated, so the
+        # current task's object still carries its old PENDING status. Treat it as
+        # APPROVED by checking its id explicitly.
+        all_same_node_approved = all(
+            t.id == task.id or t.status == ApprovalTaskStatus.APPROVED
+            for t in same_node_tasks
+        )
         if all_same_node_approved:
             instance.status = ApprovalInstanceStatus.APPROVED
             await self.instance_repository.update_instance(instance)


### PR DESCRIPTION
…holds stale status

sibling_tasks (and thus same_node_tasks) is fetched from DB before the current task is updated to APPROVED. The all_same_node_approved check then sees the current task as still PENDING, so the condition is always False for a single-approver and-mode node — outbox is never created and the instance stays PENDING forever.

Fix: treat the current task as APPROVED in the check by matching on id, instead of relying on the stale in-memory status.