### PR TITLE
fix(workflow): support temp knowledge mode arrays

### DIFF
--- a/src/frontend/platform/src/pages/BuildPage/flow/FlowNode/component/KnowledgeSelectItem.tsx
+++ b/src/frontend/platform/src/pages/BuildPage/flow/FlowNode/component/KnowledgeSelectItem.tsx
@@ -49,6 +49,13 @@ const mergeOptionsByValue = (currentOptions, nextOptions) => {
     ]
 }
 
+export function hasTempKnowledgeMode(fileParseMode: unknown): boolean {
+    if (Array.isArray(fileParseMode)) {
+        return fileParseMode.includes('ingest_to_temp_kb')
+    }
+    return fileParseMode === 'ingest_to_temp_kb'
+}
+
 export default function KnowledgeSelectItem({ data, nodeId, onChange, onVarEvent, onValidate, i18nPrefix }) {
     const { flow } = useFlowStore()
     const { t } = useTranslation('flow')
@@ -89,11 +96,12 @@ export default function KnowledgeSelectItem({ data, nodeId, onChange, onVarEvent
                 group.params.forEach(param => {
                     if (param.key === 'form_input') {
                         param.value.forEach(val => {
-                            val.file_parse_mode === 'ingest_to_temp_kb' && val.type === 'file'
-                                && files.push({
+                            if (val.type === 'file' && hasTempKnowledgeMode(val.file_parse_mode)) {
+                                files.push({
                                     label: `${val.key}(${val.value})`,
                                     value: `${node.id}.${val.key}`
                                 })
+                            }
                         })
                     }
                 })

--- a/src/frontend/platform/src/test/knowledgeSelectItem.test.ts
+++ b/src/frontend/platform/src/test/knowledgeSelectItem.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { hasTempKnowledgeMode } from "@/pages/BuildPage/flow/FlowNode/component/KnowledgeSelectItem";
+
+describe("hasTempKnowledgeMode", () => {
+  it("accepts the v3 form strategy array", () => {
+    expect(hasTempKnowledgeMode(["extract_text", "ingest_to_temp_kb"])).toBe(
+      true,
+    );
+  });
+
+  it("accepts the legacy string strategy", () => {
+    expect(hasTempKnowledgeMode("ingest_to_temp_kb")).toBe(true);
+  });
+
+  it("rejects strategies that do not ingest to the temporary knowledge base", () => {
+    expect(hasTempKnowledgeMode(["extract_text"])).toBe(false);
+    expect(hasTempKnowledgeMode(["keep_raw"])).toBe(false);
+    expect(hasTempKnowledgeMode(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
This pull request refactors the way the code checks for the `ingest_to_temp_kb` mode in file parsing, improving maintainability and test coverage. The main change is the introduction of a utility function to detect the temporary knowledge base ingestion mode, along with corresponding unit tests.

**Refactoring and Logic Extraction**
- Added a new utility function `hasTempKnowledgeMode` to encapsulate the logic for checking if a file parse mode includes `ingest_to_temp_kb`, supporting both string and array formats.
- Updated the logic in `KnowledgeSelectItem` to use the new `hasTempKnowledgeMode` function, simplifying conditionals and improving readability.

**Testing**
- Added unit tests for `hasTempKnowledgeMode` in `knowledgeSelectItem.test.ts`, ensuring correct behavior for both legacy and current data formats.## What