### PR TITLE
fix(knowledge): return subcategory in upload records

### DIFF
--- a/src/backend/bisheng/knowledge/domain/schemas/knowledge_space_schema.py
+++ b/src/backend/bisheng/knowledge/domain/schemas/knowledge_space_schema.py
@@ -815,6 +815,11 @@ class ShougangPortalUploadedFileResp(BaseModel):
     folder_path_name: str = "根目录"
     status: int | None = None
     file_encoding: str | None = None
+    file_subcategory_code: str | None = Field(
+        default=None,
+        max_length=16,
+        description="Second-level file category code persisted on the knowledge file",
+    )
     tags: list[dict] = Field(default_factory=list)
     abstract: str = ""
     create_time: str = ""

--- a/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
+++ b/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
@@ -12802,6 +12802,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 folder_path_name=self._folder_path_name_from_map(file.file_level_path, folder_map),
                 status=file.status,
                 file_encoding=file.file_encoding,
+                file_subcategory_code=getattr(file, "file_subcategory_code", None),
                 tags=file_tags.get(int(file.id), []),
                 abstract=file.abstract or "",
                 create_time=self._format_datetime(file.create_time),

--- a/src/backend/test/test_knowledge_space_service.py
+++ b/src/backend/test/test_knowledge_space_service.py
@@ -1597,6 +1597,8 @@ async def test_list_my_uploaded_files_queries_uploader_records_without_read_perm
         user_id=service.login_user.user_id,
         status=KnowledgeFileStatus.PROCESSING.value,
     )
+    source_file.file_encoding = "SGGF-STD-EM-20260600000001"
+    source_file.file_subcategory_code = "STD"
     folders = [
         _make_file(file_id=37, knowledge_id=10, file_type=FileType.DIR.value, file_name="技术文档"),
         _make_file(file_id=38, knowledge_id=10, file_type=FileType.DIR.value, file_name="能源管理"),
@@ -1625,10 +1627,14 @@ async def test_list_my_uploaded_files_queries_uploader_records_without_read_perm
             "bisheng.knowledge.domain.services.knowledge_space_service.TagDao.get_tags_by_resource_batch",
             return_value={
                 "501": [
-                    SimpleNamespace(id=11, name="能源"),
-                    SimpleNamespace(id=12, name="安全"),
+                    SimpleNamespace(id=11, name="能源", resource_type=None),
+                    SimpleNamespace(id=12, name="安全", resource_type=None),
                 ],
             },
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.ReviewTagDao.get_tags_by_resource_batch",
+            return_value={},
         ),
         patch.object(
             service,
@@ -1647,7 +1653,12 @@ async def test_list_my_uploaded_files_queries_uploader_records_without_read_perm
     assert result.data[0].space_level == KnowledgeSpaceLevelEnum.TEAM
     assert result.data[0].folder_path_name == "技术文档/能源管理"
     assert result.data[0].parent_id == 38
-    assert result.data[0].tags == [{"id": 11, "name": "能源"}, {"id": 12, "name": "安全"}]
+    assert result.data[0].file_encoding == "SGGF-STD-EM-20260600000001"
+    assert result.data[0].file_subcategory_code == "STD"
+    assert result.data[0].tags == [
+        {"id": 11, "name": "能源", "resource_type": None},
+        {"id": 12, "name": "安全", "resource_type": None},
+    ]
 
 
 @pytest.mark.asyncio
@@ -1693,6 +1704,10 @@ async def test_list_my_uploaded_files_defaults_missing_space_level_to_personal(s
             "bisheng.knowledge.domain.services.knowledge_space_service.TagDao.get_tags_by_resource_batch",
             return_value={},
         ),
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.ReviewTagDao.get_tags_by_resource_batch",
+            return_value={},
+        ),
         patch.object(
             service,
             "_get_space_level",
@@ -1705,6 +1720,7 @@ async def test_list_my_uploaded_files_defaults_missing_space_level_to_personal(s
     mock_get_space_level.assert_awaited_once_with(10)
     assert result.data[0].knowledge_name == "个人知识空间"
     assert result.data[0].space_level == KnowledgeSpaceLevelEnum.PERSONAL
+    assert result.data[0].file_subcategory_code is None
 
 
 @pytest.mark.asyncio

--- a/src/frontend/client/src/api/knowledge.test.ts
+++ b/src/frontend/client/src/api/knowledge.test.ts
@@ -613,6 +613,7 @@ describe("listMyUploadedFilesApi", () => {
             folder_path_name: "能源管理",
             status: 1,
             file_encoding: "SGGF-STD-EM-20260600000001",
+            file_subcategory_code: "STD",
             tags: [{ id: 1, name: "能源" }],
             abstract: "摘要",
             create_time: "2026-06-02 10:00:00",
@@ -640,6 +641,7 @@ describe("listMyUploadedFilesApi", () => {
       name: "能源管理标准.pdf",
       folderPathName: "能源管理",
       fileEncoding: "SGGF-STD-EM-20260600000001",
+      fileSubcategoryCode: "STD",
     });
   });
 });

--- a/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.test.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.test.tsx
@@ -4176,6 +4176,7 @@ describe("PortalKnowledgeWorkbench", () => {
             spaceLevel: SpaceLevel.PERSONAL,
             folderPathName: "根目录",
             fileEncoding: "SGGF-STD-EM-20260600000001",
+            fileSubcategoryCode: "STD",
             tags: [{ id: 1, name: "能源" }],
             summary: "AI 摘要",
         };
@@ -4209,6 +4210,10 @@ describe("PortalKnowledgeWorkbench", () => {
         fireEvent.change(within(dialog).getByLabelText("选择文件"), {
             target: { files: [file] },
         });
+        selectPortalSubcategory(dialog, "文件分类", "请选择", "标准规范", "标准规范 / 标准规范");
+        fireEvent.change(within(dialog).getByLabelText("业务域"), {
+            target: { value: "EM" },
+        });
         fireEvent.click(within(dialog).getByRole("button", { name: "上传" }));
 
         const drawer = await screen.findByTestId("portal-uploaded-files-drawer");
@@ -4228,7 +4233,7 @@ describe("PortalKnowledgeWorkbench", () => {
         expect(within(drawer).getByText("解析中")).toHaveClass("uploadRecordStatusInfo");
         expect(within(drawer).getByText("根目录")).toBeInTheDocument();
         expect(within(drawer).getByText("SGGF-STD-EM-20260600000001")).toBeInTheDocument();
-        expect(getPortalCategoryButton(drawer, "修改测试文档.pdf文件分类", "标准规范 / --")).toBeInTheDocument();
+        expect(getPortalCategoryButton(drawer, "修改测试文档.pdf文件分类", "标准规范 / 标准规范")).toBeInTheDocument();
         expect(within(drawer).getByLabelText("修改测试文档.pdf业务域类型 当前业务域：EM")).toHaveDisplayValue("EM / 能源");
         expect(within(drawer).getAllByText("能源").length).toBeGreaterThanOrEqual(1);
         expect(within(drawer).queryByText("个人知识库 / 设备部")).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary
- `my-uploaded-files` now returns `file_subcategory_code`, so upload records keep the selected file category during parse polling instead of falling back to `大类 / --`.
- Update backend/frontend tests to cover subcategory mapping and display in the upload-records drawer.

## Test plan
- [ ] Upload a file with an explicit file category/subcategory selected
- [ ] Open 上传记录 while status is 解析中 and confirm category shows full `大类 / 小类` (not `大类 / --`)
- [ ] After parse completes, confirm upload records and main file list show the same category
- [ ] Backend: `pytest test/test_knowledge_space_service.py::test_list_my_uploaded_files_queries_uploader_records_without_read_permission`
- [ ] Frontend: jest cases for `listMyUploadedFilesApi` mapping and `opens upload records after successful upload`


Made with [Cursor](https://cursor.com)