### PR TITLE
fix(F028): unwrap user-query JSON envelopes + recover answer text fro…

### DIFF
--- a/src/backend/bisheng/workstation/domain/services/conversation_export_service.py
+++ b/src/backend/bisheng/workstation/domain/services/conversation_export_service.py
@@ -251,7 +251,7 @@ class ConversationExportService:
             turns.append(
                 ConversationTurn(
                     user_name=user_name,
-                    user_query=cls._strip_citations(q.message or ''),
+                    user_query=cls._strip_citations(cls._extract_query_text(q)),
                     sender_name=sender_name,
                     answers=answer_texts,
                 )
@@ -265,6 +265,37 @@ class ConversationExportService:
     @staticmethod
     def _is_query(m: ChatMessage) -> bool:
         return (m.category or '').lower() == 'question'
+
+    @staticmethod
+    def _extract_query_text(m: ChatMessage) -> str:
+        """Pull the user-facing text out of a ``question`` ChatMessage.
+
+        The frontend wraps user input in different JSON envelopes depending on
+        the chat surface, so the raw ``message`` column is rarely a plain
+        string:
+
+        - daily mode (workstation) : ``{"query": "<text>", "files": [...]}``
+        - app chat / workflow      : ``{"data": {...}, "input": "<text>"}``
+        - legacy / plain           : just the raw string
+
+        Returns the unwrapped text. If the envelope shape is unknown but the
+        row is valid JSON, we fall back to the raw string to avoid silently
+        dropping content (better to render a JSON-y line than an empty turn).
+        """
+        raw = m.message or ''
+        if not raw:
+            return ''
+        try:
+            data = json.loads(raw)
+        except (ValueError, TypeError):
+            return raw
+        if not isinstance(data, dict):
+            return raw
+        for key in ('query', 'input'):
+            value = data.get(key)
+            if isinstance(value, str) and value:
+                return value
+        return raw
 
     @staticmethod
     def _parse_parent_msg_id(m: ChatMessage) -> Optional[int]:
@@ -311,6 +342,13 @@ class ConversationExportService:
 
             msg = data.get('msg') or ''
             events = data.get('events') or []
+
+            # The v2.5 agent-native format may keep the final answer text only
+            # in ``events`` (last item with type ``text``) and leave ``msg``
+            # empty. Fall through to events to recover that case, and also
+            # capture text from workflow OUTPUT nodes whose ``output_type``
+            # is ``text``.
+            text_chunks: list[str] = []
             placeholders: list[str] = []
             for e in events:
                 if not isinstance(e, dict):
@@ -319,15 +357,29 @@ class ConversationExportService:
                 # Drop reasoning / tool interactions.
                 if etype in {'thinking', 'tool_call', 'tool_result'}:
                     continue
-                # Workflow non-text output blocks (forms, buttons, file cards).
+                if etype == 'text':
+                    content = e.get('content') or ''
+                    if content:
+                        text_chunks.append(content)
+                    continue
                 if etype == 'output':
                     output_kind = (e.get('output_type') or e.get('kind') or '').lower()
-                    if output_kind and output_kind != 'text':
+                    if output_kind == 'text':
+                        content = (
+                            e.get('content')
+                            or (e.get('data') or {}).get('content')
+                            or (e.get('data') or {}).get('text')
+                            or ''
+                        )
+                        if isinstance(content, str) and content:
+                            text_chunks.append(content)
+                    elif output_kind:
                         placeholders.append(f'[交互组件：{output_kind}]')
 
+            body = msg if msg.strip() else '\n\n'.join(text_chunks)
             if placeholders:
-                msg = (msg or '').rstrip() + '\n\n' + '\n\n'.join(placeholders)
-            return msg
+                body = (body or '').rstrip() + '\n\n' + '\n\n'.join(placeholders)
+            return body
 
         # agent_tool_call / agent_thinking / unknown -> drop
         return ''

--- a/src/backend/test/workstation/test_conversation_export_service.py
+++ b/src/backend/test/workstation/test_conversation_export_service.py
@@ -391,3 +391,115 @@ def test_build_turns_query_without_answer():
     assert turns[0].answers == []
     # Sender name falls back to flow_name when no answer
     assert turns[0].sender_name == 'Workstation'
+
+
+# Issue: real workstation/workflow data wraps the user query in JSON envelopes
+# rather than storing plain text. The renderer must unwrap before passing to
+# Markdown, otherwise the export shows ``{"query": "..."}`` literally.
+
+def test_build_turns_unwraps_daily_mode_query_envelope():
+    """日常模式：``{"query": "...", "files": []}`` → 渲染为 query 字段内容。"""
+    session = _make_session(flow_type=FlowType.WORKSTATION.value)
+    msgs = [
+        _make_chat_message(
+            1, 'question',
+            json.dumps({'query': '今天天气', 'files': []}, ensure_ascii=False),
+        ),
+        _make_chat_message(2, 'answer', '北京晴', sender='M'),
+    ]
+    turns = ConversationExportService._build_turns(msgs, session, user_name='Admin')
+    assert turns[0].user_query == '今天天气'
+
+
+def test_build_turns_unwraps_workflow_input_envelope():
+    """工作流：``{"data": {...}, "input": "..."}`` → 渲染为 input 字段内容。"""
+    session = _make_session(flow_type=FlowType.WORKFLOW.value, flow_name='搬家助手')
+    msgs = [
+        _make_chat_message(
+            1, 'question',
+            json.dumps(
+                {'data': {'chatId': 'fc569', 'id': '265f9', 'type': 5},
+                 'input': '引导问题1：如何根据物品数量和类型制定详细的搬家计划？'},
+                ensure_ascii=False,
+            ),
+        ),
+        _make_chat_message(2, 'answer', '答复', sender='M'),
+    ]
+    turns = ConversationExportService._build_turns(msgs, session, user_name='Admin')
+    assert turns[0].user_query == '引导问题1：如何根据物品数量和类型制定详细的搬家计划？'
+
+
+def test_build_turns_unwraps_query_then_strips_citations():
+    """JSON 拆出来的 query 文本仍要走角标剥除（边界场景：user 问的内容也可能含角标，少见但理论上可能）。"""
+    session = _make_session()
+    payload = json.dumps(
+        {'query': '问' + 'x' + '题', 'files': []},
+        ensure_ascii=False,
+    )
+    msgs = [
+        _make_chat_message(1, 'question', payload),
+        _make_chat_message(2, 'answer', '答', sender='M'),
+    ]
+    turns = ConversationExportService._build_turns(msgs, session, user_name='Admin')
+    assert turns[0].user_query == '问题'
+
+
+# Issue: agent_answer with empty ``msg`` but text content sitting in
+# ``events`` (v2.5 agent-native format per chat_helpers.py:218-273). Previously
+# such answers exported as empty turns.
+
+def test_build_turns_agent_answer_falls_back_to_events_text():
+    """``msg`` 为空时, 末尾 ``events`` 中的 text 块作为答复内容。"""
+    session = _make_session(flow_type=FlowType.ASSISTANT.value, flow_name='Bot')
+    payload = json.dumps({
+        'msg': '',
+        'events': [
+            {'type': 'thinking', 'content': '思考...'},
+            {'type': 'text', 'content': '最终答复正文'},
+        ],
+    }, ensure_ascii=False)
+    msgs = [
+        _make_chat_message(1, 'question', 'q'),
+        _make_chat_message(2, 'agent_answer', payload, parent_msg_id=1),
+    ]
+    turns = ConversationExportService._build_turns(msgs, session, user_name='Admin')
+    assert turns[0].answers == ['最终答复正文']
+
+
+def test_build_turns_agent_answer_workflow_text_output_captured():
+    """工作流 OUTPUT 节点 ``output_type=text`` 也要被收进答复正文 (不只是占位)。"""
+    session = _make_session(flow_type=FlowType.WORKFLOW.value, flow_name='流')
+    payload = json.dumps({
+        'msg': '',
+        'events': [
+            {'type': 'output', 'output_type': 'text', 'content': '工作流文本输出'},
+            {'type': 'output', 'output_type': 'form'},  # 非 text → 占位
+        ],
+    }, ensure_ascii=False)
+    msgs = [
+        _make_chat_message(1, 'question', 'q'),
+        _make_chat_message(2, 'agent_answer', payload, parent_msg_id=1),
+    ]
+    turns = ConversationExportService._build_turns(msgs, session, user_name='Admin')
+    text = turns[0].answers[0]
+    assert '工作流文本输出' in text
+    assert '[交互组件：form]' in text
+
+
+def test_build_turns_agent_answer_strips_citations_from_events_text():
+    """从 events 拿出来的 text 也要剥角标 (而不只剥 msg 字段)。"""
+    session = _make_session(flow_type=FlowType.ASSISTANT.value, flow_name='Bot')
+    payload = json.dumps({
+        'msg': '',
+        'events': [
+            {'type': 'text', 'content': '答 ' + 'knowledgesearch_28624655:4' + ' 完'},
+        ],
+    }, ensure_ascii=False)
+    msgs = [
+        _make_chat_message(1, 'question', 'q'),
+        _make_chat_message(2, 'agent_answer', payload, parent_msg_id=1),
+    ]
+    turns = ConversationExportService._build_turns(msgs, session, user_name='Admin')
+    assert '' not in turns[0].answers[0]
+    assert 'knowledgesearch' not in turns[0].answers[0]
+    assert turns[0].answers[0] == '答  完'


### PR DESCRIPTION
…m events[]

Two issues surfaced in real-data testing on the test machine:

1. User queries were exported as raw JSON envelopes instead of plain text. The workstation chat stores ``question`` rows with shape ``{"query": "<text>", "files": []}`` (daily mode) or ``{"data": {...}, "input": "<text>"}`` (workflow / app-chat). The exporter was treating ``message`` as plain text and rendering the JSON verbatim into the Markdown / docx / pdf output.

   Added ``_extract_query_text(m)`` that unwraps either envelope shape, falls back to raw text for legacy / unknown payloads, and routes the result through the existing citation stripper.

2. Some ``agent_answer`` rows have an empty ``msg`` field with the actual answer text living in ``events[*].content`` (type=text) — the v2.5 agent-native format documented in chat_helpers.py. Workflow OUTPUT nodes with ``output_type=text`` were similarly dropped because the old code only recognized non-text outputs as placeholder candidates. Citation markers leaking through the export came from this path: the recovered events text was never passed through the stripper.

   Reworked ``_extract_answer_text``:
   - prefer ``msg`` when present;
   - otherwise concatenate event ``text`` blocks and ``output`` blocks with ``output_type=text`` (covering both LLM events and workflow text-output nodes);
   - keep the ``[交互组件:<kind>]`` placeholder for non-text outputs.

   The whole answer body (whatever its source) is then run through
   ``_strip_citations`` exactly like before.

Test coverage: +6 unit tests (envelope unwrap × 3, events-text fallback, workflow text-output capture, citation strip on events-derived text). Backend suite now 85/85 green.