### PR TITLE
fix(client): 知识空间网页预览 MinIO URL 改写

### DIFF
--- a/src/frontend/client/src/pages/knowledge/FilePreview/FilePreviewPage.tsx
+++ b/src/frontend/client/src/pages/knowledge/FilePreview/FilePreviewPage.tsx
@@ -16,6 +16,7 @@ import { PermissionDialog } from "~/components/permission";
 import { FileAiDock } from "~/pages/Subscription/AiChat/FileAiDock";
 import FilePreview from "./index";
 import { RichKnowledgePreview } from "./RichKnowledgePreview";
+import { resolveKnowledgePreviewUrl } from "./previewUrlUtils";
 import { useLocalize } from "~/hooks";
 
 /**
@@ -35,13 +36,6 @@ function extractExtFromUrl(url: string, fallback: string): string {
         // Parsing failed, use fallback
     }
     return fallback;
-}
-
-function resolvePreviewUrl(url: string): string {
-    if (!url) return "";
-    return /^https?:\/\//.test(url)
-        ? url
-        : `${window.location.origin}${__APP_ENV__.BASE_URL}${url}`;
 }
 
 const AUDIO_EXTENSIONS = new Set(["mp3", "wav", "m4a", "aac", "flac", "ogg"]);
@@ -87,9 +81,9 @@ export default function FilePreviewPage() {
             .then((data) => {
                 const resolvedPreview = {
                     ...data,
-                    original_url: resolvePreviewUrl(data.original_url),
-                    preview_url: resolvePreviewUrl(data.preview_url),
-                    html_preview_url: resolvePreviewUrl(data.html_preview_url),
+                    original_url: resolveKnowledgePreviewUrl(data.original_url),
+                    preview_url: resolveKnowledgePreviewUrl(data.preview_url),
+                    html_preview_url: resolveKnowledgePreviewUrl(data.html_preview_url),
                 };
                 setPreviewData(resolvedPreview);
 
@@ -118,7 +112,7 @@ export default function FilePreviewPage() {
                     return;
                 }
 
-                setFileUrl(resolvePreviewUrl(chosenUrl));
+                setFileUrl(resolveKnowledgePreviewUrl(chosenUrl));
                 setFileType(ext);
             })
             .catch((err) => console.error("Failed to load preview URL:", err))

--- a/src/frontend/client/src/pages/knowledge/FilePreview/RichKnowledgePreview.tsx
+++ b/src/frontend/client/src/pages/knowledge/FilePreview/RichKnowledgePreview.tsx
@@ -5,6 +5,7 @@ import rehypeHighlight from "rehype-highlight";
 import remarkGfm from "remark-gfm";
 import type { KnowledgeFilePreview } from "~/api/knowledge";
 import { useLocalize } from "~/hooks";
+import { resolveKnowledgePreviewUrl } from "./previewUrlUtils";
 import { TopBar } from "./TopBar";
 
 interface RichKnowledgePreviewProps {
@@ -98,7 +99,7 @@ function MarkdownFromUrl({ fileUrl }: { fileUrl: string }) {
         }
         setLoading(true);
         setError("");
-        fetch(fileUrl)
+        fetch(resolveKnowledgePreviewUrl(fileUrl))
             .then((response) => {
                 if (!response.ok) throw new Error(localize("com_knowledge.failure_status", { 0: response.status }));
                 return response.text();
@@ -152,7 +153,7 @@ function MediaTranscriptTabs({ fileUrl }: { fileUrl: string }) {
         }
         setLoading(true);
         setError("");
-        fetch(fileUrl)
+        fetch(resolveKnowledgePreviewUrl(fileUrl))
             .then((response) => {
                 if (!response.ok) throw new Error(localize("com_knowledge.failure_status", { 0: response.status }));
                 return response.text();
@@ -217,8 +218,11 @@ export function RichKnowledgePreview({
     const localize = useLocalize();
     const isMedia = isMediaPreview(preview);
     const isVideo = isVideoPreview(preview);
-    const mediaTextUrl = preview.preview_url && !isMediaUrl(preview.preview_url) ? preview.preview_url : "";
-    const webLinkMarkdownUrl = preview.preview_url || preview.original_url || "";
+    const mediaTextUrl = preview.preview_url && !isMediaUrl(preview.preview_url)
+        ? resolveKnowledgePreviewUrl(preview.preview_url)
+        : "";
+    const webLinkMarkdownUrl = resolveKnowledgePreviewUrl(preview.preview_url || preview.original_url || "");
+    const mediaPlaybackUrl = resolveKnowledgePreviewUrl(preview.original_url || "");
 
     const title = useMemo(() => {
         if (preview.file_source === "web_link") {
@@ -245,11 +249,11 @@ export function RichKnowledgePreview({
                             {isVideo ? (
                                 <video
                                     className="max-h-[420px] w-full rounded-[6px] bg-black"
-                                    src={preview.original_url}
+                                    src={mediaPlaybackUrl}
                                     controls
                                 />
                             ) : (
-                                <audio className="w-full" src={preview.original_url} controls />
+                                <audio className="w-full" src={mediaPlaybackUrl} controls />
                             )}
                         </section>
                         {mediaTextUrl ? <MediaTranscriptTabs fileUrl={mediaTextUrl} /> : null}

--- a/src/frontend/client/src/pages/knowledge/FilePreview/previewUrlUtils.ts
+++ b/src/frontend/client/src/pages/knowledge/FilePreview/previewUrlUtils.ts
@@ -1,0 +1,12 @@
+/**
+ * Rewrite backend/MinIO absolute URLs to same-origin paths under BASE_URL,
+ * matching Platform RichPreviewFile and Client PreviewFile components.
+ */
+export function resolveKnowledgePreviewUrl(url: string): string {
+    if (!url) return "";
+    if (/^https?:\/\//.test(url)) {
+        return url.replace(/https?:\/\/[^/]+/, __APP_ENV__.BASE_URL);
+    }
+    const normalizedPath = url.startsWith("/") ? url : `/${url}`;
+    return `${window.location.origin}${__APP_ENV__.BASE_URL}${normalizedPath}`;
+}

--- a/src/frontend/client/src/pages/knowledge/FilePreview/viewers/HtmlViewer.tsx
+++ b/src/frontend/client/src/pages/knowledge/FilePreview/viewers/HtmlViewer.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useLocalize } from "~/hooks";
+import { resolveKnowledgePreviewUrl } from "../previewUrlUtils";
 
 interface HtmlViewerProps {
     fileUrl: string;
@@ -16,7 +17,7 @@ export function HtmlViewer({ fileUrl, zoomLevel }: HtmlViewerProps) {
         const fetchHtml = async () => {
             try {
                 setLoading(true);
-                const response = await fetch(fileUrl);
+                const response = await fetch(resolveKnowledgePreviewUrl(fileUrl));
                 if (!response.ok) throw new Error(localize("com_knowledge.failure_status", { 0: response.status }));
                 const text = await response.text();
                 setHtmlContent(text);

--- a/src/frontend/client/src/pages/knowledge/FilePreview/viewers/MarkdownViewer.tsx
+++ b/src/frontend/client/src/pages/knowledge/FilePreview/viewers/MarkdownViewer.tsx
@@ -3,6 +3,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
 import { useLocalize } from "~/hooks";
+import { resolveKnowledgePreviewUrl } from "../previewUrlUtils";
 
 interface MarkdownViewerProps {
     fileUrl: string;
@@ -19,7 +20,7 @@ export function MarkdownViewer({ fileUrl, zoomLevel }: MarkdownViewerProps) {
         const fetchMarkdown = async () => {
             try {
                 setLoading(true);
-                const response = await fetch(fileUrl);
+                const response = await fetch(resolveKnowledgePreviewUrl(fileUrl));
                 if (!response.ok) throw new Error(localize("com_knowledge.failure_status", { 0: response.status }));
                 const text = await response.text();
                 setContent(text);


### PR DESCRIPTION
## Summary

- Fix Client knowledge space file preview stuck on「加载中…」when opening web link imports.
- Rewrite MinIO absolute URLs to same-origin `/workspace` paths before fetch (aligned with Platform `RichPreviewFile`).

## Test plan

- [ ] Open a web link file in Client `/workspace` knowledge space — Markdown renders instead of infinite loading
- [ ] Platform knowledge base preview unchanged
- [ ] Media preview (audio/video) playback still works


Made with [Cursor](https://cursor.com)