### PR TITLE
ci(security): avoid script injection from commit message in workflows

### DIFF
--- a/.github/workflows/base_ci.yml
+++ b/.github/workflows/base_ci.yml
@@ -114,8 +114,10 @@ jobs:
       # 获取提交信息
       - name: Process git message
         id: process_message
+        env:
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
-          value=$(echo "${{ github.event.head_commit.message }}" | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/%0A/g')
+          value=$(echo "$HEAD_COMMIT_MESSAGE" | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/%0A/g')
           value=$(echo "${value}" | sed -e ':a' -e 'N' -e '$!ba' -e 's/\r/%0A/g')
           echo "message=${value}" >> $GITHUB_ENV
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,8 +173,10 @@ jobs:
 
       - name: Process git message
         id: process_message
+        env:
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
-          value=$(echo "${{ github.event.head_commit.message }}" | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/%0A/g')
+          value=$(echo "$HEAD_COMMIT_MESSAGE" | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/%0A/g')
           value=$(echo "${value}" | sed -e ':a' -e 'N' -e '$!ba' -e 's/\r/%0A/g')
           echo "message=${value}" >> $GITHUB_ENV
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,8 +151,10 @@ jobs:
         
         - name: Process git message
           id: process_message
+          env:
+            HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
           run: |
-            value=$(echo "${{ github.event.head_commit.message }}" | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/%0A/g')
+            value=$(echo "$HEAD_COMMIT_MESSAGE" | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/%0A/g')
             value=$(echo "${value}" | sed -e ':a' -e 'N' -e '$!ba' -e 's/\r/%0A/g')
             echo "message=${value}" >> $GITHUB_ENV
           shell: bash


### PR DESCRIPTION
### What
The "Process git message" step in `base_ci.yml`, `ci.yml`, and `release.yml` interpolates
`${{ github.event.head_commit.message }}` **directly into a `run:` shell**:

```yaml
run: |
  value=$(echo "${{ github.event.head_commit.message }}" | sed ...)
```

This PR passes the commit message through an `env:` variable and references `"$HEAD_COMMIT_MESSAGE"`
in the shell instead.

### Why
When a `${{ ... }}` context is expanded straight into a shell line, its contents become part of the
command. A commit message containing shell metacharacters — e.g. `$(...)`, backticks, `;` — would be
**executed by the runner** (GitHub's ["Understanding the risk of script injections"](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections)).
Routing the value through an environment variable keeps it as data, not code.

### Scope / safety
- Behaviour is unchanged for ordinary commit messages.
- Only the three affected steps are touched. Signed-off.

<sub>AI-assisted; I verified the workflows and the mitigation myself against commit `9eb9328e82e7`.</sub>
