### PR TITLE
feat(tools): add DataForB2B preset API tools

### DIFF
--- a/src/backend/bisheng/database/data/t_gpts_tools.json
+++ b/src/backend/bisheng/database/data/t_gpts_tools.json
@@ -1114,5 +1114,284 @@
     "is_delete": 0,
     "user_id": 1,
     "id": 38
+  },
+  {
+    "name": "Search People",
+    "logo": null,
+    "desc": "Search LinkedIn people / B2B leads by structured filters (job title, company, location, industry, seniority, skills). Find decision-makers and build a prospect list.",
+    "tool_key": "dataforb2b_search_people",
+    "type": 17,
+    "is_preset": 1,
+    "is_delete": 0,
+    "user_id": null,
+    "create_time": "2026-06-19 00:00:00",
+    "update_time": "2026-06-19 00:00:00",
+    "id": 39,
+    "api_params": [
+      {
+        "name": "filters",
+        "description": "JSON filter object {op, conditions:[{column,type,value,value2?}]} or a bare list of conditions",
+        "in": "query",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "count",
+        "description": "Number of results (1-100)",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "offset",
+        "description": "Pagination offset: 0, then 25, 50, …",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ]
+  },
+  {
+    "name": "Search Company",
+    "logo": null,
+    "desc": "Search LinkedIn companies / accounts by structured filters (industry, headcount, location, funding, keywords). Build target-account lists for B2B sales.",
+    "tool_key": "dataforb2b_search_company",
+    "type": 17,
+    "is_preset": 1,
+    "is_delete": 0,
+    "user_id": null,
+    "create_time": "2026-06-19 00:00:00",
+    "update_time": "2026-06-19 00:00:00",
+    "id": 40,
+    "api_params": [
+      {
+        "name": "filters",
+        "description": "JSON filter object {op, conditions:[{column,type,value,value2?}]} or a bare list of conditions",
+        "in": "query",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "count",
+        "description": "Number of results (1-100)",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "offset",
+        "description": "Pagination offset: 0, then 25, 50, …",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ]
+  },
+  {
+    "name": "Reasoning Search",
+    "logo": null,
+    "desc": "Natural-language people/company search — describe the audience in plain text and DataForB2B builds the filters. May ask clarifying questions (free).",
+    "tool_key": "dataforb2b_reasoning_search",
+    "type": 17,
+    "is_preset": 1,
+    "is_delete": 0,
+    "user_id": null,
+    "create_time": "2026-06-19 00:00:00",
+    "update_time": "2026-06-19 00:00:00",
+    "id": 41,
+    "api_params": [
+      {
+        "name": "query",
+        "description": "Natural-language search, e.g. 'CTOs at Series A fintech startups in France'",
+        "in": "query",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "category",
+        "description": "'people' or 'companies'",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "max_results",
+        "description": "Number of results (1-100)",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "session_id",
+        "description": "session_id from a previous needs_input/refine turn",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "answers",
+        "description": "JSON object {question_id: answer} answering a needs_input turn",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ]
+  },
+  {
+    "name": "Enrich Profile",
+    "logo": null,
+    "desc": "Enrich a professional profile from a LinkedIn URL — full profile (role, experience, skills) plus work email, personal email, phone and GitHub. Email finder for outreach.",
+    "tool_key": "dataforb2b_enrich_profile",
+    "type": 17,
+    "is_preset": 1,
+    "is_delete": 0,
+    "user_id": null,
+    "create_time": "2026-06-19 00:00:00",
+    "update_time": "2026-06-19 00:00:00",
+    "id": 42,
+    "api_params": [
+      {
+        "name": "profile_identifier",
+        "description": "LinkedIn profile URL, public id (john-doe), or encoded prof_… id",
+        "in": "query",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "enrich_profile",
+        "description": "Return the full profile (role, experience, skills)",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "boolean"
+        }
+      },
+      {
+        "name": "enrich_work_email",
+        "description": "Find the work email",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "boolean"
+        }
+      },
+      {
+        "name": "enrich_personal_email",
+        "description": "Find the personal email",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "boolean"
+        }
+      },
+      {
+        "name": "enrich_phone",
+        "description": "Find the phone number",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "boolean"
+        }
+      },
+      {
+        "name": "enrich_github",
+        "description": "Find the GitHub profile",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "boolean"
+        }
+      }
+    ]
+  },
+  {
+    "name": "Enrich Company",
+    "logo": null,
+    "desc": "Enrich a company from its domain, name or LinkedIn company URL — firmographics, headcount/size, industry, domain and social profiles.",
+    "tool_key": "dataforb2b_enrich_company",
+    "type": 17,
+    "is_preset": 1,
+    "is_delete": 0,
+    "user_id": null,
+    "create_time": "2026-06-19 00:00:00",
+    "update_time": "2026-06-19 00:00:00",
+    "id": 43,
+    "api_params": [
+      {
+        "name": "company_identifier",
+        "description": "Company domain, name/slug, LinkedIn company URL, or org_… id",
+        "in": "query",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ]
+  },
+  {
+    "name": "Typeahead",
+    "logo": null,
+    "desc": "Resolve the exact stored value for a free-text filter before searching (company, industry, category, location, city, region, school, title, skill, investor).",
+    "tool_key": "dataforb2b_typeahead",
+    "type": 17,
+    "is_preset": 1,
+    "is_delete": 0,
+    "user_id": null,
+    "create_time": "2026-06-19 00:00:00",
+    "update_time": "2026-06-19 00:00:00",
+    "id": 44,
+    "api_params": [
+      {
+        "name": "type",
+        "description": "company, people_industry, company_industry, category, location, city, region, school, title, skill, investor",
+        "in": "query",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "q",
+        "description": "Prefix/text to autocomplete (1-100 chars)",
+        "in": "query",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "limit",
+        "description": "Max suggestions (1-20)",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ]
   }
 ]

--- a/src/backend/bisheng/database/data/t_gpts_tools_type.json
+++ b/src/backend/bisheng/database/data/t_gpts_tools_type.json
@@ -244,5 +244,21 @@
     "user_id": null,
     "is_delete": 0,
     "openapi_schema": null
+  },
+  {
+    "id": 17,
+    "name": "DataForB2B",
+    "logo": "https://api.dataforb2b.ai/DataForB2B_logo.png",
+    "description": "Find and enrich LinkedIn people and companies: search B2B leads and accounts by filters or natural language, and enrich profiles/companies with work email, personal email, phone and firmographics.",
+    "server_host": "https://api.dataforb2b.ai",
+    "auth_method": 0,
+    "api_key": "",
+    "auth_type": "basic",
+    "is_preset": 1,
+    "user_id": null,
+    "is_delete": 0,
+    "create_time": "2026-06-19 00:00:00",
+    "update_time": "2026-06-19 00:00:00",
+    "openapi_schema": null
   }
 ]

--- a/src/backend/bisheng_langchain/gpts/tools/api_tools/__init__.py
+++ b/src/backend/bisheng_langchain/gpts/tools/api_tools/__init__.py
@@ -11,6 +11,7 @@ from bisheng_langchain.gpts.tools.message.wechat import WechatMessageTool
 from langchain_core.tools import BaseTool
 from mypy_extensions import KwArg
 
+from .dataforb2b import DataForB2B
 from .flow import FlowTools
 from .macro_data import MacroData
 from .sina import StockInfo
@@ -112,6 +113,15 @@ _WECHAT_TOOLS: Dict[str, Tuple[Callable[[KwArg(Any)], BaseTool], List[str]]] = {
     'wechat_send_message': (WechatMessageTool.get_api_tool, [])
 }
 
+_DATAFORB2B_TOOLS: Dict[str, Tuple[Callable[[KwArg(Any)], BaseTool], List[str]]] = {
+    'dataforb2b_search_people': (DataForB2B.get_api_tool, ['api_key']),
+    'dataforb2b_search_company': (DataForB2B.get_api_tool, ['api_key']),
+    'dataforb2b_reasoning_search': (DataForB2B.get_api_tool, ['api_key']),
+    'dataforb2b_enrich_profile': (DataForB2B.get_api_tool, ['api_key']),
+    'dataforb2b_enrich_company': (DataForB2B.get_api_tool, ['api_key']),
+    'dataforb2b_typeahead': (DataForB2B.get_api_tool, ['api_key']),
+}
+
 ALL_API_TOOLS = {}
 ALL_API_TOOLS.update(_TIAN_YAN_CHA_TOOLS)
 ALL_API_TOOLS.update(_SINA_TOOLS)
@@ -124,3 +134,4 @@ ALL_API_TOOLS.update(_DING_TOOLS)
 ALL_API_TOOLS.update(_EMAIL_TOOLS)
 ALL_API_TOOLS.update(_FEISHU_TOOLS)
 ALL_API_TOOLS.update(_WECHAT_TOOLS)
+ALL_API_TOOLS.update(_DATAFORB2B_TOOLS)

--- a/src/backend/bisheng_langchain/gpts/tools/api_tools/dataforb2b.py
+++ b/src/backend/bisheng_langchain/gpts/tools/api_tools/dataforb2b.py
@@ -1,0 +1,250 @@
+"""DataForB2B api
+
+B2B data tools for finding and enriching LinkedIn people / companies:
+search people & companies by structured filters, natural-language reasoning
+search, profile & company enrichment (work/personal email, phone, GitHub),
+and a typeahead helper that resolves the exact stored value for a filter.
+
+Drop this file in:
+    src/backend/bisheng_langchain/gpts/tools/api_tools/dataforb2b.py
+and register the tools in the api_tools ``__init__.py`` (see _DATAFORB2B_TOOLS).
+"""
+import json
+from typing import Any, Optional
+
+import requests
+from pydantic import BaseModel, Field
+
+from bisheng_langchain.gpts.tools.api_tools.base import MultArgsSchemaTool
+
+BASE_URL = "https://api.dataforb2b.ai"
+REQUEST_TIMEOUT = 120
+MAX_RESPONSE_CHARS = 30000
+
+
+# --- args schemas ---------------------------------------------------------
+
+class SearchPeopleArgs(BaseModel):
+    """args_schema for dataforb2b_search_people"""
+    filters: str = Field(
+        description=(
+            "JSON filter object: {\"op\": \"and\", \"conditions\": "
+            "[{\"column\", \"type\", \"value\", \"value2?\"}]}. A bare JSON list "
+            "of conditions is also accepted. Operators (type): =, !=, like, "
+            "not_like, in, not_in, >, >=, <, <=, between. Common people columns: "
+            "first_name, last_name, current_title, current_company, "
+            "current_company_industry, current_company_size (2-10,11-50,51-200,"
+            "201-500,501-1000,1001-5000,5001-10000,10001+), profile_location, "
+            "profile_country (ISO-2 UPPER, use GB not UK), skill, school, "
+            "years_of_experience, keyword. Resolve free-text values with "
+            "dataforb2b_typeahead first when unsure."
+        )
+    )
+    count: int = Field(default=25, description="Number of results (1-100)")
+    offset: int = Field(default=0, description="Pagination offset: 0, then 25, 50, …")
+
+
+class SearchCompanyArgs(BaseModel):
+    """args_schema for dataforb2b_search_company"""
+    filters: str = Field(
+        description=(
+            "JSON filter object: {\"op\": \"and\", \"conditions\": "
+            "[{\"column\", \"type\", \"value\", \"value2?\"}]}. A bare JSON list "
+            "is also accepted. Operators: =, !=, like, not_like, in, not_in, >, "
+            ">=, <, <=, between. Common company columns: name, domain, industry "
+            "(lowercase e.g. 'software development'), employee_count (1-10,11-50,"
+            "51-200,201-500,501-1000,1001-5000,5001-10000,10001+), "
+            "country_iso_code (ISO-2), city, region, founded_year, "
+            "funding_stage_normalized, has_funding, keyword."
+        )
+    )
+    count: int = Field(default=25, description="Number of results (1-100)")
+    offset: int = Field(default=0, description="Pagination offset: 0, then 25, 50, …")
+
+
+class ReasoningSearchArgs(BaseModel):
+    """args_schema for dataforb2b_reasoning_search"""
+    query: str = Field(
+        description="Natural-language search, e.g. 'CTOs at Series A fintech startups in France'"
+    )
+    category: str = Field(
+        default="people", description="What to search: 'people' or 'companies'"
+    )
+    max_results: int = Field(default=25, description="Number of results (1-100)")
+    session_id: Optional[str] = Field(
+        default=None,
+        description="Pass the session_id from a previous needs_input/refine turn",
+    )
+    answers: Optional[str] = Field(
+        default=None,
+        description="JSON object {question_id: answer} answering a needs_input turn",
+    )
+
+
+class EnrichProfileArgs(BaseModel):
+    """args_schema for dataforb2b_enrich_profile"""
+    profile_identifier: str = Field(
+        description="LinkedIn profile URL, public id (john-doe), or encoded prof_… id"
+    )
+    enrich_profile: bool = Field(
+        default=True, description="Return the full profile (role, experience, skills)"
+    )
+    enrich_work_email: bool = Field(default=False, description="Find the work email")
+    enrich_personal_email: bool = Field(
+        default=False, description="Find the personal email"
+    )
+    enrich_phone: bool = Field(default=False, description="Find the phone number")
+    enrich_github: bool = Field(default=False, description="Find the GitHub profile")
+
+
+class EnrichCompanyArgs(BaseModel):
+    """args_schema for dataforb2b_enrich_company"""
+    company_identifier: str = Field(
+        description="Company domain, name/slug, LinkedIn company URL, or org_… id"
+    )
+
+
+class TypeaheadArgs(BaseModel):
+    """args_schema for dataforb2b_typeahead"""
+    type: str = Field(
+        description=(
+            "One of: company, people_industry, company_industry, category, "
+            "location, city, region, school, title, skill, investor"
+        )
+    )
+    q: str = Field(description="Prefix/text to autocomplete (1-100 chars)")
+    limit: int = Field(default=20, description="Max suggestions (1-20)")
+
+
+_ARGS_SCHEMAS = {
+    "search_people": SearchPeopleArgs,
+    "search_company": SearchCompanyArgs,
+    "reasoning_search": ReasoningSearchArgs,
+    "enrich_profile": EnrichProfileArgs,
+    "enrich_company": EnrichCompanyArgs,
+    "typeahead": TypeaheadArgs,
+}
+
+
+class DataForB2B(BaseModel):
+    """DataForB2B B2B data client (https://api.dataforb2b.ai)."""
+
+    api_key: str = Field(description="DataForB2B API key")
+
+    # --- http helpers -----------------------------------------------------
+
+    def _headers(self) -> dict:
+        return {"api_key": self.api_key, "Content-Type": "application/json"}
+
+    def _post(self, path: str, payload: dict) -> str:
+        resp = requests.post(
+            f"{BASE_URL}{path}",
+            json=payload,
+            headers=self._headers(),
+            timeout=REQUEST_TIMEOUT,
+        )
+        return self._handle(resp)
+
+    def _get(self, path: str, params: dict) -> str:
+        resp = requests.get(
+            f"{BASE_URL}{path}",
+            params=params,
+            headers=self._headers(),
+            timeout=REQUEST_TIMEOUT,
+        )
+        return self._handle(resp)
+
+    @staticmethod
+    def _handle(resp: requests.Response) -> str:
+        if resp.status_code == 401:
+            return "DataForB2B error: invalid or missing API key (401)."
+        if resp.status_code == 403:
+            return "DataForB2B error: API key lacks permission for this resource (403)."
+        if resp.status_code >= 400:
+            return f"DataForB2B error ({resp.status_code}): {resp.text[:2000]}"
+        return resp.text[:MAX_RESPONSE_CHARS]
+
+    @staticmethod
+    def _filters(raw: str) -> dict:
+        try:
+            value = json.loads(raw) if isinstance(raw, str) else raw
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON in 'filters': {e}")
+        if isinstance(value, list):
+            return {"op": "and", "conditions": value}
+        if isinstance(value, dict) and "conditions" not in value and "op" not in value:
+            # a single bare condition dict
+            return {"op": "and", "conditions": [value]}
+        return value
+
+    # --- tools ------------------------------------------------------------
+
+    def search_people(self, filters: str, count: int = 25, offset: int = 0) -> str:
+        """Search LinkedIn people / B2B leads by structured filters (job title, company, location, industry, seniority, skills). Use it to find employees at a company, decision-makers (founders, C-suite, VPs, directors), and build a prospect list. Resolve free-text filter values with dataforb2b_typeahead first."""
+        return self._post(
+            "/search/people",
+            {"filters": self._filters(filters), "count": count, "offset": offset,
+             "enrich_live": False},
+        )
+
+    def search_company(self, filters: str, count: int = 25, offset: int = 0) -> str:
+        """Search LinkedIn companies / accounts by structured filters (industry, headcount, location, funding, keywords). Build target-account lists for B2B sales and account-based marketing."""
+        return self._post(
+            "/search/companies",
+            {"filters": self._filters(filters), "count": count, "offset": offset,
+             "enrich_live": False},
+        )
+
+    def reasoning_search(self, query: str, category: str = "people",
+                         max_results: int = 25, session_id: Optional[str] = None,
+                         answers: Optional[str] = None) -> str:
+        """Natural-language people/company search over the DataForB2B LinkedIn database — describe the audience in plain text (e.g. 'CTOs at Series A fintech startups in France') and the agent builds the filters. May return status 'needs_input' with clarifying questions (free); answer them by re-calling with the returned session_id and an answers JSON."""
+        payload: dict = {"query": query, "category": category,
+                         "max_results": max_results, "enrich_live": False}
+        if session_id:
+            payload["session_id"] = session_id
+        if answers:
+            try:
+                payload["answers"] = json.loads(answers) if isinstance(answers, str) else answers
+            except json.JSONDecodeError as e:
+                raise ValueError(f"Invalid JSON in 'answers': {e}")
+        return self._post("/search/reasoning", payload)
+
+    def enrich_profile(self, profile_identifier: str, enrich_profile: bool = True,
+                       enrich_work_email: bool = False,
+                       enrich_personal_email: bool = False,
+                       enrich_phone: bool = False,
+                       enrich_github: bool = False) -> str:
+        """Enrich a professional profile from a LinkedIn URL — returns the full profile (current role, experience, skills) plus work email, personal email, phone and GitHub. Works as an email finder for lead enrichment and cold outreach. Charged only for the flags you enable; at least one must be true."""
+        flags = {
+            "enrich_profile": enrich_profile,
+            "enrich_work_email": enrich_work_email,
+            "enrich_personal_email": enrich_personal_email,
+            "enrich_phone": enrich_phone,
+            "enrich_github": enrich_github,
+        }
+        if not any(flags.values()):
+            flags["enrich_profile"] = True
+        return self._post("/enrich/profile", {"profile_identifier": profile_identifier, **flags})
+
+    def enrich_company(self, company_identifier: str) -> str:
+        """Enrich a company from its domain, name or LinkedIn company URL — firmographics, headcount/size, industry, domain and social profiles. Account enrichment for B2B sales and CRM."""
+        return self._post("/enrich/company", {"company_identifier": company_identifier})
+
+    def typeahead(self, type: str, q: str, limit: int = 20) -> str:
+        """Resolve the exact stored value for a free-text filter before searching (results ordered by popularity). type is one of: company, people_industry, company_industry, category, location, city, region, school, title, skill, investor. Use it when unsure which value to filter on, or when a search returns few/no results."""
+        return self._get("/typeahead", {"type": type, "q": q, "limit": limit})
+
+    # --- registration -----------------------------------------------------
+
+    @classmethod
+    def get_api_tool(cls, name: str, **kwargs: Any) -> "BaseTool":
+        attr_name = name.split("_", 1)[-1]  # dataforb2b_search_people -> search_people
+        instance = cls(**kwargs)
+        class_method = getattr(instance, attr_name)
+        return MultArgsSchemaTool(
+            name=name,
+            description=class_method.__doc__,
+            func=class_method,
+            args_schema=_ARGS_SCHEMAS[attr_name],
+        )


### PR DESCRIPTION
## What

Adds **DataForB2B** ([dataforb2b.ai](https://dataforb2b.ai)) as a preset tool provider — B2B data tools to **search and enrich LinkedIn people and companies**. It follows the existing `tianyancha` / `firecrawl` `api_tools` pattern.

## Tools (6)

| tool_key | endpoint | does |
|---|---|---|
| `dataforb2b_search_people` | `POST /search/people` | find people / B2B leads by structured filters |
| `dataforb2b_search_company` | `POST /search/companies` | find companies / accounts by filters |
| `dataforb2b_reasoning_search` | `POST /search/reasoning` | natural-language people/company search |
| `dataforb2b_enrich_profile` | `POST /enrich/profile` | enrich a profile → work/personal email, phone, GitHub |
| `dataforb2b_enrich_company` | `POST /enrich/company` | enrich a company → firmographics |
| `dataforb2b_typeahead` | `GET /typeahead` | resolve the exact stored value for a free-text filter |

Single `api_key` credential (sent as the `api_key` header). Base URL `https://api.dataforb2b.ai`.

## Changes

- `bisheng_langchain/gpts/tools/api_tools/dataforb2b.py` — new `DataForB2B` class (POST-JSON, `firecrawl`-style).
- `bisheng_langchain/gpts/tools/api_tools/__init__.py` — import + `_DATAFORB2B_TOOLS` registered in `ALL_API_TOOLS`.
- `bisheng/database/data/t_gpts_tools_type.json` — provider card (id 17).
- `bisheng/database/data/t_gpts_tools.json` — 6 preset tools (ids 39-44).

## Notes

- `enrich_live` is hard-wired to `false` (no surprise live-credit spend).
- Responses are truncated to 30k chars to stay within agent context.
- Seed ids (type 17, tools 39-44) are the next free ids on `main` — happy to rebase/bump if they collide before merge.