### PR TITLE
fix(portal): 新增/删除知识库后仅刷新当前分类列表

### DIFF
--- a/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.tsx
@@ -91,7 +91,7 @@ import { PortalUploadedFilesDrawer } from "./components/PortalUploadedFilesDrawe
 import { SpaceSidebar } from "./components/SpaceSidebar";
 import { usePortalApprovalBridge } from "./hooks/usePortalApprovalBridge";
 import { resolvePortalDeepLinkTarget, usePortalDeepLink } from "./hooks/usePortalDeepLink";
-import { usePortalSpaces } from "./hooks/usePortalSpaces";
+import { getSpacesLevelQueryKey, usePortalSpaces } from "./hooks/usePortalSpaces";
 import { usePortalUploadDialog } from "./hooks/usePortalUploadDialog";
 import {
     BUSINESS_DOMAIN_OPTIONS,
@@ -559,7 +559,10 @@ export default function PortalKnowledgeWorkbench() {
             if (activeSpace?.id === space.id) {
                 setActiveSpace(getNextActiveSpace(space.id));
             }
-            await queryClient.invalidateQueries({ queryKey: ["knowledgeSpaces"] });
+            // Only refresh the current category list — other levels are unchanged.
+            await queryClient.invalidateQueries({
+                queryKey: getSpacesLevelQueryKey(space.spaceLevel),
+            });
             showToast({ message: "知识库已删除", severity: NotificationSeverity.SUCCESS });
         } catch (error) {
             showToast({
@@ -2476,15 +2479,17 @@ export default function PortalKnowledgeWorkbench() {
             const result = await submitKnowledgeSpaceCreate(form);
 
             if (result.created && result.space) {
-                // 先等空间列表刷新（新空间进入 selectableSpaces），再切换当前空间；否则默认空间
-                // 守卫会在刷新完成前把 activeSpace 重置回默认库，导致“前往知识库”跳不到新空间。
-                await queryClient.invalidateQueries({ queryKey: ["knowledgeSpaces"] });
+                // Wait for this category's list to include the new space before switching;
+                // otherwise the default-space guard can reset activeSpace too early.
+                await queryClient.invalidateQueries({
+                    queryKey: getSpacesLevelQueryKey(result.space.spaceLevel ?? form.spaceLevel),
+                });
                 setActiveSpace(result.space);
                 showToast({ message: "创建知识库成功", severity: NotificationSeverity.SUCCESS });
                 return true;
             }
 
-            void queryClient.invalidateQueries({ queryKey: ["knowledgeSpaces"] });
+            // Approval-only: no space yet, so sidebar lists do not need a reload.
             showToast({ message: "已提交申请", severity: NotificationSeverity.SUCCESS });
             return { showSuccess: false };
         } catch (error) {

--- a/src/frontend/client/src/pages/knowledge/portal/hooks/usePortalSpaces.test.ts
+++ b/src/frontend/client/src/pages/knowledge/portal/hooks/usePortalSpaces.test.ts
@@ -1,5 +1,9 @@
 import { SpaceLevel, SpaceRole, type KnowledgeSpace } from "~/api/knowledge";
-import { resolveSpacePermissions } from "./usePortalSpaces";
+import {
+    getSpacesLevelQueryKey,
+    resolveSpacePermissions,
+    resolveSpacesListLevel,
+} from "./usePortalSpaces";
 
 const makeSpace = (overrides: Partial<KnowledgeSpace> = {}): KnowledgeSpace =>
     ({
@@ -10,6 +14,30 @@ const makeSpace = (overrides: Partial<KnowledgeSpace> = {}): KnowledgeSpace =>
         isFavorite: false,
         ...overrides,
     }) as KnowledgeSpace;
+
+describe("getSpacesLevelQueryKey", () => {
+    it("maps each category to its sidebar list query key", () => {
+        expect(getSpacesLevelQueryKey(SpaceLevel.PUBLIC)).toEqual(
+            ["knowledgeSpaces", "level", SpaceLevel.PUBLIC],
+        );
+        expect(getSpacesLevelQueryKey(SpaceLevel.DEPARTMENT)).toEqual(
+            ["knowledgeSpaces", "level", SpaceLevel.DEPARTMENT],
+        );
+        expect(getSpacesLevelQueryKey(SpaceLevel.PERSONAL)).toEqual(
+            ["knowledgeSpaces", "level", SpaceLevel.PERSONAL],
+        );
+        expect(getSpacesLevelQueryKey(SpaceLevel.TEAM)).toEqual(
+            ["knowledgeSpaces", "level", SpaceLevel.TEAM],
+        );
+    });
+
+    it("maps TEAM_KS onto the shared team list query", () => {
+        expect(resolveSpacesListLevel(SpaceLevel.TEAM_KS)).toBe(SpaceLevel.TEAM);
+        expect(getSpacesLevelQueryKey(SpaceLevel.TEAM_KS)).toEqual(
+            ["knowledgeSpaces", "level", SpaceLevel.TEAM],
+        );
+    });
+});
 
 describe("resolveSpacePermissions（个人知识库只有编辑功能）", () => {
     it("个人库：即便是 creator 也不能删除、不能授权", () => {

--- a/src/frontend/client/src/pages/knowledge/portal/hooks/usePortalSpaces.ts
+++ b/src/frontend/client/src/pages/knowledge/portal/hooks/usePortalSpaces.ts
@@ -76,6 +76,19 @@ function getSpaceGroupKey(space?: Pick<KnowledgeSpace, "spaceLevel"> | null): Sp
     }
 }
 
+/**
+ * Map a space level to the list-query level used by `usePortalSpaces`.
+ * TEAM_KS shares the team sidebar group / query with TEAM.
+ */
+export function resolveSpacesListLevel(spaceLevel: SpaceLevel): SpaceLevel {
+    return spaceLevel === SpaceLevel.TEAM_KS ? SpaceLevel.TEAM : spaceLevel;
+}
+
+/** React Query key for the portal sidebar list of one space category. */
+export function getSpacesLevelQueryKey(spaceLevel: SpaceLevel) {
+    return ["knowledgeSpaces", "level", resolveSpacesListLevel(spaceLevel)] as const;
+}
+
 export function usePortalSpaces({
     activeSpace,
     setActiveSpace,


### PR DESCRIPTION
## Summary
- 门户知识库侧栏在新增/删除空间后，只 invalidate 当前分类的 `knowledgeSpaces` level 查询，不再全量刷新所有分组。
- 审批仅提交、尚未建库时不再触发无意义的列表刷新。
- 补充 `getSpacesLevelQueryKey` / `TEAM_KS → TEAM` 映射单测。

## Test plan
- [x] `npx jest --testPathPattern='usePortalSpaces\.test' --watchAll=false`
- [ ] 门户联调：在公共/部门/团队分组新建知识库，确认仅该分组列表更新并切到新库
- [ ] 门户联调：删除当前分类下知识库，确认仅该分组列表更新，其它分组无多余请求
- [ ] 审批创建路径：提交申请后侧栏不因空刷新闪动


Made with [Cursor](https://cursor.com)