### PR TITLE
feat(portal): add category-file-counts aggregation API

### DIFF
--- a/src/backend/bisheng/knowledge/api/endpoints/shougang_portal.py
+++ b/src/backend/bisheng/knowledge/api/endpoints/shougang_portal.py
@@ -30,6 +30,8 @@ from bisheng.knowledge.domain.schemas.knowledge_space_schema import (
     ShougangPortalDomainBindableSpacesResp,
     ShougangPortalDomainFileCountReq,
     ShougangPortalDomainFileCountResp,
+    ShougangPortalCategoryFileCountReq,
+    ShougangPortalCategoryFileCountResp,
     ShougangPortalFavoriteCreateReq,
     ShougangPortalFavoriteCreateResp,
     ShougangPortalFavoriteFilesResp,
@@ -279,6 +281,15 @@ async def count_shougang_portal_domain_files(
 ) -> Any:
     counts = await svc.count_shougang_portal_domain_files(req.domains)
     return resp_200(ShougangPortalDomainFileCountResp(counts=counts).model_dump(mode="json"))
+
+
+@router.post("/category-file-counts")
+async def count_shougang_portal_category_files(
+    req: ShougangPortalCategoryFileCountReq,
+    svc: Any = Depends(get_knowledge_space_service),
+) -> Any:
+    counts = await svc.count_shougang_portal_category_files(req.categories)
+    return resp_200(ShougangPortalCategoryFileCountResp(counts=counts).model_dump(mode="json"))
 
 
 @router.post("/home")

--- a/src/backend/bisheng/knowledge/domain/models/knowledge_file.py
+++ b/src/backend/bisheng/knowledge/domain/models/knowledge_file.py
@@ -12,6 +12,7 @@ from bisheng.common.models.base import SQLModelSerializable
 from bisheng.core.database import get_async_db_session, get_sync_db_session
 from bisheng.core.database.dialect_helpers import UPDATE_TIME_SERVER_DEFAULT, JsonType
 from bisheng.database.base import async_get_count, get_count
+from bisheng.knowledge.domain.constants import parse_shougang_file_encoding_codes
 
 
 class KnowledgeFileStatus(int, Enum):
@@ -582,6 +583,53 @@ class KnowledgeFileDao(KnowledgeFileBase):
             code = parts[-2].strip().upper()
             if knowledge_id in normalized_scopes.get(code, set()):
                 canonical_ids_by_code[code].add(int(document_id or file_id))
+        return {code: len(canonical_ids_by_code[code]) for code in counts}
+
+    @classmethod
+    async def async_count_files_by_category_scopes(cls, category_space_ids: dict[str, set[int]]) -> dict[str, int]:
+        """Count successful files for each document-type and knowledge-space scope.
+
+        Document type comes from ``parse_shougang_file_encoding_codes`` (category segment),
+        matching portal/search filtering. LIKE prefilters may over-fetch; Python exact match
+        rejects rows whose category segment is not the requested code.
+        """
+        normalized_scopes = {
+            code.strip().upper(): {int(space_id) for space_id in space_ids if int(space_id) > 0}
+            for code, space_ids in category_space_ids.items()
+            if code and code.strip()
+        }
+        counts = dict.fromkeys(normalized_scopes, 0)
+        conditions = [
+            and_(
+                KnowledgeFile.knowledge_id.in_(space_ids),
+                col(KnowledgeFile.file_encoding).like(f"%-{code}-%"),
+            )
+            for code, space_ids in normalized_scopes.items()
+            if space_ids
+        ]
+        if not conditions:
+            return counts
+        statement = select(
+            KnowledgeFile.id,
+            KnowledgeFile.reference_document_id,
+            KnowledgeFile.knowledge_id,
+            KnowledgeFile.file_encoding,
+        ).where(
+            KnowledgeFile.file_type == FileType.FILE.value,
+            KnowledgeFile.status == KnowledgeFileStatus.SUCCESS.value,
+            col(KnowledgeFile.file_encoding).is_not(None),
+            or_(*conditions),
+            cls.active_inventory_predicate(),
+        )
+        async with get_async_db_session() as session:
+            rows = (await session.exec(statement)).all()
+        canonical_ids_by_code = {code: set() for code in normalized_scopes}
+        for file_id, document_id, knowledge_id, encoding in rows:
+            document_type, _ = parse_shougang_file_encoding_codes({"file_encoding": encoding})
+            if not document_type:
+                continue
+            if knowledge_id in normalized_scopes.get(document_type, set()):
+                canonical_ids_by_code[document_type].add(int(document_id or file_id))
         return {code: len(canonical_ids_by_code[code]) for code in counts}
 
     @classmethod

--- a/src/backend/bisheng/knowledge/domain/schemas/knowledge_space_schema.py
+++ b/src/backend/bisheng/knowledge/domain/schemas/knowledge_space_schema.py
@@ -5,7 +5,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from bisheng.common.models.space_channel_member import UserRoleEnum
-from bisheng.knowledge.domain.constants import normalize_business_domain_code
+from bisheng.knowledge.domain.constants import normalize_business_domain_code, normalize_file_category_code
 from bisheng.knowledge.domain.models.knowledge import AuthTypeEnum, KnowledgeBase
 from bisheng.knowledge.domain.models.knowledge_file import KnowledgeFileRead
 from bisheng.knowledge.domain.models.knowledge_space_scope import (
@@ -379,6 +379,29 @@ class ShougangPortalDomainFileCountReq(BaseModel):
 
 
 class ShougangPortalDomainFileCountResp(BaseModel):
+    counts: dict[str, int] = Field(default_factory=dict)
+
+
+class ShougangPortalCategoryFileCountItem(BaseModel):
+    code: str = Field(..., max_length=16, description="Primary document-type / file-category code")
+    space_ids: list[int] = Field(
+        default_factory=list, max_length=200, description="Visible candidate knowledge space IDs"
+    )
+
+    @field_validator("code", mode="before")
+    @classmethod
+    def normalize_code(cls, value: Any):
+        normalized = normalize_file_category_code(value)
+        if not normalized:
+            raise ValueError("file category code is invalid")
+        return normalized
+
+
+class ShougangPortalCategoryFileCountReq(BaseModel):
+    categories: list[ShougangPortalCategoryFileCountItem] = Field(default_factory=list, max_length=200)
+
+
+class ShougangPortalCategoryFileCountResp(BaseModel):
     counts: dict[str, int] = Field(default_factory=dict)
 
 

--- a/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
+++ b/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
@@ -188,6 +188,7 @@ from bisheng.knowledge.domain.schemas.knowledge_space_schema import (
     ShougangPortalAdvancedFileSearchReq,
     ShougangPortalDomainBindableSpaceResp,
     ShougangPortalDomainFileCountItem,
+    ShougangPortalCategoryFileCountItem,
     ShougangPortalFavoriteCreateReq,
     ShougangPortalFavoriteCreateResp,
     ShougangPortalFavoriteFileItem,
@@ -4814,6 +4815,18 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 int(space.id) for space in spaces if space.id is not None
             )
         return await KnowledgeFileDao.async_count_files_by_domain_scopes(visible_scopes)
+
+    async def count_shougang_portal_category_files(
+        self,
+        categories: list[ShougangPortalCategoryFileCountItem],
+    ) -> dict[str, int]:
+        visible_scopes: dict[str, set[int]] = {}
+        for category in categories:
+            spaces = await self._get_shougang_portal_visible_search_spaces(category.space_ids, None)
+            visible_scopes.setdefault(category.code, set()).update(
+                int(space.id) for space in spaces if space.id is not None
+            )
+        return await KnowledgeFileDao.async_count_files_by_category_scopes(visible_scopes)
 
     async def get_shougang_portal_home(self, req: ShougangPortalHomeReq) -> dict:
         result = await self._get_shougang_portal_home_sections(req)

--- a/src/backend/test/test_shougang_domain_file_counts_dao.py
+++ b/src/backend/test/test_shougang_domain_file_counts_dao.py
@@ -139,3 +139,60 @@ async def test_count_files_by_domain_scopes_only_counts_matching_visible_spaces(
 
     # 11 不在 PP 可见空间；最后一条的业务域是 QM，但 10 不在 QM 可见空间。
     assert result == {'PP': 1, 'QM': 1}
+
+
+@pytest.mark.asyncio
+async def test_count_files_by_category_scopes_only_counts_matching_visible_spaces():
+    class FakeResult:
+        def all(self):
+            return [
+                (1, None, 10, 'GF-STD-PP-001'),
+                (2, None, 11, 'GF-STD-PP-002'),
+                (3, None, 20, 'GF-RPT-QM-003'),
+                # LIKE %-STD-% matches, but category segment is RPT (before QM).
+                (4, None, 10, 'GF-EXTRA-STD-RPT-QM-005'),
+            ]
+
+    class FakeSession:
+        async def exec(self, statement):
+            self.statement = statement
+            return FakeResult()
+
+    session = FakeSession()
+    with _patch_session_factory(session):
+        result = await KnowledgeFileDao.async_count_files_by_category_scopes(
+            {'STD': {10}, 'RPT': {20}},
+        )
+
+    # space 11 not in STD scope; GF-EXTRA-STD-RPT-QM-005 is RPT but space 10 not in RPT scope
+    assert result == {'STD': 1, 'RPT': 1}
+
+
+@pytest.mark.asyncio
+async def test_count_files_by_category_scopes_rejects_like_overfetch():
+    class FakeResult:
+        def all(self):
+            return [
+                # LIKE %-STD-% matches because STD sits in a non-category segment;
+                # parse yields document type RPT, domain QM.
+                (1, None, 10, 'GF-STD-EXTRA-RPT-QM-001'),
+                (2, None, 10, 'GF-STD-PP-002'),
+            ]
+
+    class FakeSession:
+        async def exec(self, statement):
+            return FakeResult()
+
+    session = FakeSession()
+    with _patch_session_factory(session):
+        result = await KnowledgeFileDao.async_count_files_by_category_scopes(
+            {'STD': {10}},
+        )
+
+    assert result == {'STD': 1}
+
+
+@pytest.mark.asyncio
+async def test_count_files_by_category_scopes_empty_space_returns_zero():
+    result = await KnowledgeFileDao.async_count_files_by_category_scopes({'STD': set()})
+    assert result == {'STD': 0}

--- a/src/backend/test/test_shougang_portal_endpoint.py
+++ b/src/backend/test/test_shougang_portal_endpoint.py
@@ -188,6 +188,10 @@ class _FakeKnowledgeSpaceService:
         self.requested_codes = domains
         return {"PP": 5, "QM": 2}
 
+    async def count_shougang_portal_category_files(self, categories):
+        self.requested_categories = categories
+        return {"STD": 7, "RPT": 3}
+
     async def get_shougang_portal_home(self, req):
         return {
             "sections": {
@@ -597,6 +601,35 @@ async def test_shougang_portal_domain_file_counts_delegates_to_service(monkeypat
         {"code": "QM", "space_ids": [13]},
     ]
     assert response.data["counts"] == {"PP": 5, "QM": 2}
+
+
+@pytest.mark.asyncio
+async def test_shougang_portal_category_file_counts_delegates_to_service(monkeypatch: pytest.MonkeyPatch):
+    endpoint_module_name = 'bisheng.knowledge.api.endpoints.shougang_portal'
+    previous_endpoint_module = sys.modules.get(endpoint_module_name)
+    sys.modules.pop(endpoint_module_name, None)
+    try:
+        endpoint = _load_shougang_portal_endpoint(monkeypatch)
+        fake_service = _FakeKnowledgeSpaceService()
+        req = endpoint.ShougangPortalCategoryFileCountReq(
+            categories=[
+                {"code": "STD", "space_ids": [11, 12]},
+                {"code": "RPT", "space_ids": [13]},
+            ]
+        )
+        response = await endpoint.count_shougang_portal_category_files(req, svc=fake_service)
+    finally:
+        if previous_endpoint_module is None:
+            sys.modules.pop(endpoint_module_name, None)
+        else:
+            sys.modules[endpoint_module_name] = previous_endpoint_module
+
+    assert response.status_code == 200
+    assert [item.model_dump() for item in fake_service.requested_categories] == [
+        {"code": "STD", "space_ids": [11, 12]},
+        {"code": "RPT", "space_ids": [13]},
+    ]
+    assert response.data["counts"] == {"STD": 7, "RPT": 3}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Batch-count successful files by document type and visible space scopes for home category navigation.

## What

简要描述做了什么改动。

## Why

为什么需要这个改动？

## How

实现方式、设计决策（如有）。

## Test

- [ ] 本地测试通过
- [ ] 114 测试服务器验证通过

## Related

- Issue/ticket:
