### PR TITLE
fix(knowledge): show upload-time business domain before file encoding exists

### DIFF
--- a/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
+++ b/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
@@ -3605,8 +3605,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
         # department binding. Portal discovery and department-file approval
         # intentionally fail closed when scope and binding disagree.
         should_create_department_binding = department_id is not None and (
-            level == KnowledgeSpaceLevelEnum.DEPARTMENT
-            or (is_clinic and KnowledgeSpaceLevelEnum.is_team_level(level))
+            level == KnowledgeSpaceLevelEnum.DEPARTMENT or (is_clinic and KnowledgeSpaceLevelEnum.is_team_level(level))
         )
         if should_create_department_binding:
             try:
@@ -5771,8 +5770,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 await self._enrich_with_version_info(authorized_files)
             except Exception:
                 logger.exception(
-                    "Failed to enrich authorized portal QA files with version metadata "
-                    "space_id=%s file_count=%s",
+                    "Failed to enrich authorized portal QA files with version metadata space_id=%s file_count=%s",
                     space_id,
                     len(authorized_files),
                 )
@@ -5783,14 +5781,11 @@ class KnowledgeSpaceService(KnowledgeUtils):
                     enrich_files=True,
                 )
                 authorized_metadata_by_id = {
-                    int(item.get("id") or 0): item
-                    for item in authorized_metadata
-                    if int(item.get("id") or 0) > 0
+                    int(item.get("id") or 0): item for item in authorized_metadata if int(item.get("id") or 0) > 0
                 }
             except Exception:
                 logger.exception(
-                    "Failed to enrich authorized portal QA files with readonly metadata "
-                    "space_id=%s file_count=%s",
+                    "Failed to enrich authorized portal QA files with readonly metadata space_id=%s file_count=%s",
                     space_id,
                     len(authorized_files),
                 )
@@ -7065,9 +7060,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 empty_reason = "permission_check_limit_reached"
             elif ordered_candidate_count == 0 and not cached_candidates:
                 empty_reason = (
-                    "generic_pool_empty"
-                    if not user_domains and not interest_candidates
-                    else "no_eligible_candidate"
+                    "generic_pool_empty" if not user_domains and not interest_candidates else "no_eligible_candidate"
                 )
             elif authorization_state.error_count > 0 and authorization_state.allowed_count == 0:
                 empty_reason = "permission_check_failed_closed"
@@ -9566,9 +9559,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
             list(space_ids),
             spaces=spaces,
         )
-        department_space_ids = await self._get_valid_department_space_ids(
-            space_ids - public_space_ids
-        )
+        department_space_ids = await self._get_valid_department_space_ids(space_ids - public_space_ids)
 
         public_files: list[KnowledgeFile] = []
         department_files: list[KnowledgeFile] = []
@@ -9584,10 +9575,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
 
         accepted_ids: set[int] = set()
         if public_files:
-            accepted_ids.update(
-                int(file.id)
-                for file in self._accept_shougang_portal_public_files(public_files)
-            )
+            accepted_ids.update(int(file.id) for file in self._accept_shougang_portal_public_files(public_files))
         for file in department_files:
             file_id = int(file.id)
             self._portal_unchecked_department_file_ids.add(file_id)
@@ -11659,12 +11647,10 @@ class KnowledgeSpaceService(KnowledgeUtils):
             if shared_source_by_item:
                 space_metadata = await KnowledgeDao.async_get_space_source_metadata_by_ids(list(source_space_ids))
                 space_name_map = {
-                    int(space_id): str(metadata[0] or space_id)
-                    for space_id, metadata in space_metadata.items()
+                    int(space_id): str(metadata[0] or space_id) for space_id, metadata in space_metadata.items()
                 }
                 source_department_name_map = {
-                    int(space_id): str(metadata[1] or "")
-                    for space_id, metadata in space_metadata.items()
+                    int(space_id): str(metadata[1] or "") for space_id, metadata in space_metadata.items()
                 }
             else:
                 source_spaces = await KnowledgeDao.async_get_spaces_by_ids(list(source_space_ids))
@@ -12125,17 +12111,9 @@ class KnowledgeSpaceService(KnowledgeUtils):
         )
         version_map = {int(version.id): version for version in primary_versions}
         primary_file_ids = sorted(
-            {
-                int(version.knowledge_file_id)
-                for version in primary_versions
-                if version.knowledge_file_id is not None
-            }
+            {int(version.knowledge_file_id) for version in primary_versions if version.knowledge_file_id is not None}
         )
-        primary_files = (
-            await KnowledgeFileDao.aget_file_by_ids(primary_file_ids)
-            if primary_file_ids
-            else []
-        )
+        primary_files = await KnowledgeFileDao.aget_file_by_ids(primary_file_ids) if primary_file_ids else []
         primary_file_map = {int(file.id): file for file in primary_files}
 
         info: dict[int, dict] = {}
@@ -12165,9 +12143,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 else None
             )
             primary_file = (
-                primary_file_map.get(int(primary_version.knowledge_file_id))
-                if primary_version is not None
-                else None
+                primary_file_map.get(int(primary_version.knowledge_file_id)) if primary_version is not None else None
             )
             canonical_document_id = (
                 int(document.id) if document is not None else getattr(item, "_canonical_document_id", None)
@@ -12289,6 +12265,8 @@ class KnowledgeSpaceService(KnowledgeUtils):
                         [],
                     )
                     item["summary"] = one.abstract or ""
+                    # Expose upload-time business domain before file_encoding is generated.
+                    item["business_domain_code"] = get_business_domain_code_from_file(one) or None
                     # Version enrichment fields set by _enrich_with_version_info (if version_repo is set).
                     item["version_no"] = getattr(one, "_version_no", None)
                     item["is_multi_version"] = getattr(one, "_is_multi_version", False)

--- a/src/backend/test/knowledge/test_portal_qa_tree_selection.py
+++ b/src/backend/test/knowledge/test_portal_qa_tree_selection.py
@@ -18,7 +18,7 @@ def _file(
     space_id: int = 7101,
     *,
     folder: bool = False,
-    path: str = '',
+    path: str = "",
     status: int = KnowledgeFileStatus.SUCCESS.value,
 ):
     item = SimpleNamespace(
@@ -30,12 +30,12 @@ def _file(
         file_name=f"{'folder' if folder else 'file'}-{file_id}.md",
     )
     item.model_dump = lambda: {
-        'id': item.id,
-        'knowledge_id': item.knowledge_id,
-        'file_type': item.file_type,
-        'status': item.status,
-        'file_level_path': item.file_level_path,
-        'file_name': item.file_name,
+        "id": item.id,
+        "knowledge_id": item.knowledge_id,
+        "file_type": item.file_type,
+        "status": item.status,
+        "file_level_path": item.file_level_path,
+        "file_name": item.file_name,
     }
     return item
 
@@ -43,28 +43,28 @@ def _file(
 @pytest.mark.asyncio
 async def test_resolve_qa_scope_file_ids_expands_folders_and_dedupes(monkeypatch):
     service = object.__new__(svc_mod.KnowledgeSpaceService)
-    service.login_user = SimpleNamespace(user_id=7, user_name='tester')
+    service.login_user = SimpleNamespace(user_id=7, user_name="tester")
     service.version_repo = None
 
     records = {
-        3001: _file(3001, folder=True, path=''),
+        3001: _file(3001, folder=True, path=""),
         9001: _file(9001),
-        9002: _file(9002, path='/3001'),
+        9002: _file(9002, path="/3001"),
     }
 
     async def _query_by_id(file_id):
         return records.get(file_id)
 
     async def _children_by_prefix(_space_id, prefix, file_status=None):
-        assert prefix == '/3001'
+        assert prefix == "/3001"
         assert file_status == KnowledgeFileStatus.SUCCESS
         return [records[9001], records[9002]]
 
-    monkeypatch.setattr(service, '_require_read_permission', AsyncMock())
-    monkeypatch.setattr(service, '_require_permission_id', AsyncMock())
-    monkeypatch.setattr(service, '_filter_visible_child_items', AsyncMock(side_effect=lambda items, **_kwargs: items))
-    monkeypatch.setattr(svc_mod.KnowledgeFileDao, 'query_by_id', _query_by_id)
-    monkeypatch.setattr(svc_mod.SpaceFileDao, 'get_children_by_prefix', _children_by_prefix)
+    monkeypatch.setattr(service, "_require_read_permission", AsyncMock())
+    monkeypatch.setattr(service, "_require_permission_id", AsyncMock())
+    monkeypatch.setattr(service, "_filter_visible_child_items", AsyncMock(side_effect=lambda items, **_kwargs: items))
+    monkeypatch.setattr(svc_mod.KnowledgeFileDao, "query_by_id", _query_by_id)
+    monkeypatch.setattr(svc_mod.SpaceFileDao, "get_children_by_prefix", _children_by_prefix)
 
     result = await service.resolve_qa_scope_file_ids(
         folder_refs=[SimpleNamespace(knowledge_space_id=7101, folder_id=3001)],
@@ -73,17 +73,17 @@ async def test_resolve_qa_scope_file_ids_expands_folders_and_dedupes(monkeypatch
     )
 
     assert result == {7101: [9001, 9002]}
-    service._require_permission_id.assert_any_await('folder', 3001, 'view_folder', space_id=7101)
-    service._require_permission_id.assert_any_await('knowledge_file', 9001, 'view_file', space_id=7101)
+    service._require_permission_id.assert_any_await("folder", 3001, "view_folder", space_id=7101)
+    service._require_permission_id.assert_any_await("knowledge_file", 9001, "view_file", space_id=7101)
 
 
 @pytest.mark.asyncio
 async def test_resolve_qa_scope_file_ids_rejects_more_than_twenty_files(monkeypatch):
     service = object.__new__(svc_mod.KnowledgeSpaceService)
-    service.login_user = SimpleNamespace(user_id=7, user_name='tester')
+    service.login_user = SimpleNamespace(user_id=7, user_name="tester")
     service.version_repo = None
-    folder = _file(3001, folder=True, path='')
-    files = [_file(9100 + idx, path='/3001') for idx in range(21)]
+    folder = _file(3001, folder=True, path="")
+    files = [_file(9100 + idx, path="/3001") for idx in range(21)]
 
     async def _query_by_id(file_id):
         return folder if file_id == 3001 else None
@@ -91,13 +91,13 @@ async def test_resolve_qa_scope_file_ids_rejects_more_than_twenty_files(monkeypa
     async def _children_by_prefix(_space_id, _prefix, file_status=None):
         return files
 
-    monkeypatch.setattr(service, '_require_read_permission', AsyncMock())
-    monkeypatch.setattr(service, '_require_permission_id', AsyncMock())
-    monkeypatch.setattr(service, '_filter_visible_child_items', AsyncMock(side_effect=lambda items, **_kwargs: items))
-    monkeypatch.setattr(svc_mod.KnowledgeFileDao, 'query_by_id', _query_by_id)
-    monkeypatch.setattr(svc_mod.SpaceFileDao, 'get_children_by_prefix', _children_by_prefix)
+    monkeypatch.setattr(service, "_require_read_permission", AsyncMock())
+    monkeypatch.setattr(service, "_require_permission_id", AsyncMock())
+    monkeypatch.setattr(service, "_filter_visible_child_items", AsyncMock(side_effect=lambda items, **_kwargs: items))
+    monkeypatch.setattr(svc_mod.KnowledgeFileDao, "query_by_id", _query_by_id)
+    monkeypatch.setattr(svc_mod.SpaceFileDao, "get_children_by_prefix", _children_by_prefix)
 
-    with pytest.raises(ValueError, match='一次最多可选择20个文件进行问答。'):
+    with pytest.raises(ValueError, match="一次最多可选择20个文件进行问答。"):
         await service.resolve_qa_scope_file_ids(
             folder_refs=[SimpleNamespace(knowledge_space_id=7101, folder_id=3001)],
             file_refs=[],
@@ -532,9 +532,9 @@ async def test_portal_department_folder_stats_separate_discoverable_and_authoriz
 @pytest.mark.asyncio
 async def test_folder_extra_info_uses_visible_success_file_count(monkeypatch):
     service = object.__new__(svc_mod.KnowledgeSpaceService)
-    folder = _file(3001, folder=True, path='')
-    visible_file = _file(9001, path='/3001')
-    hidden_file = _file(9002, path='/3001')
+    folder = _file(3001, folder=True, path="")
+    visible_file = _file(9001, path="/3001")
+    hidden_file = _file(9002, path="/3001")
 
     class _ExecResult:
         def all(self):
@@ -552,126 +552,130 @@ async def test_folder_extra_info_uses_visible_success_file_count(monkeypatch):
 
     async def _children_by_prefix(space_id, prefix, file_status=None):
         assert space_id == 7101
-        assert prefix == '/3001'
+        assert prefix == "/3001"
         assert file_status == KnowledgeFileStatus.SUCCESS
         return [visible_file, hidden_file]
 
-    monkeypatch.setattr(core_database, 'get_async_db_session', lambda: _Session())
-    monkeypatch.setattr(svc_mod, 'get_async_db_session', lambda: _Session())
-    monkeypatch.setattr(svc_mod.SpaceFileDao, 'get_children_by_prefix', _children_by_prefix)
-    monkeypatch.setattr(service, '_build_child_permission_context', AsyncMock(return_value={}))
-    monkeypatch.setattr(service, '_filter_visible_child_items', AsyncMock(return_value=[visible_file]))
+    monkeypatch.setattr(core_database, "get_async_db_session", lambda: _Session())
+    monkeypatch.setattr(svc_mod, "get_async_db_session", lambda: _Session())
+    monkeypatch.setattr(svc_mod.SpaceFileDao, "get_children_by_prefix", _children_by_prefix)
+    monkeypatch.setattr(service, "_build_child_permission_context", AsyncMock(return_value={}))
+    monkeypatch.setattr(service, "_filter_visible_child_items", AsyncMock(return_value=[visible_file]))
 
     result = await service._handle_file_folder_extra_info([folder])
 
-    assert result[0]['success_file_num'] == 2
-    assert result[0]['visible_success_file_num'] == 1
+    assert result[0]["success_file_num"] == 2
+    assert result[0]["visible_success_file_num"] == 1
 
 
 @pytest.mark.asyncio
 async def test_get_space_folder_stats_returns_counts_in_request_order(monkeypatch):
     service = object.__new__(svc_mod.KnowledgeSpaceService)
-    service.login_user = SimpleNamespace(user_id=7, user_name='tester')
+    service.login_user = SimpleNamespace(user_id=7, user_name="tester")
 
-    folder_a = _file(3001, folder=True, path='')
-    folder_b = _file(3002, folder=True, path='')
+    folder_a = _file(3001, folder=True, path="")
+    folder_b = _file(3002, folder=True, path="")
 
     async def _get_files_by_ids(file_ids):
         assert file_ids == [3002, 3001]
         return [folder_a, folder_b]
 
-    monkeypatch.setattr(service, '_require_read_permission', AsyncMock())
-    monkeypatch.setattr(service, '_require_resource_permission', AsyncMock())
+    monkeypatch.setattr(service, "_require_read_permission", AsyncMock())
+    monkeypatch.setattr(service, "_require_resource_permission", AsyncMock())
     monkeypatch.setattr(
         service,
-        '_load_folder_stat_counts',
-        AsyncMock(return_value={
-            3001: {
-                'file_num': 7,
-                'success_file_num': 5,
-                'visible_success_file_num': 4,
-                'processing_file_num': 1,
-            },
-            3002: {
-                'file_num': 3,
-                'success_file_num': 2,
-                'visible_success_file_num': 2,
-                'processing_file_num': 0,
-            },
-        }),
+        "_load_folder_stat_counts",
+        AsyncMock(
+            return_value={
+                3001: {
+                    "file_num": 7,
+                    "success_file_num": 5,
+                    "visible_success_file_num": 4,
+                    "processing_file_num": 1,
+                },
+                3002: {
+                    "file_num": 3,
+                    "success_file_num": 2,
+                    "visible_success_file_num": 2,
+                    "processing_file_num": 0,
+                },
+            }
+        ),
     )
-    monkeypatch.setattr(svc_mod.KnowledgeFileDao, 'aget_file_by_ids', staticmethod(_get_files_by_ids))
+    monkeypatch.setattr(svc_mod.KnowledgeFileDao, "aget_file_by_ids", staticmethod(_get_files_by_ids))
 
     result = await service.get_space_folder_stats(7101, [3002, 3001, 3002])
 
     assert result == {
-        'stats': [
+        "stats": [
             {
-                'folder_id': 3002,
-                'file_num': 3,
-                'success_file_num': 2,
-                'visible_success_file_num': 2,
-                'processing_file_num': 0,
+                "folder_id": 3002,
+                "file_num": 3,
+                "success_file_num": 2,
+                "visible_success_file_num": 2,
+                "processing_file_num": 0,
             },
             {
-                'folder_id': 3001,
-                'file_num': 7,
-                'success_file_num': 5,
-                'visible_success_file_num': 4,
-                'processing_file_num': 1,
+                "folder_id": 3001,
+                "file_num": 7,
+                "success_file_num": 5,
+                "visible_success_file_num": 4,
+                "processing_file_num": 1,
             },
         ]
     }
     service._require_read_permission.assert_awaited_once_with(7101)
-    service._require_resource_permission.assert_any_await('can_read', 'folder', 3001)
-    service._require_resource_permission.assert_any_await('can_read', 'folder', 3002)
+    service._require_resource_permission.assert_any_await("can_read", "folder", 3001)
+    service._require_resource_permission.assert_any_await("can_read", "folder", 3002)
 
 
 @pytest.mark.asyncio
 async def test_get_space_folder_stats_applies_filters(monkeypatch):
     service = object.__new__(svc_mod.KnowledgeSpaceService)
-    service.login_user = SimpleNamespace(user_id=7, user_name='tester')
+    service.login_user = SimpleNamespace(user_id=7, user_name="tester")
 
-    space = SimpleNamespace(id=7101, index_name='idx')
-    folder = _file(3001, folder=True, path='')
+    space = SimpleNamespace(id=7101, index_name="idx")
+    folder = _file(3001, folder=True, path="")
 
     async def _get_files_by_ids(file_ids):
         assert file_ids == [3001]
         return [folder]
 
-    monkeypatch.setattr(service, '_require_read_permission', AsyncMock(return_value=space))
-    monkeypatch.setattr(service, '_require_resource_permission', AsyncMock())
+    monkeypatch.setattr(service, "_require_read_permission", AsyncMock(return_value=space))
+    monkeypatch.setattr(service, "_require_resource_permission", AsyncMock())
     monkeypatch.setattr(
         service,
-        '_load_filtered_folder_stat_counts',
-        AsyncMock(return_value={
-            3001: {
-                'file_num': 2,
-                'success_file_num': 1,
-                'visible_success_file_num': 1,
-                'processing_file_num': 1,
-            },
-        }),
+        "_load_filtered_folder_stat_counts",
+        AsyncMock(
+            return_value={
+                3001: {
+                    "file_num": 2,
+                    "success_file_num": 1,
+                    "visible_success_file_num": 1,
+                    "processing_file_num": 1,
+                },
+            }
+        ),
     )
-    monkeypatch.setattr(service, '_load_folder_stat_counts', AsyncMock())
-    monkeypatch.setattr(svc_mod.KnowledgeFileDao, 'aget_file_by_ids', staticmethod(_get_files_by_ids))
+    monkeypatch.setattr(service, "_load_folder_stat_counts", AsyncMock())
+    monkeypatch.setattr(svc_mod.KnowledgeFileDao, "aget_file_by_ids", staticmethod(_get_files_by_ids))
 
     result = await service.get_space_folder_stats(
         7101,
         [3001],
         file_status=[KnowledgeFileStatus.SUCCESS.value, KnowledgeFileStatus.WAITING.value],
-        keyword='制度',
+        keyword="制度",
         tag_ids=[11],
     )
 
     assert result == {
-        'stats': [
+        "stats": [
             {
-                'folder_id': 3001,
-                'file_num': 2,
-                'success_file_num': 1,
-                'visible_success_file_num': 1,
-                'processing_file_num': 1,
+                "folder_id": 3001,
+                "file_num": 2,
+                "success_file_num": 1,
+                "visible_success_file_num": 1,
+                "processing_file_num": 1,
             },
         ]
     }
@@ -679,7 +683,7 @@ async def test_get_space_folder_stats_applies_filters(monkeypatch):
         space=space,
         folders=[folder],
         file_status=[KnowledgeFileStatus.SUCCESS.value, KnowledgeFileStatus.WAITING.value],
-        keyword='制度',
+        keyword="制度",
         tag_ids=[11],
     )
     service._load_folder_stat_counts.assert_not_called()
@@ -689,81 +693,115 @@ async def test_get_space_folder_stats_applies_filters(monkeypatch):
 async def test_load_filtered_folder_stat_counts_aggregates_descendant_files(monkeypatch):
     service = object.__new__(svc_mod.KnowledgeSpaceService)
     service.version_repo = None
-    space = SimpleNamespace(id=7101, index_name='idx')
-    folder = _file(3001, folder=True, path='')
-    visible_success = _file(9001, path='/3001')
-    waiting = _file(9002, path='/3001/sub', status=KnowledgeFileStatus.WAITING.value)
-    outside = _file(9003, path='', status=KnowledgeFileStatus.SUCCESS.value)
+    space = SimpleNamespace(id=7101, index_name="idx")
+    folder = _file(3001, folder=True, path="")
+    visible_success = _file(9001, path="/3001")
+    waiting = _file(9002, path="/3001/sub", status=KnowledgeFileStatus.WAITING.value)
+    outside = _file(9003, path="", status=KnowledgeFileStatus.SUCCESS.value)
     captured = {}
 
     async def _aget_file_by_filters(*args, **kwargs):
-        captured['args'] = args
-        captured['kwargs'] = kwargs
+        captured["args"] = args
+        captured["kwargs"] = kwargs
         return [visible_success, waiting, outside]
 
-    monkeypatch.setattr(service, '_resolve_folder_stats_tag_file_ids', AsyncMock(return_value=[9001, 9002]))
-    monkeypatch.setattr(service, '_resolve_folder_stats_keyword_file_ids', AsyncMock(return_value=[9001]))
-    monkeypatch.setattr(service, '_build_child_permission_context', AsyncMock(return_value={}))
-    monkeypatch.setattr(service, '_filter_visible_child_items', AsyncMock(return_value=[visible_success]))
-    monkeypatch.setattr(svc_mod.KnowledgeFileDao, 'aget_file_by_filters', staticmethod(_aget_file_by_filters))
+    monkeypatch.setattr(service, "_resolve_folder_stats_tag_file_ids", AsyncMock(return_value=[9001, 9002]))
+    monkeypatch.setattr(service, "_resolve_folder_stats_keyword_file_ids", AsyncMock(return_value=[9001]))
+    monkeypatch.setattr(service, "_build_child_permission_context", AsyncMock(return_value={}))
+    monkeypatch.setattr(service, "_filter_visible_child_items", AsyncMock(return_value=[visible_success]))
+    monkeypatch.setattr(svc_mod.KnowledgeFileDao, "aget_file_by_filters", staticmethod(_aget_file_by_filters))
 
     result = await service._load_filtered_folder_stat_counts(
         space=space,
         folders=[folder],
         file_status=[KnowledgeFileStatus.SUCCESS.value, KnowledgeFileStatus.WAITING.value],
-        keyword='制度',
+        keyword="制度",
         tag_ids=[11],
     )
 
     assert result[3001] == {
-        'file_num': 2,
-        'success_file_num': 1,
-        'visible_success_file_num': 1,
-        'processing_file_num': 1,
+        "file_num": 2,
+        "success_file_num": 1,
+        "visible_success_file_num": 1,
+        "processing_file_num": 1,
     }
-    assert captured['args'][0] == 7101
-    assert captured['kwargs']['file_name'] == '制度'
-    assert captured['kwargs']['status'] == [
+    assert captured["args"][0] == 7101
+    assert captured["kwargs"]["file_name"] == "制度"
+    assert captured["kwargs"]["status"] == [
         KnowledgeFileStatus.SUCCESS.value,
         KnowledgeFileStatus.WAITING.value,
     ]
-    assert captured['kwargs']['file_ids'] == [9001, 9002]
-    assert captured['kwargs']['extra_file_ids'] == [9001]
-    assert captured['kwargs']['file_type'] == FileType.FILE.value
+    assert captured["kwargs"]["file_ids"] == [9001, 9002]
+    assert captured["kwargs"]["extra_file_ids"] == [9001]
+    assert captured["kwargs"]["file_type"] == FileType.FILE.value
+
+
+@pytest.mark.asyncio
+async def test_handle_file_folder_extra_info_exposes_business_domain_code_before_encoding(monkeypatch):
+    import json
+
+    service = object.__new__(svc_mod.KnowledgeSpaceService)
+    file_item = _file(4001)
+    file_item.split_rule = json.dumps({"business_domain_code": "EM"})
+    file_item.file_encoding = None
+    file_item.abstract = "summary"
+    file_item.thumbnails = None
+    file_item.similar_status = 0
+
+    monkeypatch.setattr(
+        svc_mod.KnowledgeSpaceService,
+        "_load_document_distribution_info",
+        AsyncMock(return_value={}),
+    )
+    monkeypatch.setattr(
+        svc_mod.KnowledgeSpaceService,
+        "_load_file_tags_batch",
+        AsyncMock(return_value={}),
+    )
+    monkeypatch.setattr(
+        svc_mod.KnowledgeSpaceService,
+        "get_logo_share_link",
+        staticmethod(lambda value: value),
+    )
+
+    result = await service._handle_file_folder_extra_info([file_item])
+
+    assert result[0]["business_domain_code"] == "EM"
+    assert result[0]["file_encoding"] is None
 
 
 @pytest.mark.asyncio
 async def test_handle_file_folder_extra_info_can_skip_folder_counts():
     service = object.__new__(svc_mod.KnowledgeSpaceService)
-    folder = _file(3001, folder=True, path='')
+    folder = _file(3001, folder=True, path="")
 
     result = await service._handle_file_folder_extra_info([folder], include_folder_counts=False)
 
-    assert result[0]['summary'] == ''
-    assert 'file_num' not in result[0]
-    assert 'success_file_num' not in result[0]
-    assert 'visible_success_file_num' not in result[0]
-    assert 'processing_file_num' not in result[0]
+    assert result[0]["summary"] == ""
+    assert "file_num" not in result[0]
+    assert "success_file_num" not in result[0]
+    assert "visible_success_file_num" not in result[0]
+    assert "processing_file_num" not in result[0]
 
 
 @pytest.mark.asyncio
 async def test_handle_file_folder_extra_info_uses_folder_count_override():
     service = object.__new__(svc_mod.KnowledgeSpaceService)
-    folder = _file(3001, folder=True, path='')
+    folder = _file(3001, folder=True, path="")
 
     result = await service._handle_file_folder_extra_info(
         [folder],
         folder_counts_override={
             3001: {
-                'file_num': 2,
-                'success_file_num': 1,
-                'visible_success_file_num': 1,
-                'processing_file_num': 1,
+                "file_num": 2,
+                "success_file_num": 1,
+                "visible_success_file_num": 1,
+                "processing_file_num": 1,
             },
         },
     )
 
-    assert result[0]['file_num'] == 2
-    assert result[0]['success_file_num'] == 1
-    assert result[0]['visible_success_file_num'] == 1
-    assert result[0]['processing_file_num'] == 1
+    assert result[0]["file_num"] == 2
+    assert result[0]["success_file_num"] == 1
+    assert result[0]["visible_success_file_num"] == 1
+    assert result[0]["processing_file_num"] == 1

--- a/src/frontend/client/src/pages/knowledge/SpaceDetail/FileTable.tsx
+++ b/src/frontend/client/src/pages/knowledge/SpaceDetail/FileTable.tsx
@@ -59,6 +59,7 @@ import {
     fileEncodingBusinessDomainLabel,
     normalizeEncodingCode,
     parseFileEncoding,
+    resolveFileBusinessDomainCode,
 } from "../portal/uploadMetadata";
 
 /** 状态列悬停：下载 / 更多 — 白底、细灰边、4px 圆角 */
@@ -818,9 +819,10 @@ export function FileTable({ files, selectedFiles, handleSelectAll, handleSelectF
         const fileCategoryCode = normalizeEncodingCode(
             nextDraft.fileCategoryCode ?? currentDraft.fileCategoryCode ?? parsed.fileCategoryCode,
         );
-        const businessDomainCode = normalizeEncodingCode(
-            nextDraft.businessDomainCode ?? currentDraft.businessDomainCode ?? parsed.businessDomainCode,
-        );
+        const businessDomainCode = resolveFileBusinessDomainCode(file, {
+            ...currentDraft,
+            ...nextDraft,
+        }, encodingPrefix);
         const normalizedSubcategoryCode = fileSubcategoryCode === undefined
             ? currentDraft.fileSubcategoryCode
             : normalizeEncodingCode(fileSubcategoryCode);
@@ -1170,9 +1172,7 @@ function FileRow({
     const selectedFileCategoryCode = normalizeEncodingCode(
         encodingDraft?.fileCategoryCode ?? parsedEncoding.fileCategoryCode,
     );
-    const selectedBusinessDomainCode = normalizeEncodingCode(
-        encodingDraft?.businessDomainCode ?? parsedEncoding.businessDomainCode,
-    );
+    const selectedBusinessDomainCode = resolveFileBusinessDomainCode(file, encodingDraft, encodingPrefix);
     const hasCurrentBusinessDomainOption = businessDomainOptions.some((option) => option.code === selectedBusinessDomainCode);
     const classificationEncodingText = selectedFileCategoryCode && selectedBusinessDomainCode
         ? composeFileEncoding(file.fileEncoding, selectedFileCategoryCode, selectedBusinessDomainCode, encodingPrefix)

--- a/src/frontend/client/src/pages/knowledge/portal/components/PortalInfoDrawer.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/components/PortalInfoDrawer.tsx
@@ -10,6 +10,7 @@ import {
     fileEncodingBusinessDomainLabel,
     normalizeEncodingCode,
     parseFileEncoding,
+    resolveFileBusinessDomainCode,
 } from "../uploadMetadata";
 import { formatFileSize } from "../utils";
 import {
@@ -181,9 +182,7 @@ export function PortalInfoDrawer({
     const selectedFileCategoryCode = normalizeEncodingCode(
         encodingDraft.fileCategoryCode ?? parsedEncoding.fileCategoryCode,
     );
-    const selectedBusinessDomainCode = normalizeEncodingCode(
-        encodingDraft.businessDomainCode ?? parsedEncoding.businessDomainCode,
-    );
+    const selectedBusinessDomainCode = resolveFileBusinessDomainCode(selectedFile, encodingDraft, encodingPrefix);
     const hasCurrentBusinessDomainOption = businessDomainOptions.some((option) => option.code === selectedBusinessDomainCode);
     const displayFileEncoding = selectedFileCategoryCode && selectedBusinessDomainCode
         ? composeFileEncoding(selectedFile?.fileEncoding, selectedFileCategoryCode, selectedBusinessDomainCode, encodingPrefix)
@@ -194,8 +193,10 @@ export function PortalInfoDrawer({
         const fileCategoryCode = normalizeEncodingCode(
             nextDraft.fileCategoryCode ?? encodingDraft.fileCategoryCode ?? parsedEncoding.fileCategoryCode,
         );
-        const businessDomainCode = normalizeEncodingCode(
-            nextDraft.businessDomainCode ?? encodingDraft.businessDomainCode ?? parsedEncoding.businessDomainCode,
+        const businessDomainCode = resolveFileBusinessDomainCode(
+            selectedFile,
+            { ...encodingDraft, ...nextDraft },
+            encodingPrefix,
         );
         const normalizedSubcategoryCode = fileSubcategoryCode === undefined
             ? encodingDraft.fileSubcategoryCode

--- a/src/frontend/client/src/pages/knowledge/portal/uploadMetadata.test.ts
+++ b/src/frontend/client/src/pages/knowledge/portal/uploadMetadata.test.ts
@@ -1,0 +1,18 @@
+import { resolveFileBusinessDomainCode } from "./uploadMetadata";
+
+describe("resolveFileBusinessDomainCode", () => {
+    it("prefers draft, then API field, then parsed file_encoding", () => {
+        expect(resolveFileBusinessDomainCode(
+            { businessDomainCode: "EM", fileEncoding: "SGGF-STD-PP-20260600000001" },
+            { businessDomainCode: "FI" },
+        )).toBe("FI");
+
+        expect(resolveFileBusinessDomainCode(
+            { businessDomainCode: "EM", fileEncoding: null },
+        )).toBe("EM");
+
+        expect(resolveFileBusinessDomainCode(
+            { businessDomainCode: null, fileEncoding: "SGGF-STD-PP-20260600000001" },
+        )).toBe("PP");
+    });
+});

--- a/src/frontend/client/src/pages/knowledge/portal/uploadMetadata.ts
+++ b/src/frontend/client/src/pages/knowledge/portal/uploadMetadata.ts
@@ -107,6 +107,22 @@ export function filterBusinessDomainOptionsByCodes(
     return options.filter((option) => allowedCodes.has(option.code));
 }
 
+/** Resolve business domain for display/edit: draft → API field → parsed file_encoding. */
+export function resolveFileBusinessDomainCode(
+    source: {
+        businessDomainCode?: string | null;
+        fileEncoding?: string | null;
+    } | null | undefined,
+    draft?: EncodingDraft,
+    fallbackPrefix = DEFAULT_ENCODING_PREFIX,
+): string {
+    return normalizeEncodingCode(
+        draft?.businessDomainCode
+        ?? source?.businessDomainCode
+        ?? parseFileEncoding(source?.fileEncoding, fallbackPrefix).businessDomainCode,
+    );
+}
+
 export function parseFileEncoding(
     encoding?: string | null,
     fallbackPrefix = DEFAULT_ENCODING_PREFIX,


### PR DESCRIPTION
## Summary
- Expose `business_domain_code` in knowledge space file list responses while files are still parsing, using the value saved in `split_rule` at upload time.
- Add `resolveFileBusinessDomainCode` on the client and use it in the file table and info drawer so selected business domains render before `file_encoding` is generated.

## Test plan
- [x] Frontend unit test: `src/frontend/client/src/pages/knowledge/portal/uploadMetadata.test.ts`
- [x] Backend unit test: `test/knowledge/test_portal_qa_tree_selection.py::test_handle_file_folder_extra_info_exposes_business_domain_code_before_encoding`
- [ ] Upload a file with a selected business domain and confirm the list shows it immediately while status is `解析中`
- [ ] After parsing completes, confirm the business domain still matches the selected value


Made with [Cursor](https://cursor.com)