### PR TITLE
fix(approval): keep route dialog scrollable with multi-AND conditions

### DIFF
--- a/src/frontend/platform/src/pages/ApprovalPage/index.tsx
+++ b/src/frontend/platform/src/pages/ApprovalPage/index.tsx
@@ -767,11 +767,12 @@ function RouteDialog({
 
   return (
     <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
-      <DialogContent className="max-w-lg">
-        <DialogHeader>
+      {/* Cap height and scroll the body so multi-AND conditions cannot push Save off-screen. */}
+      <DialogContent className="flex max-h-[90vh] max-w-lg flex-col overflow-hidden">
+        <DialogHeader className="shrink-0">
           <DialogTitle>{initial.id ? t("approvalPage.editRoute") : t("approvalPage.addRoute")}</DialogTitle>
         </DialogHeader>
-        <div className="space-y-4 py-2">
+        <div data-testid="route-dialog-body" className="min-h-0 flex-1 space-y-4 overflow-y-auto py-2">
           <label className="block text-sm text-text-secondary">
             {t("approvalPage.routeNameLabel")}
             <input
@@ -987,7 +988,7 @@ function RouteDialog({
             </label>
           )}
         </div>
-        <DialogFooter>
+        <DialogFooter className="shrink-0">
           <button
             type="button"
             onClick={onClose}

--- a/src/frontend/platform/src/test/approvalPage.test.tsx
+++ b/src/frontend/platform/src/test/approvalPage.test.tsx
@@ -909,6 +909,43 @@ describe("ApprovalPage", () => {
     });
   });
 
+  it("keeps the route dialog scrollable when multiple AND conditions are added", async () => {
+    const user = userEvent.setup();
+    listApprovalScenarioPresetsApi.mockResolvedValue([
+      {
+        scenario_code: "knowledge_space_create_request",
+        scenario_name: "知识空间创建审批",
+        handler_key: "knowledge_space_create_request",
+        condition_fields: ["applicant_role", "space_level", "applicant_department_id"],
+        approver_source_types: ["direct_user", "department_admin", "role_user"],
+      },
+    ]);
+    listApprovalScenariosApi.mockResolvedValue([
+      {
+        id: 34,
+        scenario_code: "knowledge_space_create_request",
+        scenario_name: "知识空间创建审批",
+        enabled: true,
+      },
+    ]);
+    listApprovalRoutesApi.mockResolvedValue([]);
+
+    render(<ApprovalPage />);
+    await screen.findAllByText("知识空间创建审批");
+
+    await user.click(screen.getByRole("button", { name: /新增分支/ }));
+    await screen.findByText("新增条件分支");
+
+    await user.click(screen.getByRole("button", { name: "添加条件" }));
+    await user.click(screen.getByRole("button", { name: "添加条件" }));
+    expect(screen.getByLabelText("条件 3 字段")).toBeInTheDocument();
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.className).toMatch(/max-h-\[90vh\]/);
+    expect(within(dialog).getByTestId("route-dialog-body")).toHaveClass("overflow-y-auto");
+    expect(within(dialog).getByRole("button", { name: "保存" })).toBeInTheDocument();
+  });
+
   it("keeps generic knowledge space source labels outside Shougang publish preset", async () => {
     const user = userEvent.setup();
     listApprovalScenarioPresetsApi.mockResolvedValue([


### PR DESCRIPTION
## Summary
- Fix approval route dialog overflowing the viewport when multiple AND conditions are added, which blocked scrolling and made Save unreachable
- Keep dialog body scrollable (`max-h-[90vh]`) with a sticky footer so Save stays visible
- Add regression coverage for the scrollable dialog layout

## Test plan
- [x] `npm test -- --run src/test/approvalPage.test.tsx` (23 passed)
- [ ] Platform 审批配置：新增/编辑条件分支，添加多条「且」条件后可滚动并保存
- [ ] 填写完整条件值后保存成功；仅选字段未填值时保存仍禁用（原有校验）


Made with [Cursor](https://cursor.com)