### PR TITLE
fix(knowledge): show selected business domain in upload records

### DIFF
--- a/src/backend/bisheng/knowledge/domain/schemas/knowledge_space_schema.py
+++ b/src/backend/bisheng/knowledge/domain/schemas/knowledge_space_schema.py
@@ -820,6 +820,11 @@ class ShougangPortalUploadedFileResp(BaseModel):
         max_length=16,
         description="Second-level file category code persisted on the knowledge file",
     )
+    business_domain_code: str | None = Field(
+        default=None,
+        max_length=16,
+        description=("Selected business domain code for this file (from split_rule, else parsed from file_encoding)"),
+    )
     tags: list[dict] = Field(default_factory=list)
     abstract: str = ""
     create_time: str = ""

--- a/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
+++ b/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
@@ -114,6 +114,7 @@ from bisheng.database.models.tenant import TenantDao
 from bisheng.database.models.user_group import UserGroupDao
 from bisheng.department.domain.services.department_service import DepartmentService
 from bisheng.knowledge.domain.constants import (
+    get_business_domain_code_from_file,
     normalize_business_domain_code,
     parse_shougang_file_encoding_codes,
 )
@@ -12803,6 +12804,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 status=file.status,
                 file_encoding=file.file_encoding,
                 file_subcategory_code=getattr(file, "file_subcategory_code", None),
+                business_domain_code=get_business_domain_code_from_file(file) or None,
                 tags=file_tags.get(int(file.id), []),
                 abstract=file.abstract or "",
                 create_time=self._format_datetime(file.create_time),

--- a/src/backend/test/test_knowledge_space_service.py
+++ b/src/backend/test/test_knowledge_space_service.py
@@ -1597,8 +1597,14 @@ async def test_list_my_uploaded_files_queries_uploader_records_without_read_perm
         user_id=service.login_user.user_id,
         status=KnowledgeFileStatus.PROCESSING.value,
     )
-    source_file.file_encoding = "SGGF-STD-EM-20260600000001"
+    source_file.file_encoding = None
     source_file.file_subcategory_code = "STD"
+    source_file.split_rule = json.dumps(
+        {
+            "file_category_code": "STD",
+            "business_domain_code": "EM",
+        }
+    )
     folders = [
         _make_file(file_id=37, knowledge_id=10, file_type=FileType.DIR.value, file_name="技术文档"),
         _make_file(file_id=38, knowledge_id=10, file_type=FileType.DIR.value, file_name="能源管理"),
@@ -1653,8 +1659,9 @@ async def test_list_my_uploaded_files_queries_uploader_records_without_read_perm
     assert result.data[0].space_level == KnowledgeSpaceLevelEnum.TEAM
     assert result.data[0].folder_path_name == "技术文档/能源管理"
     assert result.data[0].parent_id == 38
-    assert result.data[0].file_encoding == "SGGF-STD-EM-20260600000001"
+    assert result.data[0].file_encoding is None
     assert result.data[0].file_subcategory_code == "STD"
+    assert result.data[0].business_domain_code == "EM"
     assert result.data[0].tags == [
         {"id": 11, "name": "能源", "resource_type": None},
         {"id": 12, "name": "安全", "resource_type": None},
@@ -1721,9 +1728,56 @@ async def test_list_my_uploaded_files_defaults_missing_space_level_to_personal(s
     assert result.data[0].knowledge_name == "个人知识空间"
     assert result.data[0].space_level == KnowledgeSpaceLevelEnum.PERSONAL
     assert result.data[0].file_subcategory_code is None
+    assert result.data[0].business_domain_code is None
 
 
 @pytest.mark.asyncio
+async def test_list_my_uploaded_files_prefers_split_rule_business_domain_over_encoding(service):
+    source_file = _make_file(
+        file_id=501,
+        knowledge_id=10,
+        file_name="业务域文档.pdf",
+        file_level_path="",
+        level=0,
+        user_id=service.login_user.user_id,
+        status=KnowledgeFileStatus.SUCCESS.value,
+    )
+    source_file.file_encoding = "SGGF-STD-PP-20260600000001"
+    source_file.split_rule = json.dumps({"business_domain_code": "EM"})
+    space = _make_space(space_id=10, space_level=KnowledgeSpaceLevelEnum.PERSONAL)
+    space.name = "个人知识空间"
+
+    with (
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.KnowledgeFileDao.alist_user_uploaded_files",
+            new_callable=AsyncMock,
+            return_value=([source_file], 1),
+            create=True,
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.KnowledgeDao.async_get_spaces_by_ids",
+            new_callable=AsyncMock,
+            return_value=[space],
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.KnowledgeFileDao.aget_file_by_ids",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.TagDao.get_tags_by_resource_batch",
+            return_value={},
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.ReviewTagDao.get_tags_by_resource_batch",
+            return_value={},
+        ),
+    ):
+        result = await service.list_my_uploaded_files(page=1, page_size=20)
+
+    assert result.data[0].business_domain_code == "EM"
+
+
 async def test_update_file_encoding_bumps_serial_when_duplicate_across_all_spaces(service):
     def _normalize_file_category_code(value):
         if not isinstance(value, str):

--- a/src/frontend/client/src/api/knowledge.test.ts
+++ b/src/frontend/client/src/api/knowledge.test.ts
@@ -614,6 +614,7 @@ describe("listMyUploadedFilesApi", () => {
             status: 1,
             file_encoding: "SGGF-STD-EM-20260600000001",
             file_subcategory_code: "STD",
+            business_domain_code: "EM",
             tags: [{ id: 1, name: "能源" }],
             abstract: "摘要",
             create_time: "2026-06-02 10:00:00",
@@ -642,6 +643,7 @@ describe("listMyUploadedFilesApi", () => {
       folderPathName: "能源管理",
       fileEncoding: "SGGF-STD-EM-20260600000001",
       fileSubcategoryCode: "STD",
+      businessDomainCode: "EM",
     });
   });
 });

--- a/src/frontend/client/src/api/knowledge.ts
+++ b/src/frontend/client/src/api/knowledge.ts
@@ -535,6 +535,7 @@ export interface KnowledgeFile {
     approvalReason?: string;
     fileEncoding?: string | null;        // mapped from file_encoding
     fileSubcategoryCode?: string | null; // mapped from file_subcategory_code
+    businessDomainCode?: string | null; // mapped from business_domain_code (file-level selection)
     summary?: string;
     isPendingApproval?: boolean;
     version_no?: number;          // primary version number; absent for folders / legacy files
@@ -1121,6 +1122,7 @@ export function mapChild(raw: any, spaceId: string): KnowledgeFile {
         isPendingApproval: Boolean(raw?.is_pending_approval),
         fileEncoding: raw?.file_encoding ?? null,
         fileSubcategoryCode: raw?.file_subcategory_code ?? null,
+        businessDomainCode: raw?.business_domain_code ?? null,
         summary: raw?.summary ?? raw?.abstract ?? "",
         version_no: raw?.version_no !== undefined && raw?.version_no !== null ? Number(raw.version_no) : undefined,
         is_multi_version: Boolean(raw?.is_multi_version),

--- a/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.test.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.test.tsx
@@ -4446,6 +4446,42 @@ describe("PortalKnowledgeWorkbench", () => {
         });
     });
 
+    test("shows selected business domain in upload records before encoding is ready", async () => {
+        const personalSpace = makeSpace("personal-1", "设备部", {
+            role: SpaceRole.ADMIN,
+        });
+        const uploadedRecord = {
+            ...makeFile("501", "解析中文档.pdf", {
+                type: FileType.PDF,
+                status: FileStatus.PROCESSING,
+            }),
+            spaceName: "设备部",
+            spaceLevel: SpaceLevel.PERSONAL,
+            folderPathName: "根目录",
+            fileEncoding: "",
+            fileSubcategoryCode: "STD",
+            businessDomainCode: "EM",
+            tags: [],
+        };
+        jest.mocked(getGroupedSpacesApi).mockResolvedValue({
+            publicSpaces: [],
+            departmentSpaces: [],
+            teamSpaces: [],
+            personalSpaces: [personalSpace],
+        } as any);
+        jest.mocked(getSpaceChildrenApi).mockResolvedValue({ data: [], total: 0 } as any);
+        jest.mocked(listMyUploadedFilesApi).mockResolvedValue({ data: [uploadedRecord], total: 1 } as any);
+
+        renderWorkbench();
+
+        openMyUploadsFromPortalShell();
+        const drawer = await screen.findByTestId("portal-uploaded-files-drawer");
+
+        expect(within(drawer).getByText("解析中")).toHaveClass("uploadRecordStatusInfo");
+        expect(getPortalCategoryButton(drawer, "修改解析中文档.pdf文件分类", "标准规范 / 标准规范")).toBeInTheDocument();
+        expect(within(drawer).getByLabelText("修改解析中文档.pdf业务域类型 当前业务域：EM")).toHaveDisplayValue("EM / 能源");
+    });
+
     test("shows double dash placeholders for empty uploaded record fields", async () => {
         const personalSpace = makeSpace("personal-1", "设备部", {
             role: SpaceRole.ADMIN,

--- a/src/frontend/client/src/pages/knowledge/portal/components/PortalUploadedFilesDrawer.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/components/PortalUploadedFilesDrawer.tsx
@@ -385,7 +385,10 @@ export function PortalUploadedFilesDrawer({
             nextDraft.fileCategoryCode ?? currentDraft.fileCategoryCode ?? parsed.fileCategoryCode,
         );
         const businessDomainCode = normalizeEncodingCode(
-            nextDraft.businessDomainCode ?? currentDraft.businessDomainCode ?? parsed.businessDomainCode,
+            nextDraft.businessDomainCode
+            ?? currentDraft.businessDomainCode
+            ?? record.businessDomainCode
+            ?? parsed.businessDomainCode,
         );
         const normalizedSubcategoryCode = fileSubcategoryCode === undefined
             ? currentDraft.fileSubcategoryCode
@@ -514,7 +517,11 @@ export function PortalUploadedFilesDrawer({
                             const parsedEncoding = parseFileEncoding(record.fileEncoding, encodingPrefix);
                             const draft = encodingDrafts[record.id] ?? {};
                             const selectedFileCategoryCode = normalizeEncodingCode(draft.fileCategoryCode ?? parsedEncoding.fileCategoryCode);
-                            const selectedBusinessDomainCode = normalizeEncodingCode(draft.businessDomainCode ?? parsedEncoding.businessDomainCode);
+                            const selectedBusinessDomainCode = normalizeEncodingCode(
+                                draft.businessDomainCode
+                                ?? record.businessDomainCode
+                                ?? parsedEncoding.businessDomainCode,
+                            );
                             const selectedBusinessDomainText = selectedBusinessDomainCode || EMPTY_FIELD_PLACEHOLDER;
                             const recordBusinessDomainOptions = filterBusinessDomainOptionsByCodes(
                                 businessDomainOptions,


### PR DESCRIPTION
## Summary
- `my-uploaded-files` now returns file-level `business_domain_code` (from `split_rule`, falling back to `file_encoding`).
- Upload records drawer uses that field so the selected business domain is visible during parsing, before encoding is generated.

## Test plan
- [ ] Upload a file with an explicit business domain selected
- [ ] Open 上传记录 while status is 解析中 and confirm 业务域类型 shows the selected domain (not `--`)
- [ ] After parse completes, confirm business domain remains consistent with encoding
- [ ] Backend: `pytest test/test_knowledge_space_service.py -k list_my_uploaded_files`
- [ ] Frontend: jest case `shows selected business domain in upload records before encoding is ready`


Made with [Cursor](https://cursor.com)