### PR TITLE
fix(knowledge): normalize media extension case for preview transcript

### DIFF
--- a/src/backend/bisheng/knowledge/domain/services/knowledge_service.py
+++ b/src/backend/bisheng/knowledge/domain/services/knowledge_service.py
@@ -909,7 +909,7 @@ class KnowledgeService(KnowledgeUtils):
         preview_exts = {
             "doc", "docx", "wps", "xls", "xlsx", "et", "ppt", "pptx", "dps", "ofd",
         } | MEDIA_FILE_EXTENSIONS
-        if file_ext in preview_exts:
+        if file_ext.lower() in preview_exts:
             new_file_name = KnowledgeUtils.get_tmp_preview_file_object_name(filepath)
             if await minio_client.object_exists(minio_client.tmp_bucket, new_file_name):
                 file_share_url = await minio_client.get_share_link(new_file_name, minio_client.tmp_bucket)

--- a/src/backend/bisheng/knowledge/domain/services/knowledge_utils.py
+++ b/src/backend/bisheng/knowledge/domain/services/knowledge_utils.py
@@ -207,6 +207,7 @@ class KnowledgeUtils(BaseService):
         """Get a temporary preview file atminioStorage Path for This path is stored in a temporarybucket"""
         file_name = os.path.basename(file_path)
         file_name_no_ext, file_ext = file_name.rsplit(".", 1)
+        file_ext = file_ext.lower()
         if file_ext in ["doc", "docx", "wps"]:
             return f"preview/{file_name_no_ext}.docx"
         elif file_ext in ["xls", "xlsx", "et"]:

--- a/src/backend/test/knowledge/test_upload_file_size.py
+++ b/src/backend/test/knowledge/test_upload_file_size.py
@@ -41,3 +41,6 @@ class TestKnowledgeUploadFileSize:
 
     def test_media_transcript_preview_object_name(self):
         assert KnowledgeUtils.get_tmp_preview_file_object_name('/tmp/foo.m4a') == 'preview/foo_transcript.md'
+
+    def test_media_transcript_preview_object_name_uppercase_ext(self):
+        assert KnowledgeUtils.get_tmp_preview_file_object_name('/tmp/foo.MP3') == 'preview/foo_transcript.md'


### PR DESCRIPTION
## Summary
- Lowercase file extension in `get_tmp_preview_file_object_name` so `.MP3` uploads upload transcript MD to MinIO
- Harden preview URL swap in `get_preview_file_chunk` with lowercase ext check

Fixes step-3 empty 识别文本 when audio files use uppercase extensions.

## Test plan
- [ ] Upload `乔布斯_副本.MP3` → step 3 left panel shows recognized text
- [ ] `.mov` / `.m4a` lowercase still works


Made with [Cursor](https://cursor.com)