### PR TITLE
feat(knowledge): knowledge ASR setting + client add menu polish

### DIFF
--- a/src/backend/bisheng/knowledge/domain/services/media_transcription_service.py
+++ b/src/backend/bisheng/knowledge/domain/services/media_transcription_service.py
@@ -91,11 +91,11 @@ class KnowledgeMediaTranscriptionService:
 
     @classmethod
     def _resolve_asr_model(cls, tenant_id: int | None) -> tuple[LLMModel, LLMServer]:
-        workbench_llm = LLMService.get_workbench_llm_sync(tenant_id=tenant_id)
-        if not workbench_llm.asr_model or not workbench_llm.asr_model.id:
+        knowledge_llm = LLMService.get_knowledge_llm(tenant_id=tenant_id)
+        if not knowledge_llm.asr_model_id:
             raise NoAsrModelConfigError()
 
-        model_info = LLMDao.get_model_by_id(int(workbench_llm.asr_model.id))
+        model_info = LLMDao.get_model_by_id(int(knowledge_llm.asr_model_id))
         if not model_info:
             raise AsrModelConfigDeletedError()
         if model_info.model_type != LLMModelType.ASR.value:

--- a/src/backend/bisheng/llm/domain/schemas.py
+++ b/src/backend/bisheng/llm/domain/schemas.py
@@ -131,6 +131,7 @@ class KnowledgeLLMConfig(BaseModel):
         None, description="Documentation Knowledge Base Extraction Header Model'sID"
     )
     qa_similar_model_id: int | None = Field(None, description="QAThe Knowledge Base Similarity Question Model'sID")
+    asr_model_id: int | None = Field(None, description="Knowledge base media transcription ASR model ID")
     abstract_enabled: bool = Field(default=True, description="Whether to generate file summaries after parsing")
     auto_tag_enabled: bool = Field(default=True, description="Whether to generate file tags after upload parsing")
     abstract_prompt: str | None = Field(None, description="Summary Prompt")

--- a/src/backend/bisheng/llm/domain/services/llm.py
+++ b/src/backend/bisheng/llm/domain/services/llm.py
@@ -910,7 +910,13 @@ class LLMService:
         """Update default model configuration for knowledge base"""
         target = _resolve_tenant_id(tenant_id)
         await avalidate_system_model_refs(
-            [data.embedding_model_id, data.source_model_id, data.extract_title_model_id, data.qa_similar_model_id],
+            [
+                data.embedding_model_id,
+                data.source_model_id,
+                data.extract_title_model_id,
+                data.qa_similar_model_id,
+                data.asr_model_id,
+            ],
             target,
         )
         await cls._base_update_llm_config(

--- a/src/backend/test/knowledge/test_media_transcription_service.py
+++ b/src/backend/test/knowledge/test_media_transcription_service.py
@@ -1,12 +1,17 @@
 import subprocess
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
 from bisheng.common.errcode.knowledge import KnowledgeMediaNoRecognizableAudioError
+from bisheng.common.errcode.server import NoAsrModelConfigError
 from bisheng.knowledge.domain.services.media_transcription_service import (
     KnowledgeMediaTranscriptionService,
     TranscriptSegment,
 )
+from bisheng.llm.domain.const import LLMModelType, LLMServerType
+from bisheng.llm.domain.schemas import KnowledgeLLMConfig
 
 
 def test_normalize_segments_keeps_aliyun_millisecond_timestamps_consistent() -> None:
@@ -111,6 +116,45 @@ def test_convert_to_wav_reports_missing_audio_stream(monkeypatch, tmp_path) -> N
 
     with pytest.raises(KnowledgeMediaNoRecognizableAudioError):
         KnowledgeMediaTranscriptionService._convert_to_wav(str(media_path))
+
+
+def test_resolve_asr_model_reads_knowledge_config(monkeypatch) -> None:
+    model_info = SimpleNamespace(
+        id=42,
+        model_name="paraformer-realtime-v2",
+        model_type=LLMModelType.ASR.value,
+        server_id=7,
+        online=True,
+        config={},
+    )
+    server_info = SimpleNamespace(name="Aliyun", type=LLMServerType.QWEN.value, config={"api_key": "sk-test"})
+
+    monkeypatch.setattr(
+        "bisheng.knowledge.domain.services.media_transcription_service.LLMService.get_knowledge_llm",
+        lambda tenant_id=None: KnowledgeLLMConfig(asr_model_id=42),
+    )
+    monkeypatch.setattr(
+        "bisheng.knowledge.domain.services.media_transcription_service.LLMDao.get_model_by_id",
+        lambda model_id: model_info if model_id == 42 else None,
+    )
+    monkeypatch.setattr(
+        "bisheng.knowledge.domain.services.media_transcription_service.LLMDao.get_server_by_id",
+        lambda server_id: server_info if server_id == 7 else None,
+    )
+
+    resolved_model, resolved_server = KnowledgeMediaTranscriptionService._resolve_asr_model(tenant_id=1)
+
+    assert resolved_model is model_info
+    assert resolved_server is server_info
+
+
+def test_resolve_asr_model_requires_knowledge_config() -> None:
+    with patch(
+        "bisheng.knowledge.domain.services.media_transcription_service.LLMService.get_knowledge_llm",
+        return_value=KnowledgeLLMConfig(asr_model_id=None),
+    ):
+        with pytest.raises(NoAsrModelConfigError):
+            KnowledgeMediaTranscriptionService._resolve_asr_model(tenant_id=1)
 
 
 def test_empty_asr_text_reports_missing_recognizable_audio(monkeypatch, tmp_path) -> None:

--- a/src/backend/test/llm/test_llm_share_fallback.py
+++ b/src/backend/test/llm/test_llm_share_fallback.py
@@ -367,7 +367,7 @@ async def test_update_knowledge_llm_calls_validator_with_all_model_ids():
 
     payload = KnowledgeLLMConfig(
         embedding_model_id=4, source_model_id=7,
-        extract_title_model_id=7, qa_similar_model_id=7,
+        extract_title_model_id=7, qa_similar_model_id=7, asr_model_id=9,
     )
     with patch(
         'bisheng.llm.domain.services.llm.avalidate_system_model_refs',
@@ -380,7 +380,7 @@ async def test_update_knowledge_llm_calls_validator_with_all_model_ids():
 
     args, kwargs = mock_validate.call_args
     passed_ids = list(args[0])
-    assert set(passed_ids) == {4, 7}
+    assert set(passed_ids) == {4, 7, 9}
     assert (kwargs.get('target_tenant_id') if 'target_tenant_id' in kwargs else args[1]) == 1
 
 

--- a/src/frontend/client/src/locales/en/translation.json
+++ b/src/frontend/client/src/locales/en/translation.json
@@ -1830,6 +1830,7 @@
     "update_time": "Update time",
     "upload_feature_dev": "Upload file feature is under development",
     "upload_file": "Upload file",
+    "upload_file_types_tip": "Supports document, image, audio and video files",
     "upload_folder": "Upload folder",
     "uploading_status": "Uploading",
     "users_count": "users",

--- a/src/frontend/client/src/locales/ja/translation.json
+++ b/src/frontend/client/src/locales/ja/translation.json
@@ -1753,6 +1753,7 @@
     "update_time": "更新時間",
     "upload_feature_dev": "ファイルアップロード機能は開発中です",
     "upload_file": "ファイルのアップロード",
+    "upload_file_types_tip": "文書、画像、音声、動画ファイルに対応",
     "upload_folder": "フォルダーをアップロード",
     "uploading_status": "アップロード中",
     "users_count": "ユーザー",

--- a/src/frontend/client/src/locales/zh-Hans/translation.json
+++ b/src/frontend/client/src/locales/zh-Hans/translation.json
@@ -1754,6 +1754,7 @@
     "update_time": "更新时间",
     "upload_feature_dev": "上传文件功能开发中",
     "upload_file": "上传文件",
+    "upload_file_types_tip": "支持上传文档、图片、音频和视频文件",
     "upload_folder": "上传文件夹",
     "uploading_status": "上传中",
     "users_count": "用户",

--- a/src/frontend/client/src/pages/knowledge/SpaceDetail/KnowledgeSpaceHeader.tsx
+++ b/src/frontend/client/src/pages/knowledge/SpaceDetail/KnowledgeSpaceHeader.tsx
@@ -1,4 +1,4 @@
-import { FolderPlus, FolderUp, Link2 } from "lucide-react";
+import { CircleHelp, FolderPlus, FolderUp, Link2 } from "lucide-react";
 import { Outlined } from "bisheng-icons";
 import { KnowledgeSpace, FileStatus, SortType, SortDirection, SpaceRole, VisibilityType } from "~/api/knowledge";
 import { cn } from "~/utils";
@@ -12,7 +12,11 @@ import {
     DropdownMenuCheckboxItem
 } from "~/components/ui/DropdownMenu";
 import { knowledgeSpaceDropdownSurfaceClassName } from "~/components/SidebarListMoreMenu";
-import { ActionMenuContent, ActionMenuItem } from "~/components/ActionMenu";
+import {
+    ActionMenuContent,
+    ActionMenuItem,
+    actionMenuLabelClassName,
+} from "~/components/ActionMenu";
 import { Button } from "~/components/ui/Button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "~/components/ui/Tooltip2";
 import { CopyShareLinkButton } from "~/components/CopyShareLinkButton";
@@ -307,78 +311,73 @@ export function KnowledgeSpaceHeader({
                 </DropdownMenu>
             )}
             {showAddMenu && (
-                canUploadFile ? (
-                    // Split button per design 11495:14337: left half = direct upload, right half = dropdown
-                    // (only "新建文件夹"). When canCreateFolder is false the chevron half is omitted and the
-                    // shell becomes a single-action button.
-                    <div className="inline-flex h-8 shrink-0 items-stretch overflow-hidden rounded-md border border-[#ebebeb] bg-white">
+                <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
                         <button
                             type="button"
                             disabled={isSearching}
-                            onClick={onTriggerUpload}
-                            className={cn(
-                                "inline-flex items-center justify-center px-4 text-sm text-[#212121] transition-colors",
-                                "hover:bg-[#f7f8fa] disabled:cursor-not-allowed disabled:text-[#c9cdd4] disabled:hover:bg-transparent",
-                                "border-r border-[#ebebeb]"
-                            )}
+                            className="inline-flex h-8 shrink-0 items-center justify-center gap-1 rounded-md border border-[#ebebeb] bg-white px-4 text-sm text-[#212121] transition-colors hover:bg-[#f7f8fa] disabled:cursor-not-allowed disabled:text-[#c9cdd4] disabled:hover:bg-transparent"
                         >
                             {localize("com_knowledge.add_new")}
+                            <Outlined.Down className="size-4" />
                         </button>
-                        <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                                <button
-                                    type="button"
-                                    disabled={isSearching}
-                                    aria-label={localize("com_knowledge.add_new")}
-                                    className="inline-flex items-center justify-center px-2 text-[#212121] transition-colors hover:bg-[#f7f8fa] disabled:cursor-not-allowed disabled:text-[#c9cdd4] disabled:hover:bg-transparent"
-                                >
-                                    <Outlined.Down className="size-4" />
-                                </button>
-                            </DropdownMenuTrigger>
-                            <ActionMenuContent align="end">
-                                <ActionMenuItem
-                                    onClick={onTriggerWebLink}
-                                    icon={<Link2 />}
-                                    label={localize("com_knowledge.web_link")}
-                                />
-                                <ActionMenuItem
-                                    onClick={onTriggerUploadFolder}
-                                    icon={<FolderUp />}
-                                    label={localize("com_knowledge.upload_folder")}
-                                />
-                                {canCreateFolder && (
-                                    <ActionMenuItem
-                                        onClick={onCreateFolder}
-                                        icon={<FolderPlus />}
-                                        label={localize("com_knowledge.new_folder")}
-                                    />
-                                )}
-                            </ActionMenuContent>
-                        </DropdownMenu>
-                    </div>
-                ) : (
-                    // Fallback when the user can only create folders: keep the original dropdown shape
-                    // so the single available action is still discoverable.
-                    <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                            <button
-                                type="button"
-                                disabled={isSearching}
-                                className="inline-flex h-8 shrink-0 items-center justify-center gap-1 rounded-md border border-[#ebebeb] bg-white px-4 text-sm text-[#212121] transition-colors hover:bg-[#f7f8fa] disabled:cursor-not-allowed disabled:text-[#c9cdd4] disabled:hover:bg-transparent"
-                            >
-                                {localize("com_knowledge.add_new")}
-                                <Outlined.Down className="size-4" />
-                            </button>
-                        </DropdownMenuTrigger>
-                        <ActionMenuContent align="end">
+                    </DropdownMenuTrigger>
+                    <ActionMenuContent align="end" width={200}>
+                        {canCreateFolder && (
                             <ActionMenuItem
                                 onClick={onCreateFolder}
                                 icon={<FolderPlus />}
                                 label={localize("com_knowledge.new_folder")}
                             />
-                        </ActionMenuContent>
-                    </DropdownMenu>
-                )
+                        )}
+                        {canUploadFile && (
+                            <>
+                                <ActionMenuItem
+                                    onClick={onTriggerUpload}
+                                    icon={<Outlined.Upload />}
+                                >
+                                    <div className="flex min-w-0 flex-1 items-center">
+                                        <span className={actionMenuLabelClassName}>
+                                            {localize("com_knowledge.upload_file")}
+                                        </span>
+                                        {supportedFormatsLabel ? (
+                                            <Tooltip>
+                                                <TooltipTrigger asChild>
+                                                    <span
+                                                        className="ml-auto inline-flex size-4 shrink-0 items-center justify-center text-[#8a94a6]"
+                                                        onClick={(event) => event.stopPropagation()}
+                                                        onPointerDown={(event) => event.stopPropagation()}
+                                                    >
+                                                        <CircleHelp className="size-3.5" />
+                                                    </span>
+                                                </TooltipTrigger>
+                                                <TooltipContent
+                                                    noArrow
+                                                    side="left"
+                                                    className="z-[999] max-w-md bg-white px-3 py-2 shadow-md"
+                                                >
+                                                    {localize("com_knowledge.supported_formats_tip", {
+                                                        formats: supportedFormatsLabel,
+                                                    })}
+                                                </TooltipContent>
+                                            </Tooltip>
+                                        ) : null}
+                                    </div>
+                                </ActionMenuItem>
+                                <ActionMenuItem
+                                    onClick={onTriggerUploadFolder}
+                                    icon={<FolderUp />}
+                                    label={localize("com_knowledge.upload_folder")}
+                                />
+                                <ActionMenuItem
+                                    onClick={onTriggerWebLink}
+                                    icon={<Link2 />}
+                                    label={localize("com_knowledge.web_link")}
+                                />
+                            </>
+                        )}
+                    </ActionMenuContent>
+                </DropdownMenu>
             )}
         </div>
     );

--- a/src/frontend/client/src/pages/knowledge/SpaceDetail/KnowledgeSpaceHeader.tsx
+++ b/src/frontend/client/src/pages/knowledge/SpaceDetail/KnowledgeSpaceHeader.tsx
@@ -42,8 +42,6 @@ interface KnowledgeSpaceHeaderProps {
     onTriggerWebLink: () => void;
     canCreateFolder?: boolean;
     canUploadFile?: boolean;
-    /** Localized comma-joined list of supported upload formats for the upload-button tooltip. */
-    supportedFormatsLabel?: string;
 
     // Batch Operation Props
     selectedCount: number;
@@ -93,7 +91,6 @@ export function KnowledgeSpaceHeader({
     onTriggerWebLink,
     canCreateFolder = false,
     canUploadFile = false,
-    supportedFormatsLabel,
     selectedCount,
     hasFoldersSelected,
     hasFailedFiles,
@@ -340,28 +337,24 @@ export function KnowledgeSpaceHeader({
                                         <span className={actionMenuLabelClassName}>
                                             {localize("com_knowledge.upload_file")}
                                         </span>
-                                        {supportedFormatsLabel ? (
-                                            <Tooltip>
-                                                <TooltipTrigger asChild>
-                                                    <span
-                                                        className="ml-auto inline-flex size-4 shrink-0 items-center justify-center text-[#8a94a6]"
-                                                        onClick={(event) => event.stopPropagation()}
-                                                        onPointerDown={(event) => event.stopPropagation()}
-                                                    >
-                                                        <CircleHelp className="size-3.5" />
-                                                    </span>
-                                                </TooltipTrigger>
-                                                <TooltipContent
-                                                    noArrow
-                                                    side="left"
-                                                    className="z-[999] max-w-md bg-white px-3 py-2 shadow-md"
+                                        <Tooltip>
+                                            <TooltipTrigger asChild>
+                                                <span
+                                                    className="ml-auto inline-flex size-4 shrink-0 items-center justify-center text-[#8a94a6]"
+                                                    onClick={(event) => event.stopPropagation()}
+                                                    onPointerDown={(event) => event.stopPropagation()}
                                                 >
-                                                    {localize("com_knowledge.supported_formats_tip", {
-                                                        formats: supportedFormatsLabel,
-                                                    })}
-                                                </TooltipContent>
-                                            </Tooltip>
-                                        ) : null}
+                                                    <CircleHelp className="size-3.5" />
+                                                </span>
+                                            </TooltipTrigger>
+                                            <TooltipContent
+                                                noArrow
+                                                side="left"
+                                                className="z-[999] max-w-md bg-white px-3 py-2 text-sm text-[#4e5969] shadow-md"
+                                            >
+                                                {localize("com_knowledge.upload_file_types_tip")}
+                                            </TooltipContent>
+                                        </Tooltip>
                                     </div>
                                 </ActionMenuItem>
                                 <ActionMenuItem

--- a/src/frontend/client/src/pages/knowledge/SpaceDetail/index.tsx
+++ b/src/frontend/client/src/pages/knowledge/SpaceDetail/index.tsx
@@ -1291,11 +1291,6 @@ export function KnowledgeSpaceContent({
                 onTriggerWebLink={triggerWebLink}
                 canCreateFolder={canCreateFolder}
                 canUploadFile={canUploadFile}
-                supportedFormatsLabel={localize(
-                    enableEtl4lm
-                        ? "com_knowledge.supported_formats_with_etl4lm"
-                        : "com_knowledge.supported_formats_basic"
-                )}
                 selectedCount={selectedFiles.size}
                 hasFoldersSelected={hasFoldersSelected}
                 hasFailedFiles={hasFailedFiles}

--- a/src/frontend/platform/public/locales/en-US/model.json
+++ b/src/frontend/platform/public/locales/en-US/model.json
@@ -17,6 +17,7 @@
     "sessionTitleGenerationModel": "Session Title Generation Model",
     "asrModel": "Speech-to-Text (ASR) Model",
     "asrModelTooltip": "Used for workbench speech-to-text scenarios",
+    "knowledgeAsrModelTooltip": "Used for speech-to-text in audio/video parsing",
     "ttsModel": "Text-to-Speech (TTS) Model",
     "ttsModelTooltip": "Used for workbench text-to-speech scenarios",
     "saveFailed": "Save failed, please try again!",

--- a/src/frontend/platform/public/locales/ja/model.json
+++ b/src/frontend/platform/public/locales/ja/model.json
@@ -15,6 +15,7 @@
     "sessionTitleGenerationModel": "セッションタイトル生成モデル",
     "asrModel": "音声認識（ASR）モデル",
     "asrModelTooltip": "ワークベンチ音声認識シナリオに使用",
+    "knowledgeAsrModelTooltip": "音声・動画解析の音声認識シナリオに使用",
     "ttsModel": "テキスト読み上げ（TTS）モデル",
     "ttsModelTooltip": "ワークベンチテキスト読み上げシナリオに使用",
     "saveFailed": "保存に失敗しました。再試行してください！",

--- a/src/frontend/platform/public/locales/zh-Hans/model.json
+++ b/src/frontend/platform/public/locales/zh-Hans/model.json
@@ -15,6 +15,7 @@
     "sessionTitleGenerationModel": "应用会话标题生成模型",
     "asrModel": "语音转文字（ASR）模型",
     "asrModelTooltip": "用于工作台语音转文字场景",
+    "knowledgeAsrModelTooltip": "用于音视频解析中语音转文字场景",
     "ttsModel": "文字转语音（TTS）模型",
     "ttsModelTooltip": "用于工作台文字转语音场景",
     "saveFailed": "保存失败，请重试！",

--- a/src/frontend/platform/src/pages/ModelPage/manage/SystemModelConfig.tsx
+++ b/src/frontend/platform/src/pages/ModelPage/manage/SystemModelConfig.tsx
@@ -147,7 +147,7 @@ export default function SystemModelConfig({
                         <WorkbenchModel llmOptions={llmOptions} embeddings={embeddings} asrModel={asrModel} ttsModel={ttsModel} onBack={onBack}></WorkbenchModel>
                     </TabsContent>
                     <TabsContent value="knowledge">
-                        <KnowledgeModle llmOptions={llmOptions} embeddings={embeddings} onBack={onBack}></KnowledgeModle>
+                        <KnowledgeModle llmOptions={llmOptions} embeddings={embeddings} asrModel={asrModel} onBack={onBack}></KnowledgeModle>
                     </TabsContent>
                     <TabsContent value="assis">
                         <AssisModel llmOptions={llmOptions} onBack={onBack}></AssisModel>

--- a/src/frontend/platform/src/pages/ModelPage/manage/tabs/KnowledgeModel.tsx
+++ b/src/frontend/platform/src/pages/ModelPage/manage/tabs/KnowledgeModel.tsx
@@ -119,7 +119,7 @@ const PromptDialog = ({ value, onChange, onRestore, onSave, label, children }) =
     </Dialog>
 }
 
-export default function KnowledgeModel({ llmOptions, embeddings, onBack }) {
+export default function KnowledgeModel({ llmOptions, embeddings, asrModel = [], onBack }) {
     const { t } = useTranslation('model')
 
     const [form, setForm] = useState({
@@ -127,6 +127,7 @@ export default function KnowledgeModel({ llmOptions, embeddings, onBack }) {
         sourceModelId: null,
         extractModelId: null,
         qaSimilarModelId: null,
+        asrModelId: null,
         abstractEnabled: true,
         autoTagEnabled: true,
         abstractPrompt: '',
@@ -144,6 +145,7 @@ export default function KnowledgeModel({ llmOptions, embeddings, onBack }) {
             embedding_model_id,
             extract_title_model_id,
             qa_similar_model_id,
+            asr_model_id,
             source_model_id,
             abstract_enabled,
             auto_tag_enabled,
@@ -155,6 +157,7 @@ export default function KnowledgeModel({ llmOptions, embeddings, onBack }) {
             sourceModelId: source_model_id,
             extractModelId: extract_title_model_id,
             qaSimilarModelId: qa_similar_model_id,
+            asrModelId: asr_model_id ?? null,
             abstractEnabled: abstract_enabled ?? true,
             autoTagEnabled: auto_tag_enabled ?? true,
             abstractPrompt: abstract_prompt ?? defalutPrompt,
@@ -182,6 +185,7 @@ export default function KnowledgeModel({ llmOptions, embeddings, onBack }) {
             embeddingModelId,
             extractModelId,
             qaSimilarModelId,
+            asrModelId,
             sourceModelId,
             abstractEnabled,
             autoTagEnabled,
@@ -204,6 +208,7 @@ export default function KnowledgeModel({ llmOptions, embeddings, onBack }) {
             embedding_model_id: embeddingModelId,
             extract_title_model_id: extractModelId,
             qa_similar_model_id: qaSimilarModelId,
+            asr_model_id: asrModelId || null,
             source_model_id: sourceModelId,
             abstract_enabled: abstractEnabled,
             auto_tag_enabled: autoTagEnabled,
@@ -321,6 +326,14 @@ export default function KnowledgeModel({ llmOptions, embeddings, onBack }) {
                 value={form.qaSimilarModelId}
                 options={llmOptions}
                 onChange={(val) => setFormAndClearInherited({ ...form, qaSimilarModelId: val })}
+            />
+            <ModelSelect
+                close
+                label={t('model.asrModel')}
+                tooltipText={t('model.knowledgeAsrModelTooltip')}
+                value={form.asrModelId}
+                options={asrModel}
+                onChange={(val) => setFormAndClearInherited({ ...form, asrModelId: val })}
             />
             <div className="mt-10 text-center space-x-6">
                 <Button className="px-6" variant="outline" onClick={onBack}>{t('model.cancel')}</Button>


### PR DESCRIPTION
## Summary

- Add optional **knowledge-base ASR model** in system model settings; media transcription reads `KnowledgeLLMConfig.asr_model_id` (no workbench fallback).
- Align Client knowledge-space **Add** dropdown (single menu, upload-file tooltip).
- Fix upload-file types tooltip visibility on Client.

## Commits (release..feat/2.6.0)

- `36dd86e34` — align knowledge space add menu with design spec
- `4bbbcad77` — show upload file types tip in knowledge space add menu
- `ccc8b9b39` — configurable ASR model in knowledge system settings

## Test plan

- [ ] CI green (Drone `cicd` deploys 116)
- [ ] Platform: 系统模型设置 → 知识库模型 → ASR field saves `asr_model_id`
- [ ] Upload audio/video in knowledge space uses configured ASR (not workbench ASR)
- [ ] Client: Add menu order + upload-file ? tooltip

Test frontend already deployed at **`ccc8b9b39`** on 120.