### PR TITLE
feat(knowledge): media upload step-3 preview and file size limits

### DIFF
--- a/src/backend/bisheng/initdb_config.yaml
+++ b/src/backend/bisheng/initdb_config.yaml
@@ -73,7 +73,7 @@ env:
   # 前端上传文件的最大限制，单位MB
   uploaded_files_maximum_size: 50
   # 知识库/知识空间音视频上传最大限制，单位MB（其余文件仍用 uploaded_files_maximum_size）
-  uploaded_media_maximum_size: 1
+  uploaded_media_maximum_size: 1024
   # 工作台「无菜单权限」占位页（/menu-unavailable）展示的纯文案，可在系统配置中修改；不配置则使用前端默认文案
   workbench_menu_unavailable_message: "暂无使用过的应用，可以前往应用广场探索更多应用"
 

--- a/src/backend/bisheng/knowledge/domain/services/knowledge_service.py
+++ b/src/backend/bisheng/knowledge/domain/services/knowledge_service.py
@@ -903,8 +903,13 @@ class KnowledgeService(KnowledgeUtils):
         # Default is the address of the source file
         minio_client = await get_minio_storage()
 
+        from bisheng.knowledge.domain.upload_file_size import MEDIA_FILE_EXTENSIONS
+
         file_share_url = minio_client.clear_minio_share_host(file_path)
-        if file_ext in ["doc", "docx", "wps", "xls", "xlsx", "et", "ppt", "pptx", "dps", "ofd"]:
+        preview_exts = {
+            "doc", "docx", "wps", "xls", "xlsx", "et", "ppt", "pptx", "dps", "ofd",
+        } | MEDIA_FILE_EXTENSIONS
+        if file_ext in preview_exts:
             new_file_name = KnowledgeUtils.get_tmp_preview_file_object_name(filepath)
             if await minio_client.object_exists(minio_client.tmp_bucket, new_file_name):
                 file_share_url = await minio_client.get_share_link(new_file_name, minio_client.tmp_bucket)

--- a/src/backend/bisheng/knowledge/domain/services/knowledge_utils.py
+++ b/src/backend/bisheng/knowledge/domain/services/knowledge_utils.py
@@ -9,6 +9,7 @@ from bisheng.common.constants.enums.telemetry import ApplicationTypeEnum
 from bisheng.common.services.base import BaseService
 from bisheng.core.cache.redis_manager import get_redis_client, get_redis_client_sync
 from bisheng.knowledge.domain.models.knowledge_space_file import SpaceFileDao
+from bisheng.knowledge.domain.upload_file_size import MEDIA_FILE_EXTENSIONS
 from bisheng.llm.domain import LLMService
 from bisheng.llm.domain.schemas import KnowledgeLLMConfig
 from bisheng.utils import md5_hash
@@ -212,7 +213,8 @@ class KnowledgeUtils(BaseService):
             return f"preview/{file_name_no_ext}.xlsx"
         elif file_ext in ["ppt", "pptx", "dps", "ofd"]:
             return f"preview/{file_name_no_ext}.pdf"
-        # No preview required for other file types
+        if file_ext in MEDIA_FILE_EXTENSIONS:
+            return f"preview/{file_name_no_ext}_transcript.md"
         return None
 
     @classmethod

--- a/src/backend/bisheng/knowledge/domain/upload_file_size.py
+++ b/src/backend/bisheng/knowledge/domain/upload_file_size.py
@@ -4,7 +4,7 @@ from bisheng.common.errcode.knowledge_space import SpaceFileSizeLimitError
 from bisheng.common.services.config_service import settings
 
 DEFAULT_UPLOADED_FILES_MAXIMUM_SIZE_MB = 50
-DEFAULT_UPLOADED_MEDIA_MAXIMUM_SIZE_MB = 1
+DEFAULT_UPLOADED_MEDIA_MAXIMUM_SIZE_MB = 1024
 
 _AUDIO_FILE_EXTENSIONS = frozenset({'mp3', 'wav', 'm4a', 'aac', 'flac', 'ogg'})
 _VIDEO_FILE_EXTENSIONS = frozenset({'mp4', 'mov', 'avi', 'mkv', 'webm'})

--- a/src/backend/test/knowledge/test_upload_file_size.py
+++ b/src/backend/test/knowledge/test_upload_file_size.py
@@ -4,21 +4,22 @@ import pytest
 
 from bisheng.common.errcode.knowledge_space import SpaceFileSizeLimitError
 from bisheng.knowledge.domain import upload_file_size as module
+from bisheng.knowledge.domain.services.knowledge_utils import KnowledgeUtils
 
 
 class TestKnowledgeUploadFileSize:
     def test_media_extension_uses_media_limit(self):
         with patch.object(module.settings, 'get_from_db', return_value={
             'uploaded_files_maximum_size': 50,
-            'uploaded_media_maximum_size': 1,
+            'uploaded_media_maximum_size': 1024,
         }):
-            assert module.get_max_upload_bytes('clip.mp4') == 1 * 1024 * 1024
+            assert module.get_max_upload_bytes('clip.mp4') == 1024 * 1024 * 1024
             assert module.get_max_upload_bytes('note.pdf') == 50 * 1024 * 1024
 
     def test_validate_rejects_oversized_document(self):
         with patch.object(module.settings, 'get_from_db', return_value={
             'uploaded_files_maximum_size': 50,
-            'uploaded_media_maximum_size': 1,
+            'uploaded_media_maximum_size': 1024,
         }):
             with pytest.raises(SpaceFileSizeLimitError):
                 module.validate_knowledge_upload_file_size('note.pdf', 51 * 1024 * 1024)
@@ -26,14 +27,17 @@ class TestKnowledgeUploadFileSize:
     def test_validate_allows_media_up_to_media_limit(self):
         with patch.object(module.settings, 'get_from_db', return_value={
             'uploaded_files_maximum_size': 50,
-            'uploaded_media_maximum_size': 1,
+            'uploaded_media_maximum_size': 1024,
         }):
-            module.validate_knowledge_upload_file_size('clip.mp4', 1 * 1024 * 1024)
+            module.validate_knowledge_upload_file_size('clip.mp4', 1024 * 1024 * 1024)
 
     def test_validate_rejects_oversized_media(self):
         with patch.object(module.settings, 'get_from_db', return_value={
             'uploaded_files_maximum_size': 50,
-            'uploaded_media_maximum_size': 1,
+            'uploaded_media_maximum_size': 1024,
         }):
             with pytest.raises(SpaceFileSizeLimitError):
-                module.validate_knowledge_upload_file_size('clip.mp4', 1 * 1024 * 1024 + 1)
+                module.validate_knowledge_upload_file_size('clip.mp4', 1024 * 1024 * 1024 + 1)
+
+    def test_media_transcript_preview_object_name(self):
+        assert KnowledgeUtils.get_tmp_preview_file_object_name('/tmp/foo.m4a') == 'preview/foo_transcript.md'

--- a/src/frontend/client/src/pages/knowledge/FilePreview/RichKnowledgePreview.tsx
+++ b/src/frontend/client/src/pages/knowledge/FilePreview/RichKnowledgePreview.tsx
@@ -247,7 +247,7 @@ export function RichKnowledgePreview({
                         actions={actions}
                     />
                 )}
-                <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+                <div className="flex min-h-0 flex-1 flex-col">
                     <div className="shrink-0 overflow-visible px-5 pb-0 pt-5">
                         <section className="mx-auto w-full max-w-[980px] overflow-visible rounded-[8px] border border-[#e5e6eb] bg-white p-4 shadow-sm">
                             <div className="mb-3 text-base font-semibold text-[#1d2129]">{title}</div>
@@ -258,7 +258,7 @@ export function RichKnowledgePreview({
                                     controls
                                 />
                             ) : (
-                                <div className="overflow-visible py-1">
+                                <div className="flex min-h-[160px] flex-col justify-end overflow-visible py-1">
                                     <audio className="w-full" src={mediaPlaybackUrl} controls />
                                 </div>
                             )}

--- a/src/frontend/client/src/pages/knowledge/knowledgeUtils.ts
+++ b/src/frontend/client/src/pages/knowledge/knowledgeUtils.ts
@@ -129,10 +129,10 @@ export function getFileInputAccept(enableEtl4lm: boolean): string {
 }
 
 /** Default maximum single file size in MB (used when env config is not available) */
-export const DEFAULT_MAX_FILE_SIZE_MB = 200;
+export const DEFAULT_MAX_FILE_SIZE_MB = 50;
 
 /** Default maximum media file size in MB when env config is not available */
-export const DEFAULT_MEDIA_MAX_FILE_SIZE_MB = 1;
+export const DEFAULT_MEDIA_MAX_FILE_SIZE_MB = 1024;
 
 export const MEDIA_FILE_EXTENSIONS = [
     "mp3", "wav", "m4a", "aac", "flac", "ogg",

--- a/src/frontend/platform/src/components/bs-comp/knowledgeUploadComponent/DropZone.tsx
+++ b/src/frontend/platform/src/components/bs-comp/knowledgeUploadComponent/DropZone.tsx
@@ -56,7 +56,7 @@ export default function DropZone({ onDrop }) {
         }
     });
 
-    const mediaMaxSize = appConfig.uploadMediaMaxSize ?? 1;
+    const mediaMaxSize = appConfig.uploadMediaMaxSize ?? 1024;
     const formatText = appConfig.enableEtl4lm
         ? t('supportedFormatsWithImages', { maxSize: appConfig.uploadFileMaxSize, mediaMaxSize })
         : t('supportedFormatsWithoutImages', { maxSize: appConfig.uploadFileMaxSize, mediaMaxSize })

--- a/src/frontend/platform/src/components/bs-comp/knowledgeUploadComponent/index.tsx
+++ b/src/frontend/platform/src/components/bs-comp/knowledgeUploadComponent/index.tsx
@@ -14,7 +14,7 @@ const MEDIA_FILE_EXTENSIONS = new Set([
 function getKnowledgeUploadSizeLimitMB(file: File, appConfig: { uploadFileMaxSize?: number; uploadMediaMaxSize?: number }) {
     const ext = file.name.split('.').pop()?.toLowerCase();
     return ext && MEDIA_FILE_EXTENSIONS.has(ext)
-        ? (appConfig.uploadMediaMaxSize ?? 1)
+        ? (appConfig.uploadMediaMaxSize ?? 1024)
         : (appConfig.uploadFileMaxSize ?? 50);
 }
 

--- a/src/frontend/platform/src/contexts/locationContext.tsx
+++ b/src/frontend/platform/src/contexts/locationContext.tsx
@@ -85,8 +85,8 @@ export function LocationProvider({ children }: { children: ReactNode }) {
           chatPrompt: !!res.application_usage_tips,
           noFace: !res.show_github_and_help,
           register: !!res.enable_registration,
-          uploadFileMaxSize: res.uploaded_files_maximum_size || 200,
-          uploadMediaMaxSize: res.uploaded_media_maximum_size ?? 1,
+          uploadFileMaxSize: res.uploaded_files_maximum_size || 50,
+          uploadMediaMaxSize: res.uploaded_media_maximum_size ?? 1024,
           enableEtl4lm: res.enable_etl4lm,
           multiTenantEnabled: !!res.multi_tenant_enabled
         }));

--- a/src/frontend/platform/src/pages/KnowledgePage/components/PreviewResult.tsx
+++ b/src/frontend/platform/src/pages/KnowledgePage/components/PreviewResult.tsx
@@ -14,6 +14,7 @@ import { useParams } from "react-router-dom";
 import useKnowledgeStore from "../useKnowledgeStore";
 import PreviewFile from "./PreviewFile";
 import PreviewParagraph from "./PreviewParagraph";
+import { buildMediaUploadPreviewData, isMediaUploadSuffix, type RichPreviewData } from "./RichPreviewFile";
 
 interface IProps {
   rules: any;
@@ -40,6 +41,7 @@ export default function PreviewResult({
   const [selectId, setSelectId] = useState(''); // 当前选择文件id
   const [syncChunksSelectId, setSelectIdSyncChunks] = useState(''); // 当前选择文件id(与chunk更新保持同步)
   const [etl, setEtl] = useState<string>('')
+  const [mediaPreviewData, setMediaPreviewData] = useState<RichPreviewData | null>(null)
   useEffect(() => {
     const file = rules.fileList[0]
     setSelectId(file.id)
@@ -74,6 +76,7 @@ export default function PreviewResult({
     }, 0);
     setFileViewUrl({ load: true, url: '' });
     setChunks([]);
+    setMediaPreviewData(null);
 
     // 合并配置（与原逻辑一致）
     const { fileList, pageHeaderFooter, chunkOverlap, chunkSize, enableFormula, forceOcr, knowledgeId, retainImages, separator, separatorRule, splitMode, hierarchyLevel, appendTitle, maxChunkSize } = rules;
@@ -135,12 +138,22 @@ export default function PreviewResult({
             })));
             setSelectIdSyncChunks(selectId);
             setFileViewUrl({ load: false, url: data.file_url });
+            if (currentFile?.suffix && isMediaUploadSuffix(currentFile.suffix)) {
+              setMediaPreviewData(buildMediaUploadPreviewData(
+                currentFile.filePath,
+                data.file_url,
+                currentFile.suffix,
+              ));
+            } else {
+              setMediaPreviewData(null);
+            }
             setPartitions(data.partitions);
             setLoading(false);
             break;
           case 'error':
             // 解析错误：处理错误（对应原 error 回调逻辑）
             handlePreviewResult(false);
+            setMediaPreviewData(null);
             setFileViewUrl({ load: false, url: '' });
             setLoading(false);
             // 原错误处理逻辑：支持的文件类型显示原文件预览
@@ -209,6 +222,7 @@ export default function PreviewResult({
       chunks={chunks}
       setChunks={setChunks}
       partitions={partitions}
+      previewData={mediaPreviewData ?? undefined}
     />}
     <div className={cn('relative', "w-full")}>
       {/* 下拉框 - 右上角 */}

--- a/src/frontend/platform/src/pages/KnowledgePage/components/RichPreviewFile.tsx
+++ b/src/frontend/platform/src/pages/KnowledgePage/components/RichPreviewFile.tsx
@@ -23,6 +23,29 @@ type WebTab = "html" | "text";
 const AUDIO_EXTENSIONS = new Set(["mp3", "wav", "m4a", "aac", "flac", "ogg"]);
 const VIDEO_EXTENSIONS = new Set(["mp4", "mov", "avi", "mkv", "webm"]);
 
+export type RichPreviewData = PreviewData;
+
+export function isMediaUploadSuffix(suffix?: string) {
+  if (!suffix) return false;
+  const ext = suffix.toLowerCase();
+  return AUDIO_EXTENSIONS.has(ext) || VIDEO_EXTENSIONS.has(ext);
+}
+
+export function buildMediaUploadPreviewData(
+  originalUrl: string,
+  transcriptUrl: string,
+  suffix: string,
+): PreviewData {
+  const ext = suffix.toLowerCase();
+  const isVideo = VIDEO_EXTENSIONS.has(ext);
+  return {
+    original_url: originalUrl,
+    preview_url: transcriptUrl,
+    file_source: isVideo ? "video_transcript" : "audio_transcript",
+    media_kind: isVideo ? "video" : "audio",
+  };
+}
+
 function normalizeUrl(url?: string) {
   if (!url) return "";
   return url.replace(/https?:\/\/[^/]+/, __APP_ENV__.BASE_URL);

--- a/src/frontend/platform/src/pages/KnowledgePage/components/RichPreviewFile.tsx
+++ b/src/frontend/platform/src/pages/KnowledgePage/components/RichPreviewFile.tsx
@@ -143,14 +143,14 @@ export default function RichPreviewFile({ file, previewData }: { file: any; prev
 
   if (isMedia) {
     return (
-      <div className="flex h-full min-h-0 flex-col overflow-hidden bg-gray-50">
+      <div className="flex h-full min-h-0 flex-col bg-gray-50">
         <div className="shrink-0 overflow-visible p-3 pb-0">
           <section className="overflow-visible rounded-md border bg-white p-3 shadow-sm">
             <div className="mb-2 text-sm font-medium text-gray-800">{title}</div>
             {isVideo ? (
               <video className="max-h-[280px] w-full rounded bg-black" src={mediaUrl} controls />
             ) : (
-              <div className="overflow-visible py-1">
+              <div className="flex min-h-[160px] flex-col justify-end overflow-visible py-1">
                 <audio className="w-full" src={mediaUrl} controls />
               </div>
             )}


### PR DESCRIPTION
## Summary
- Platform upload step 3: left RichPreview (player + transcript) + right segments for audio/video
- Backend: upload media transcript MD to MinIO during preview split
- File size limits: documents 50MB, media 1024MB (backend + Platform UI)

## Test plan
- [ ] Upload audio/video in Platform knowledge library → step 3 shows player + transcript on left, chunks on right
- [ ] Upload page shows 50MB doc / 1024MB media limits
- [ ] Backend rejects doc >50MB and media >1024MB


Made with [Cursor](https://cursor.com)