### PR TITLE
fix(audit): translate snake_case approval actions and record submit IP

### DIFF
--- a/src/backend/bisheng/channel/api/endpoints/channel_manager.py
+++ b/src/backend/bisheng/channel/api/endpoints/channel_manager.py
@@ -152,12 +152,13 @@ async def get_channel_square(
 
 @router.post("/subscribe")
 async def subscribe_channel(
+        request: Request,
         req_param: SubscribeChannelRequest,
         login_user: UserPayload = Depends(UserPayload.get_login_user),
         channel_service: 'ChannelService' = Depends(get_channel_service)
 ):
     """Subscribe channel request API: Handles subscription requests based on channel type (public, private, approval required)."""
-    status = await channel_service.subscribe_channel(req_param, login_user)
+    status = await channel_service.subscribe_channel(req_param, login_user, request)
     return resp_200(data=status.value)
 
 

--- a/src/backend/bisheng/channel/domain/services/channel_service.py
+++ b/src/backend/bisheng/channel/domain/services/channel_service.py
@@ -808,7 +808,12 @@ class ChannelService:
 
         return ChannelSquarePageResponse(data=result_list, total=total)
 
-    async def subscribe_channel(self, req: SubscribeChannelRequest, login_user: UserPayload) -> SubscriptionStatusEnum:
+    async def subscribe_channel(
+        self,
+        req: SubscribeChannelRequest,
+        login_user: UserPayload,
+        request=None,
+    ) -> SubscriptionStatusEnum:
         """
         Subscribe to a channel (public or review).
         - Private channels cannot be subscribed to.
@@ -889,6 +894,7 @@ class ChannelService:
                         'channel_name': channel.name,
                         'applicant_user_id': login_user.user_id,
                     },
+                    ip_address=get_request_ip(request) if request else None,
                 )
             )
             if gate_result.decision == 'pass':

--- a/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
+++ b/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
@@ -108,7 +108,7 @@ from bisheng.permission.domain.services.owner_service import OwnerService
 from bisheng.permission.domain.services.permission_service import PermissionService
 from bisheng.role.domain.services.quota_service import QuotaService
 from bisheng.user.domain.models.user import UserDao
-from bisheng.utils import generate_uuid
+from bisheng.utils import generate_uuid, get_request_ip
 from bisheng.worker.knowledge import file_worker
 
 if TYPE_CHECKING:
@@ -3723,6 +3723,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                         "space_type": getattr(space, "type", ""),
                         "applicant_user_id": self.login_user.user_id,
                     },
+                    ip_address=get_request_ip(self.request) if self.request else None,
                 )
             )
             if gate_result.decision == "pass":

--- a/src/frontend/platform/src/pages/LogPage/systemLog/index.tsx
+++ b/src/frontend/platform/src/pages/LogPage/systemLog/index.tsx
@@ -34,12 +34,14 @@ const useModules = () => {
 // already restricts which v2 rows reach the list — these helpers only need to
 // handle that whitelist plus a defensive fallback for unexpected rows.
 
-// Dotted action (`tenant.mount`, `llm.server.create`) → camelCase i18n leaf
-// key (`tenantMount`, `llmServerCreate`). i18next treats `.` as a nesting
-// separator, so the dotted form would resolve to a nested path that does
-// not exist in the locale files.
-const actionToI18nKey = (action: string): string => {
-    const [head, ...rest] = action.split('.')
+// Structured action (`tenant.mount`, `approval.exception.assign_approver`) →
+// camelCase i18n leaf key (`tenantMount`, `approvalExceptionAssignApprover`).
+// Both `.` and `_` act as word separators: i18next treats `.` as a nesting
+// separator and locale keys use camelCase throughout, so snake_case segments
+// must also be folded into the camelCase form to resolve.
+export const actionToI18nKey = (action: string): string => {
+    const [head, ...rest] = action.split(/[._]/).filter(Boolean)
+    if (!head) return action
     return head + rest.map(p => p.charAt(0).toUpperCase() + p.slice(1)).join('')
 }
 

--- a/src/frontend/platform/src/test/logActions.test.ts
+++ b/src/frontend/platform/src/test/logActions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { getActionsApi, getActionsByModuleApi } from "@/controllers/API/log";
+import { actionToI18nKey } from "@/pages/LogPage/systemLog";
 
 describe("audit log actions", () => {
   it("includes approval revoke grant action in the global action list", async () => {
@@ -18,6 +19,20 @@ describe("audit log actions", () => {
         expect.objectContaining({ value: "approval.instance.resubmit" }),
       ]),
     );
+  });
+
+  it("folds dotted and snake_case action segments into camelCase i18n keys", () => {
+    // Every entry whose value contains `_` previously rendered as a raw key
+    // (e.g. `approvalExceptionAssign_approver`) because the converter only
+    // split on `.`. Keep this in sync with the action list in log.ts.
+    expect(actionToI18nKey("approval.exception.assign_approver")).toBe(
+      "approvalExceptionAssignApprover",
+    );
+    expect(actionToI18nKey("approval.menu_access.revoke_grant")).toBe(
+      "approvalMenuAccessRevokeGrant",
+    );
+    expect(actionToI18nKey("tenant.mount")).toBe("tenantMount");
+    expect(actionToI18nKey("llm.server.create")).toBe("llmServerCreate");
   });
 
   it("keeps approval actions visible under the approval module filter", async () => {


### PR DESCRIPTION
- Frontend: split action i18n keys on both `.` and `_` so `approval.exception.assign_approver` resolves to `approvalExceptionAssignApprover` instead of rendering the raw key.
- Backend: propagate the request IP into `ApprovalGateRequest` from the channel-subscribe and knowledge-space-subscribe paths so the `approval.request.submit` audit row carries an `ip_address` (the menu-access path already did).