### PR TITLE
fix(client): 修复网页链接预览无限加载

### DIFF
--- a/src/frontend/client/src/pages/knowledge/FilePreview/RichKnowledgePreview.tsx
+++ b/src/frontend/client/src/pages/knowledge/FilePreview/RichKnowledgePreview.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
+import i18next from "i18next";
 import ReactMarkdown from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
 import remarkGfm from "remark-gfm";
@@ -101,14 +102,18 @@ function MarkdownFromUrl({ fileUrl }: { fileUrl: string }) {
         setError("");
         fetch(resolveKnowledgePreviewUrl(fileUrl))
             .then((response) => {
-                if (!response.ok) throw new Error(localize("com_knowledge.failure_status", { 0: response.status }));
+                if (!response.ok) {
+                    throw new Error(i18next.t("com_knowledge.failure_status", { 0: response.status }));
+                }
                 return response.text();
             })
             .then((text) => {
                 if (!cancelled) setContent(text);
             })
             .catch((err: Error) => {
-                if (!cancelled) setError(err.message || localize("com_knowledge.load_file_failed"));
+                if (!cancelled) {
+                    setError(err.message || i18next.t("com_knowledge.load_file_failed"));
+                }
             })
             .finally(() => {
                 if (!cancelled) setLoading(false);
@@ -116,7 +121,7 @@ function MarkdownFromUrl({ fileUrl }: { fileUrl: string }) {
         return () => {
             cancelled = true;
         };
-    }, [fileUrl, localize]);
+    }, [fileUrl]);
 
     if (loading) {
         return (


### PR DESCRIPTION
## Summary

- Web link preview stuck on「加载中…」because `MarkdownFromUrl` listed `useLocalize()` in effect deps; that hook returns a new function every render and retriggered fetch indefinitely.
- Media transcript path only depended on `fileUrl`, which is why audio/video worked.

## Test plan

- [ ] Open NeverSSL.html in Client knowledge space — markdown renders
- [ ] Media preview still works


Made with [Cursor](https://cursor.com)