### PR TITLE
fix(knowledge): lock business domain while parsing; scope review-tag dept admin

### DIFF
--- a/src/backend/bisheng/common/errcode/tag.py
+++ b/src/backend/bisheng/common/errcode/tag.py
@@ -4,52 +4,73 @@ from .base import BaseErrorCode
 # Label module related return error code, function module code:107
 class TagExistError(BaseErrorCode):
     Code: int = 10700
-    Msg: str = 'Tag already exist'
+    Msg: str = "Tag already exist"
 
 
 class TagNotExistError(BaseErrorCode):
     Code: int = 10701
-    Msg: str = 'No tags found'
+    Msg: str = "No tags found"
 
 
 class ReviewTagParamIsEmptyError(BaseErrorCode):
     Code: int = 10702
-    Msg: str = 'Review tag param is empty'
+    Msg: str = "Review tag param is empty"
+
 
 class ReviewTagTypeMismatchError(BaseErrorCode):
     Code: int = 10703
-    Msg: str = 'Review tag type mismatch'
-    
+    Msg: str = "Review tag type mismatch"
+
 
 class ReviewTagNotFoundError(BaseErrorCode):
     Code: int = 10704
-    Msg: str = 'Review tag not found'
-    
+    Msg: str = "Review tag not found"
+
+
 class NewTagExistedError(BaseErrorCode):
     Code: int = 10705
-    Msg: str = 'New tag already exist'
+    Msg: str = "New tag already exist"
+
 
 class OriginalTagNotFoundError(BaseErrorCode):
     Code: int = 10706
-    Msg: str = 'Original tag not found'
+    Msg: str = "Original tag not found"
+
 
 class TagLibraryNotFoundError(BaseErrorCode):
     Code: int = 10707
-    Msg: str = 'Tag library not found'
+    Msg: str = "Tag library not found"
+
 
 class TargetTagInUsedError(BaseErrorCode):
     Code: int = 10708
-    Msg: str = 'Target tag is in used'
+    Msg: str = "Target tag is in used"
 
 
 class TagNameParamsIsEmptyError(BaseErrorCode):
     Code: int = 10709
-    Msg: str = 'Tag name params is empty'
+    Msg: str = "Tag name params is empty"
+
 
 class TagPageParamsIsError(BaseErrorCode):
     Code: int = 10710
-    Msg: str = 'Tag page params is error'
+    Msg: str = "Tag page params is error"
+
 
 class TagPageSizeParamsIsError(BaseErrorCode):
     Code: int = 10711
-    Msg: str = 'Tag page size params is error'
+    Msg: str = "Tag page size params is error"
+
+
+class ReviewTagPermissionDeniedError(BaseErrorCode):
+    """Caller is not a workbench admin or org department admin for tag review."""
+
+    Code: int = 10712
+    Msg: str = "No permission to review tags"
+
+
+class ReviewTagSpaceOutOfScopeError(BaseErrorCode):
+    """Department admin attempted to review a tag outside managed spaces."""
+
+    Code: int = 10713
+    Msg: str = "Review tag is outside managed department spaces"

--- a/src/backend/bisheng/workstation/domain/repositories/review_tags_repository.py
+++ b/src/backend/bisheng/workstation/domain/repositories/review_tags_repository.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import delete, exists, func, select, update
+from sqlalchemy import Integer, cast, delete, exists, func, or_, select, update
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from bisheng.common.errcode.tag import (
@@ -12,6 +12,7 @@ from bisheng.common.errcode.tag import (
 from bisheng.core.storage.minio.minio_manager import get_minio_storage
 from bisheng.database.models.review_tags import ApproveOrRejectEnum, ReviewTag, ReviewTagLink
 from bisheng.database.models.tag import Tag, TagBusinessTypeEnum, TagResourceTypeEnum
+from bisheng.knowledge.domain.models.knowledge_file import KnowledgeFile
 from bisheng.workstation.domain.repositories.tags_repository import TagRepositoryImpl
 from bisheng.workstation.domain.schemas.review_tags_schema import ReviewTagSubmitterTarget
 
@@ -22,6 +23,44 @@ class ReviewTagsRepositoryImpl:
     def __init__(self, session: AsyncSession, tags_repository: TagRepositoryImpl):
         self.session = session
         self.tags_repository = tags_repository
+
+    def _pending_space_scope_clause(self, tenant_id: int, space_ids: set[int] | None):
+        """Restrict pending review tags to associations within ``space_ids``.
+
+        Matches either ``business_id`` on knowledge-space tags or an active
+        file link whose ``KnowledgeFile.knowledge_id`` is in scope.
+        """
+        if space_ids is None:
+            return None
+        if not space_ids:
+            # Empty managed set: match nothing.
+            return ReviewTag.id == -1
+        space_id_list = sorted(int(space_id) for space_id in space_ids)
+        space_id_strs = [str(space_id) for space_id in space_id_list]
+        business_match = ReviewTag.business_type.in_(
+            [
+                TagBusinessTypeEnum.KNOWLEDGE_SPACE.value,
+                TagBusinessTypeEnum.KNOWLEDGE.value,
+            ]
+        ) & ReviewTag.business_id.in_(space_id_strs)
+        link_match = exists(
+            select(1)
+            .select_from(ReviewTagLink)
+            .join(
+                KnowledgeFile,
+                # Compare as integers to avoid MySQL collation mismatches between
+                # CAST(id AS CHAR) and resource_id varchar collations.
+                KnowledgeFile.id == cast(ReviewTagLink.resource_id, Integer),
+            )
+            .where(
+                ReviewTagLink.tag_id == ReviewTag.id,
+                ReviewTagLink.tenant_id == tenant_id,
+                ReviewTagLink.is_deleted == False,  # noqa: E712
+                KnowledgeFile.tenant_id == tenant_id,
+                KnowledgeFile.knowledge_id.in_(space_id_list),
+            )
+        )
+        return or_(business_match, link_match)
 
     async def delete_review_tag_link(self, tag_id: int, tenant_id: int):
         await self.session.exec(
@@ -45,46 +84,139 @@ class ReviewTagsRepositoryImpl:
         )
         await self.delete_review_tag_link(tag_id, tenant_id)
 
-    async def approve_review_tag(self, tag_name: str, resource_type: TagResourceTypeEnum, tenant_id: int):
-        await self.session.exec(
-            delete(ReviewTagLink).where(
-                ReviewTagLink.tag_id.in_(
-                    select(ReviewTag.id).where(
-                        ReviewTag.name == tag_name,
-                        ReviewTag.tenant_id == tenant_id,
-                        ReviewTag.resource_type == resource_type,
-                        ReviewTag.is_deleted == False,
+    async def approve_review_tag(
+        self,
+        tag_name: str,
+        resource_type: TagResourceTypeEnum,
+        tenant_id: int,
+        space_ids: set[int] | None = None,
+    ):
+        """Hard-delete pending rows for ``tag_name``.
+
+        When ``space_ids`` is set, only in-scope file links are removed. The
+        ``ReviewTag`` row is deleted only when no active links remain — so other
+        departments' same-name file associations stay pending.
+        """
+        tags = await self.get_review_tag_list_by_tag_name(tag_name, resource_type, tenant_id, space_ids=space_ids)
+        if not tags:
+            return
+        for tag in tags:
+            if tag.id is None:
+                continue
+            if space_ids is None:
+                await self.session.exec(
+                    delete(ReviewTagLink).where(
+                        ReviewTagLink.tag_id == tag.id,
+                        ReviewTagLink.tenant_id == tenant_id,
                     )
-                ),
-                ReviewTagLink.tenant_id == tenant_id,
-            )
-        )
-        await self.session.exec(
-            delete(ReviewTag).where(
-                ReviewTag.name == tag_name,
-                ReviewTag.tenant_id == tenant_id,
-                ReviewTag.resource_type == resource_type,
-                ReviewTag.is_deleted == False,
-            )
-        )
+                )
+                await self.session.exec(
+                    delete(ReviewTag).where(
+                        ReviewTag.id == tag.id,
+                        ReviewTag.tenant_id == tenant_id,
+                    )
+                )
+                continue
+
+            in_scope_link_ids = await self._in_scope_link_ids_for_tag(int(tag.id), tenant_id, space_ids)
+            if in_scope_link_ids:
+                await self.session.exec(
+                    delete(ReviewTagLink).where(
+                        ReviewTagLink.id.in_(in_scope_link_ids),
+                        ReviewTagLink.tenant_id == tenant_id,
+                    )
+                )
+            remaining = await self.get_review_tag_link_list_by_tag_id([int(tag.id)], tenant_id)
+            if not remaining:
+                await self.session.exec(
+                    delete(ReviewTag).where(
+                        ReviewTag.id == tag.id,
+                        ReviewTag.tenant_id == tenant_id,
+                    )
+                )
 
     async def reject_review_tag(
-        self, tag_name: str, reject_reason: str, resource_type: TagResourceTypeEnum, tenant_id: int
+        self,
+        tag_name: str,
+        reject_reason: str,
+        resource_type: TagResourceTypeEnum,
+        tenant_id: int,
+        space_ids: set[int] | None = None,
     ):
-        await self.session.exec(
-            update(ReviewTag)
-            .where(
-                ReviewTag.name == tag_name, ReviewTag.tenant_id == tenant_id, ReviewTag.resource_type == resource_type
-            )
-            .values(
-                is_deleted=True,
-                reject_reason=reject_reason,
-                update_time=datetime.now(),
-                review_status=ApproveOrRejectEnum.REJECT.value,
-                review_time=datetime.now(),
-            )
-        )
-        await self.delete_review_tag_link_jilian(tag_name, resource_type, tenant_id)
+        """Soft-delete pending rows for ``tag_name``, optionally space-scoped.
+
+        Scoped reject only soft-deletes in-scope links. The parent ``ReviewTag``
+        is rejected only when no active links remain outside the scope.
+        """
+        tags = await self.get_review_tag_list_by_tag_name(tag_name, resource_type, tenant_id, space_ids=space_ids)
+        if not tags:
+            return
+        now = datetime.now()
+        for tag in tags:
+            if tag.id is None:
+                continue
+            if space_ids is None:
+                await self.session.exec(
+                    update(ReviewTag)
+                    .where(
+                        ReviewTag.id == tag.id,
+                        ReviewTag.tenant_id == tenant_id,
+                    )
+                    .values(
+                        is_deleted=True,
+                        reject_reason=reject_reason,
+                        update_time=now,
+                        review_status=ApproveOrRejectEnum.REJECT.value,
+                        review_time=now,
+                    )
+                )
+                await self.session.exec(
+                    update(ReviewTagLink)
+                    .where(
+                        ReviewTagLink.tag_id == tag.id,
+                        ReviewTagLink.tenant_id == tenant_id,
+                    )
+                    .values(is_deleted=True, update_time=now)
+                )
+                continue
+
+            in_scope_link_ids = await self._in_scope_link_ids_for_tag(int(tag.id), tenant_id, space_ids)
+            if in_scope_link_ids:
+                await self.session.exec(
+                    update(ReviewTagLink)
+                    .where(
+                        ReviewTagLink.id.in_(in_scope_link_ids),
+                        ReviewTagLink.tenant_id == tenant_id,
+                    )
+                    .values(is_deleted=True, update_time=now)
+                )
+            remaining = await self.get_review_tag_link_list_by_tag_id([int(tag.id)], tenant_id)
+            if not remaining:
+                await self.session.exec(
+                    update(ReviewTag)
+                    .where(
+                        ReviewTag.id == tag.id,
+                        ReviewTag.tenant_id == tenant_id,
+                    )
+                    .values(
+                        is_deleted=True,
+                        reject_reason=reject_reason,
+                        update_time=now,
+                        review_status=ApproveOrRejectEnum.REJECT.value,
+                        review_time=now,
+                    )
+                )
+
+    async def _pending_tag_ids_for_name(
+        self,
+        tag_name: str,
+        resource_type: TagResourceTypeEnum,
+        tenant_id: int,
+        *,
+        space_ids: set[int] | None = None,
+    ) -> list[int]:
+        tags = await self.get_review_tag_list_by_tag_name(tag_name, resource_type, tenant_id, space_ids=space_ids)
+        return [int(tag.id) for tag in tags or [] if tag.id is not None]
 
     async def delete_review_tag_link_jilian(self, tag_name: str, resource_type: TagResourceTypeEnum, tenant_id: int):
         await self.session.exec(
@@ -249,7 +381,14 @@ class ReviewTagsRepositoryImpl:
             )
         )
 
-    async def get_review_tag_group_list_by_page(self, page: int, page_size: int, tenant_id: int, keyword: str = ""):
+    async def get_review_tag_group_list_by_page(
+        self,
+        page: int,
+        page_size: int,
+        tenant_id: int,
+        keyword: str = "",
+        space_ids: set[int] | None = None,
+    ):
         where_clause = [
             ReviewTag.tenant_id == tenant_id,
             ReviewTag.is_deleted == False,
@@ -257,6 +396,9 @@ class ReviewTagsRepositoryImpl:
             ReviewTag.name.not_in(self._library_tag_name_subquery(tenant_id)),
             self._active_review_tag_link_exists(tenant_id),
         ]
+        scope_clause = self._pending_space_scope_clause(tenant_id, space_ids)
+        if scope_clause is not None:
+            where_clause.append(scope_clause)
         if keyword:
             where_clause.append(ReviewTag.name.like(f"%{keyword}%"))
 
@@ -273,7 +415,9 @@ class ReviewTagsRepositoryImpl:
         rows = result.all()
         return [{"name": row.name, "resource_type": row.resource_type} for row in rows]
 
-    async def get_review_tag_group_count_by_page(self, tenant_id: int, keyword: str = ""):
+    async def get_review_tag_group_count_by_page(
+        self, tenant_id: int, keyword: str = "", space_ids: set[int] | None = None
+    ):
         where_clause = [
             ReviewTag.tenant_id == tenant_id,
             ReviewTag.is_deleted == False,
@@ -281,6 +425,9 @@ class ReviewTagsRepositoryImpl:
             ReviewTag.name.not_in(self._library_tag_name_subquery(tenant_id)),
             self._active_review_tag_link_exists(tenant_id),
         ]
+        scope_clause = self._pending_space_scope_clause(tenant_id, space_ids)
+        if scope_clause is not None:
+            where_clause.append(scope_clause)
         if keyword:
             where_clause.append(ReviewTag.name.like(f"%{keyword}%"))
         subq = select(1).select_from(ReviewTag).where(*where_clause).group_by(ReviewTag.name, ReviewTag.resource_type)
@@ -307,9 +454,15 @@ class ReviewTagsRepositoryImpl:
         return None
 
     async def get_review_tag_resource_info_by_tag(
-        self, group_tag_name: str, resource_type: TagResourceTypeEnum, tenant_id: int
+        self,
+        group_tag_name: str,
+        resource_type: TagResourceTypeEnum,
+        tenant_id: int,
+        space_ids: set[int] | None = None,
     ):
-        tag_list = await self.get_review_tag_list_by_tag_name(group_tag_name, resource_type, tenant_id)
+        tag_list = await self.get_review_tag_list_by_tag_name(
+            group_tag_name, resource_type, tenant_id, space_ids=space_ids
+        )
         tag_library_id = self._resolve_review_tag_library_id(tag_list)
         knowledge_ids = list(
             dict.fromkeys(
@@ -320,6 +473,8 @@ class ReviewTagsRepositoryImpl:
                 and str(tag.business_id).isdigit()
             )
         )
+        if space_ids is not None:
+            knowledge_ids = [kid for kid in knowledge_ids if kid in space_ids]
         if tag_list and len(tag_list) > 0:
             minio_client = await get_minio_storage()
             resource_list = []
@@ -333,6 +488,13 @@ class ReviewTagsRepositoryImpl:
                         tag_link.resource_id, tenant_id
                     )
                     if knowledgefile:
+                        file_space_id = (
+                            int(knowledgefile.knowledge_id) if knowledgefile.knowledge_id is not None else None
+                        )
+                        if space_ids is not None and (file_space_id is None or file_space_id not in space_ids):
+                            continue
+                        if file_space_id is not None and file_space_id not in knowledge_ids:
+                            knowledge_ids.append(file_space_id)
                         if knowledgefile.object_name:
                             file_url = await minio_client.get_share_link(
                                 knowledgefile.object_name,
@@ -351,6 +513,7 @@ class ReviewTagsRepositoryImpl:
                         file_info["level"] = knowledgefile.level
                         file_info["file_level_path"] = knowledgefile.file_level_path
                         file_info["id"] = knowledgefile.id
+                        file_info["file_id"] = knowledgefile.id
                         file_info["knowledge_id"] = knowledgefile.knowledge_id
                         submit_time = tag_link.create_time or tag_create_time_by_id.get(tag_link.tag_id)
                         file_info["submit_time"] = submit_time.strftime("%Y-%m-%d %H:%M:%S") if submit_time else ""
@@ -381,7 +544,13 @@ class ReviewTagsRepositoryImpl:
         review_tag_link_list = await self.session.exec(statement)
         return review_tag_link_list.scalars().all()
 
-    async def get_review_tag_list_by_tag_name(self, tag_name: str, resource_type: TagResourceTypeEnum, tenant_id: int):
+    async def get_review_tag_list_by_tag_name(
+        self,
+        tag_name: str,
+        resource_type: TagResourceTypeEnum,
+        tenant_id: int,
+        space_ids: set[int] | None = None,
+    ):
         statement = select(ReviewTag).where(
             ReviewTag.name == tag_name,
             ReviewTag.tenant_id == tenant_id,
@@ -390,7 +559,49 @@ class ReviewTagsRepositoryImpl:
             ReviewTag.resource_type == resource_type,
         )
         review_tag_list = await self.session.exec(statement)
-        return review_tag_list.scalars().all()
+        tags = list(review_tag_list.scalars().all())
+        if space_ids is None:
+            return tags
+        scoped: list[ReviewTag] = []
+        for tag in tags:
+            # A single ReviewTag row may link files across departments; include it
+            # when any business_id or file link intersects managed spaces.
+            if await self.tag_intersects_space_scope(tag, tenant_id, space_ids):
+                scoped.append(tag)
+        return scoped
+
+    async def tag_intersects_space_scope(self, tag: ReviewTag, tenant_id: int, space_ids: set[int]) -> bool:
+        """Return True when the pending tag touches any space in ``space_ids``."""
+        if not space_ids:
+            return False
+        space_id = self._space_id_from_review_tag(tag)
+        if space_id is not None and int(space_id) in space_ids:
+            return True
+        if tag.id is None:
+            return False
+        link_ids = await self._in_scope_link_ids_for_tag(int(tag.id), tenant_id, space_ids)
+        return bool(link_ids)
+
+    async def _in_scope_link_ids_for_tag(self, tag_id: int, tenant_id: int, space_ids: set[int]) -> list[int]:
+        """Return active link ids whose file ``knowledge_id`` is in ``space_ids``."""
+        links = await self.get_review_tag_link_list_by_tag_id([tag_id], tenant_id)
+        in_scope: list[int] = []
+        for link in links or []:
+            if link.id is None:
+                continue
+            space_id, _, _, _ = await self._resolve_file_target_from_link(link, tenant_id)
+            if space_id is not None and int(space_id) in space_ids:
+                in_scope.append(int(link.id))
+        return in_scope
+
+    async def resolve_review_tag_space_id(self, tag: ReviewTag, tenant_id: int) -> int | None:
+        """Resolve a representative knowledge space id for a pending review tag row."""
+        space_id = self._space_id_from_review_tag(tag)
+        if space_id is not None:
+            return space_id
+        if tag.id is not None:
+            return await self._resolve_space_id_from_tag_links(int(tag.id), tenant_id)
+        return None
 
     @staticmethod
     def _parse_knowledge_space_id(business_id: str | None) -> int | None:
@@ -458,9 +669,10 @@ class ReviewTagsRepositoryImpl:
         tenant_id: int,
         *,
         exclude_user_id: int | None = None,
+        space_ids: set[int] | None = None,
     ) -> list[ReviewTagSubmitterTarget]:
         """Return unique submitters with their related knowledge space and file."""
-        tags = await self.get_review_tag_list_by_tag_name(tag_name, resource_type, tenant_id)
+        tags = await self.get_review_tag_list_by_tag_name(tag_name, resource_type, tenant_id, space_ids=space_ids)
         user_targets: dict[int, ReviewTagSubmitterTarget] = {}
 
         for tag in tags:
@@ -482,6 +694,8 @@ class ReviewTagsRepositoryImpl:
                 file_id = resolved_file
                 file_name = resolved_name
                 file_type = resolved_type
+            if space_ids is not None and (space_id is None or int(space_id) not in space_ids):
+                continue
             existing = user_targets.get(user_id)
             if existing is None or (existing.knowledge_space_id is None and space_id is not None):
                 user_targets[user_id] = ReviewTagSubmitterTarget(
@@ -506,6 +720,8 @@ class ReviewTagsRepositoryImpl:
                     space_id = self._space_id_from_review_tag(parent_tag) if parent_tag else None
                     if space_id is None and parent_tag and parent_tag.id is not None:
                         space_id = await self._resolve_space_id_from_tag_links(int(parent_tag.id), tenant_id)
+                if space_ids is not None and (space_id is None or int(space_id) not in space_ids):
+                    continue
                 user_targets[user_id] = ReviewTagSubmitterTarget(
                     user_id=user_id,
                     knowledge_space_id=space_id,

--- a/src/backend/bisheng/workstation/domain/services/workstation_tags_service.py
+++ b/src/backend/bisheng/workstation/domain/services/workstation_tags_service.py
@@ -6,6 +6,8 @@ from bisheng.common.dependencies.user_deps import UserPayload
 from bisheng.common.errcode.knowledge import KnowledgeSpaceTagLibraryInvalidError
 from bisheng.common.errcode.tag import (
     ReviewTagNotFoundError,
+    ReviewTagPermissionDeniedError,
+    ReviewTagSpaceOutOfScopeError,
     ReviewTagTypeMismatchError,
     TagNameParamsIsEmptyError,
     TagPageParamsIsError,
@@ -25,6 +27,8 @@ from bisheng.workstation.domain.services.review_tag_notification_service import 
 
 
 class WorkStationTagsService(BaseService):
+    """Workbench tag library and pending review-tag orchestration."""
+
     def __init__(
         self,
         request: Request,
@@ -38,11 +42,65 @@ class WorkStationTagsService(BaseService):
         self.review_tags_repository = review_tags_repository
         self.login_user = login_user
 
+    async def resolve_reviewable_space_ids(self) -> set[int] | None:
+        """Return managed space ids for the current reviewer.
+
+        ``None`` means full-tenant access (global super / RBAC admin / child
+        tenant admin). A ``set`` (possibly empty) means org department-admin
+        scope. Raises when the caller cannot review tags at all.
+        """
+        login_user = self.login_user
+        if bool(getattr(login_user, "is_global_super", False)):
+            return None
+        is_admin_fn = getattr(login_user, "is_admin", None)
+        if callable(is_admin_fn) and is_admin_fn():
+            return None
+
+        # Child tenant admin — same gate as Platform workbench config.
+        has_tenant_admin = getattr(login_user, "has_tenant_admin", None)
+        if callable(has_tenant_admin):
+            from bisheng.core.context.tenant import DEFAULT_TENANT_ID, get_current_tenant_id
+
+            tid = get_current_tenant_id()
+            if tid is None:
+                tid = getattr(login_user, "tenant_id", None)
+            if tid is not None and int(tid) != DEFAULT_TENANT_ID and await has_tenant_admin(int(tid)):
+                return None
+
+        from bisheng.database.models.department import DepartmentDao
+        from bisheng.knowledge.domain.models.department_knowledge_space import (
+            DepartmentKnowledgeSpaceDao,
+        )
+
+        admin_depts = await DepartmentDao.aget_user_admin_departments(int(login_user.user_id))
+        if not admin_depts:
+            raise ReviewTagPermissionDeniedError()
+
+        dept_ids: set[int] = set()
+        for dept in admin_depts:
+            if getattr(dept, "id", None) is None:
+                continue
+            dept_ids.add(int(dept.id))
+            path = getattr(dept, "path", None)
+            if path:
+                dept_ids.update(int(i) for i in await DepartmentDao.aget_subtree_ids(path))
+
+        bindings = await DepartmentKnowledgeSpaceDao.aget_by_department_ids(sorted(dept_ids))
+        return {int(binding.space_id) for binding in bindings or [] if getattr(binding, "space_id", None)}
+
+    def _ensure_knowledge_in_scope(self, knowledge_id: int | None, space_ids: set[int] | None) -> None:
+        """Reject approve when department admin picks a space outside scope."""
+        if space_ids is None:
+            return
+        if knowledge_id is None or int(knowledge_id) not in space_ids:
+            raise ReviewTagSpaceOutOfScopeError()
+
     async def delete_review_tag(
         self, tag_name: str, business_type: TagBusinessTypeEnum, resource_type: TagResourceTypeEnum, tenant_id: int
     ):
+        space_ids = await self.resolve_reviewable_space_ids()
         review_tag_list = await self.review_tags_repository.get_review_tag_list_by_tag_name(
-            tag_name, resource_type, tenant_id
+            tag_name, resource_type, tenant_id, space_ids=space_ids
         )
         if review_tag_list:
             for review_tag in review_tag_list:
@@ -52,16 +110,19 @@ class WorkStationTagsService(BaseService):
             await self.session.commit()
 
     async def approve_or_reject_review_tag(self, data: ApproveOrRejectRequest, tenant_id: int):
+        space_ids = await self.resolve_reviewable_space_ids()
         existed_tag_list = []
         submitter_targets = await self.review_tags_repository.list_submitter_notification_targets(
             data.tag_name,
             data.resource_type,
             tenant_id,
             exclude_user_id=self.login_user.user_id,
+            space_ids=space_ids,
         )
         if data and data.status == ApproveOrRejectEnum.APPROVE:
             if not data.tag_library_id or not data.knowledge_id:
                 raise KnowledgeSpaceTagLibraryInvalidError(msg="请选择导入的标签库")
+            self._ensure_knowledge_in_scope(data.knowledge_id, space_ids)
             from bisheng.database.models.tag import TagBusinessTypeEnum
             from bisheng.knowledge.domain.services.knowledge_space_tag_library_service import (
                 KnowledgeSpaceTagLibraryService,
@@ -71,7 +132,10 @@ class WorkStationTagsService(BaseService):
                 data.tag_name,
                 data.resource_type,
                 tenant_id,
+                space_ids=space_ids,
             )
+            if not review_tag_list:
+                raise ReviewTagNotFoundError.http_exception()
             bound_ids = await KnowledgeSpaceTagLibraryService.resolve_bound_library_ids(int(data.knowledge_id))
             tag_has_library = any(
                 getattr(tag, "business_type", None) == TagBusinessTypeEnum.TAG_LIBRARY.value
@@ -93,15 +157,23 @@ class WorkStationTagsService(BaseService):
                 data.resource_type,
                 tenant_id,
                 skip_library_add=True,
+                space_ids=space_ids,
             )
-            await self.review_tags_repository.approve_review_tag(data.tag_name, data.resource_type, tenant_id)
+            await self.review_tags_repository.approve_review_tag(
+                data.tag_name, data.resource_type, tenant_id, space_ids=space_ids
+            )
             await self.session.commit()
             from bisheng.knowledge.domain.services.tag_library_tag_service import TagLibraryTagService
 
             await TagLibraryTagService.invalidate_link_b_tenant_catalog_cache_async(tenant_id)
         elif data and data.status == ApproveOrRejectEnum.REJECT:
+            pending = await self.review_tags_repository.get_review_tag_list_by_tag_name(
+                data.tag_name, data.resource_type, tenant_id, space_ids=space_ids
+            )
+            if not pending:
+                raise ReviewTagNotFoundError.http_exception()
             await self.review_tags_repository.reject_review_tag(
-                data.tag_name, data.reject_reason, data.resource_type, tenant_id
+                data.tag_name, data.reject_reason, data.resource_type, tenant_id, space_ids=space_ids
             )
             await self.session.commit()
             from bisheng.knowledge.domain.services.tag_library_tag_service import TagLibraryTagService
@@ -141,9 +213,10 @@ class WorkStationTagsService(BaseService):
         tenant_id: int,
         *,
         skip_library_add: bool = False,
+        space_ids: set[int] | None = None,
     ):
         review_tag_list = await self.review_tags_repository.get_review_tag_list_by_tag_name(
-            tag_name, resource_type, tenant_id
+            tag_name, resource_type, tenant_id, space_ids=space_ids
         )
         existed_tag_list = []
         if not review_tag_list:
@@ -159,6 +232,16 @@ class WorkStationTagsService(BaseService):
             )
             if not review_tag_link:
                 review_tag_link = []
+            # When scoped, only move links whose file belongs to managed spaces.
+            if space_ids is not None:
+                filtered_links = []
+                for link in review_tag_link:
+                    space_id, _, _, _ = await self.review_tags_repository._resolve_file_target_from_link(
+                        link, tenant_id
+                    )
+                    if space_id is not None and int(space_id) in space_ids:
+                        filtered_links.append(link)
+                review_tag_link = filtered_links
             await self.review_tags_repository.approve_tag_to_move(
                 review_tag,
                 review_tag_link,
@@ -209,6 +292,7 @@ class WorkStationTagsService(BaseService):
         return result_list
 
     async def list_review_tag_by_page(self, page: int, page_size: int, tenant_id: int, keyword: str = ""):
+        space_ids = await self.resolve_reviewable_space_ids()
         if not page or page < 1:
             raise TagPageParamsIsError.http_exception()
         if not page_size or page_size < 1:
@@ -216,18 +300,18 @@ class WorkStationTagsService(BaseService):
 
         normalized_keyword = (keyword or "").strip()
         group_tag_list = await self.review_tags_repository.get_review_tag_group_list_by_page(
-            page, page_size, tenant_id, normalized_keyword
+            page, page_size, tenant_id, normalized_keyword, space_ids=space_ids
         )
         result_list = []
         if group_tag_list and len(group_tag_list) > 0:
             for group_tag in group_tag_list:
                 tag_obj = await self.review_tags_repository.get_review_tag_resource_info_by_tag(
-                    group_tag["name"], group_tag["resource_type"], tenant_id
+                    group_tag["name"], group_tag["resource_type"], tenant_id, space_ids=space_ids
                 )
                 if tag_obj:
                     result_list.append(tag_obj)
         total_count = await self.review_tags_repository.get_review_tag_group_count_by_page(
-            tenant_id, normalized_keyword
+            tenant_id, normalized_keyword, space_ids=space_ids
         )
         return {"data": result_list or [], "total": total_count or 0}
 

--- a/src/backend/test/workstation/test_review_tag_approve.py
+++ b/src/backend/test/workstation/test_review_tag_approve.py
@@ -32,7 +32,13 @@ def _build_tags_service() -> WorkStationTagsService:
     return WorkStationTagsService(
         request=MagicMock(),
         session=session,
-        login_user=SimpleNamespace(user_id=1, tenant_id=1),
+        login_user=SimpleNamespace(
+            user_id=1,
+            tenant_id=1,
+            is_global_super=True,
+            is_admin=lambda: True,
+            user_name="admin",
+        ),
         review_tags_repository=AsyncMock(),
     )
 
@@ -106,6 +112,7 @@ async def test_approve_review_tag_imports_to_selected_library():
         TagResourceTypeEnum.AI_AUTO_TAG,
         1,
         skip_library_add=True,
+        space_ids=None,
     )
     service.review_tags_repository.approve_review_tag.assert_awaited_once()
     service.session.commit.assert_awaited_once()
@@ -164,6 +171,9 @@ async def test_reject_review_tag_notifies_submitters():
         resource_type=TagResourceTypeEnum.MANUAL_TAG,
     )
     service.review_tags_repository.reject_review_tag = AsyncMock()
+    service.review_tags_repository.get_review_tag_list_by_tag_name = AsyncMock(
+        return_value=[SimpleNamespace(id=1, business_type="knowledge_space", business_id="137")],
+    )
     service.review_tags_repository.list_submitter_notification_targets = AsyncMock(
         return_value=[
             ReviewTagSubmitterTarget(

--- a/src/backend/test/workstation/test_review_tag_dept_admin_scope.py
+++ b/src/backend/test/workstation/test_review_tag_dept_admin_scope.py
@@ -1,0 +1,222 @@
+"""Unit tests for department-admin scoped review-tag authorization."""
+
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+base_service_stub = types.ModuleType("bisheng.common.services.base")
+
+
+class _BaseService:
+    pass
+
+
+base_service_stub.BaseService = _BaseService
+sys.modules["bisheng.common.services.base"] = base_service_stub
+workstation_tags_service = importlib.reload(
+    importlib.import_module("bisheng.workstation.domain.services.workstation_tags_service")
+)
+
+from bisheng.common.errcode.tag import (
+    ReviewTagPermissionDeniedError,
+    ReviewTagSpaceOutOfScopeError,
+)
+from bisheng.database.models.review_tags import ApproveOrRejectEnum, TagResourceTypeEnum
+from bisheng.workstation.domain.schemas.review_tags_schema import ApproveOrRejectRequest
+
+WorkStationTagsService = workstation_tags_service.WorkStationTagsService
+
+
+def _build_service(*, is_global_super: bool = False) -> WorkStationTagsService:
+    session = AsyncMock()
+    session.commit = AsyncMock()
+    return WorkStationTagsService(
+        request=MagicMock(),
+        session=session,
+        login_user=SimpleNamespace(
+            user_id=9,
+            tenant_id=1,
+            is_global_super=is_global_super,
+            is_admin=lambda: False,
+            has_tenant_admin=AsyncMock(return_value=False),
+            user_name="dept-admin",
+        ),
+        review_tags_repository=AsyncMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_reviewable_space_ids_denies_ordinary_user():
+    service = _build_service()
+    with patch(
+        "bisheng.database.models.department.DepartmentDao.aget_user_admin_departments",
+        new=AsyncMock(return_value=[]),
+    ):
+        with pytest.raises(ReviewTagPermissionDeniedError):
+            await service.resolve_reviewable_space_ids()
+
+
+@pytest.mark.asyncio
+async def test_resolve_reviewable_space_ids_for_department_admin():
+    service = _build_service()
+    admin_dept = SimpleNamespace(id=10, path="1/10/")
+    with (
+        patch(
+            "bisheng.database.models.department.DepartmentDao.aget_user_admin_departments",
+            new=AsyncMock(return_value=[admin_dept]),
+        ),
+        patch(
+            "bisheng.database.models.department.DepartmentDao.aget_subtree_ids",
+            new=AsyncMock(return_value=[10, 11]),
+        ),
+        patch(
+            "bisheng.knowledge.domain.models.department_knowledge_space.DepartmentKnowledgeSpaceDao.aget_by_department_ids",
+            new=AsyncMock(
+                return_value=[
+                    SimpleNamespace(space_id=100),
+                    SimpleNamespace(space_id=101),
+                ]
+            ),
+        ),
+    ):
+        space_ids = await service.resolve_reviewable_space_ids()
+
+    assert space_ids == {100, 101}
+
+
+@pytest.mark.asyncio
+async def test_list_review_tag_by_page_passes_space_scope():
+    service = _build_service()
+    service.resolve_reviewable_space_ids = AsyncMock(return_value={100})
+    service.review_tags_repository.get_review_tag_group_list_by_page = AsyncMock(
+        return_value=[{"name": "foo", "resource_type": TagResourceTypeEnum.MANUAL_TAG}]
+    )
+    service.review_tags_repository.get_review_tag_resource_info_by_tag = AsyncMock(
+        return_value={"tag_name": "foo", "resource_files": []}
+    )
+    service.review_tags_repository.get_review_tag_group_count_by_page = AsyncMock(return_value=1)
+
+    result = await service.list_review_tag_by_page(1, 10, tenant_id=1, keyword="fo")
+
+    assert result["total"] == 1
+    service.review_tags_repository.get_review_tag_group_list_by_page.assert_awaited_once_with(
+        1, 10, 1, "fo", space_ids={100}
+    )
+    service.review_tags_repository.get_review_tag_resource_info_by_tag.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_approve_rejects_knowledge_outside_scope():
+    service = _build_service()
+    service.resolve_reviewable_space_ids = AsyncMock(return_value={100})
+    service.review_tags_repository.list_submitter_notification_targets = AsyncMock(return_value=[])
+    data = ApproveOrRejectRequest(
+        tag_name="cross",
+        status=ApproveOrRejectEnum.APPROVE,
+        resource_type=TagResourceTypeEnum.MANUAL_TAG,
+        tag_library_id=1,
+        knowledge_id=999,
+    )
+
+    with pytest.raises(ReviewTagSpaceOutOfScopeError):
+        await service.approve_or_reject_review_tag(data, tenant_id=1)
+
+
+@pytest.mark.asyncio
+async def test_approve_passes_space_ids_to_repository():
+    service = _build_service()
+    service.resolve_reviewable_space_ids = AsyncMock(return_value={100})
+    data = ApproveOrRejectRequest(
+        tag_name="scoped",
+        status=ApproveOrRejectEnum.APPROVE,
+        resource_type=TagResourceTypeEnum.MANUAL_TAG,
+        tag_library_id=10,
+        knowledge_id=100,
+    )
+    service.approve_tag_to_move_operation = AsyncMock(return_value=[])
+    service.review_tags_repository.approve_review_tag = AsyncMock()
+    service.review_tags_repository.list_submitter_notification_targets = AsyncMock(return_value=[])
+    service.review_tags_repository.get_review_tag_list_by_tag_name = AsyncMock(
+        return_value=[SimpleNamespace(business_type="knowledge_space", business_id="100")],
+    )
+
+    with (
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_tag_library_service.KnowledgeSpaceTagLibraryService",
+        ) as library_service_cls,
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_tag_library_service.KnowledgeSpaceTagLibraryService.resolve_bound_library_ids",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "bisheng.workstation.domain.services.review_tag_notification_service.ReviewTagNotificationService.notify_after_decision",
+            new=AsyncMock(),
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.tag_library_tag_service.TagLibraryTagService.invalidate_link_b_tenant_catalog_cache_async",
+            new=AsyncMock(),
+        ),
+    ):
+        library_service_cls.return_value.append_review_tag = AsyncMock()
+        await service.approve_or_reject_review_tag(data, tenant_id=1)
+
+    service.review_tags_repository.approve_review_tag.assert_awaited_once_with(
+        "scoped",
+        TagResourceTypeEnum.MANUAL_TAG,
+        1,
+        space_ids={100},
+    )
+    service.approve_tag_to_move_operation.assert_awaited_once_with(
+        "scoped",
+        TagResourceTypeEnum.MANUAL_TAG,
+        1,
+        skip_library_add=True,
+        space_ids={100},
+    )
+
+
+@pytest.mark.asyncio
+async def test_reject_passes_space_ids_to_repository():
+    service = _build_service()
+    service.resolve_reviewable_space_ids = AsyncMock(return_value={100})
+    data = ApproveOrRejectRequest(
+        tag_name="scoped",
+        status=ApproveOrRejectEnum.REJECT,
+        reject_reason="bad",
+        resource_type=TagResourceTypeEnum.MANUAL_TAG,
+    )
+    service.review_tags_repository.reject_review_tag = AsyncMock()
+    service.review_tags_repository.get_review_tag_list_by_tag_name = AsyncMock(
+        return_value=[SimpleNamespace(id=1, business_type="knowledge_space", business_id="100")],
+    )
+    service.review_tags_repository.list_submitter_notification_targets = AsyncMock(return_value=[])
+
+    with (
+        patch(
+            "bisheng.workstation.domain.services.review_tag_notification_service.ReviewTagNotificationService.notify_after_decision",
+            new=AsyncMock(),
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.tag_library_tag_service.TagLibraryTagService.invalidate_link_b_tenant_catalog_cache_async",
+            new=AsyncMock(),
+        ),
+    ):
+        await service.approve_or_reject_review_tag(data, tenant_id=1)
+
+    service.review_tags_repository.reject_review_tag.assert_awaited_once_with(
+        "scoped",
+        "bad",
+        TagResourceTypeEnum.MANUAL_TAG,
+        1,
+        space_ids={100},
+    )
+
+
+@pytest.mark.asyncio
+async def test_global_super_has_full_scope():
+    service = _build_service(is_global_super=True)
+    assert await service.resolve_reviewable_space_ids() is None

--- a/src/frontend/client/src/pages/knowledge/SpaceDetail/FileTable.tsx
+++ b/src/frontend/client/src/pages/knowledge/SpaceDetail/FileTable.tsx
@@ -813,6 +813,8 @@ export function FileTable({ files, selectedFiles, handleSelectAll, handleSelectF
     ) => {
         if (!showEncodingClassification || file.type === FileType.FOLDER) return;
         if (!canEditFileMetadata(file)) return;
+        // Domain is part of the composed encoding; reject edits while parse is in flight.
+        if (nextDraft.businessDomainCode !== undefined && file.status === FileStatus.PROCESSING) return;
 
         const parsed = parseFileEncoding(file.fileEncoding, encodingPrefix);
         const currentDraft = encodingDrafts[file.id] ?? {};
@@ -1177,7 +1179,10 @@ function FileRow({
     const classificationEncodingText = selectedFileCategoryCode && selectedBusinessDomainCode
         ? composeFileEncoding(file.fileEncoding, selectedFileCategoryCode, selectedBusinessDomainCode, encodingPrefix)
         : fileEncodingText;
-    const encodingSelectClassName = "h-8 w-full min-w-0 rounded border border-[#dee2ec] bg-white px-2 text-sm text-[#4e5969] outline-none transition-colors focus:border-[#165dff] disabled:cursor-not-allowed disabled:bg-[#f7f8fa]";
+    // Encoding updates rewrite the composed file code; block domain edits while parse is in flight.
+    const isBusinessDomainLocked = file.status === FileStatus.PROCESSING;
+    // disabled:pointer-events-none lets the wrapper title tooltip show on hover.
+    const encodingSelectClassName = "h-8 w-full min-w-0 rounded border border-[#dee2ec] bg-white px-2 text-sm text-[#4e5969] outline-none transition-colors focus:border-[#165dff] disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-[#f7f8fa] disabled:text-[#86909c]";
     const editTagsButton = canEditTags ? (
         <button
             type="button"
@@ -1606,28 +1611,34 @@ function FileRow({
                         {isFolder ? (
                             <span className="truncate block">{EMPTY_FIELD_PLACEHOLDER}</span>
                         ) : canEditEncoding ? (
-                            <select
-                                className={encodingSelectClassName}
-                                aria-label={`修改${file.name}业务域类型 当前业务域：${selectedBusinessDomainCode || "未识别"}`}
-                                value={selectedBusinessDomainCode}
-                                disabled={savingEncoding}
-                                onClick={(event) => event.stopPropagation()}
-                                onChange={(event) => void onEncodingPartChange?.(file, { businessDomainCode: event.currentTarget.value })}
+                            // Wrap disabled select so hover tooltip still works (native title on :disabled is unreliable).
+                            <span
+                                className={cn("block w-full min-w-0", isBusinessDomainLocked && "cursor-not-allowed")}
+                                title={isBusinessDomainLocked ? "文档解析中无法更改" : undefined}
                             >
-                                {!selectedBusinessDomainCode ? (
-                                    <option value="" disabled>{EMPTY_FIELD_PLACEHOLDER}</option>
-                                ) : null}
-                                {selectedBusinessDomainCode && !hasCurrentBusinessDomainOption ? (
-                                    <option value={selectedBusinessDomainCode}>
-                                        {fileEncodingBusinessDomainLabel(selectedBusinessDomainCode, businessDomainOptions)}
-                                    </option>
-                                ) : null}
-                                {businessDomainOptions.map((option) => (
-                                    <option key={option.code} value={option.code}>
-                                        {option.code} / {option.name}
-                                    </option>
-                                ))}
-                            </select>
+                                <select
+                                    className={encodingSelectClassName}
+                                    aria-label={`修改${file.name}业务域类型 当前业务域：${selectedBusinessDomainCode || "未识别"}`}
+                                    value={selectedBusinessDomainCode}
+                                    disabled={savingEncoding || isBusinessDomainLocked}
+                                    onClick={(event) => event.stopPropagation()}
+                                    onChange={(event) => void onEncodingPartChange?.(file, { businessDomainCode: event.currentTarget.value })}
+                                >
+                                    {!selectedBusinessDomainCode ? (
+                                        <option value="" disabled>{EMPTY_FIELD_PLACEHOLDER}</option>
+                                    ) : null}
+                                    {selectedBusinessDomainCode && !hasCurrentBusinessDomainOption ? (
+                                        <option value={selectedBusinessDomainCode}>
+                                            {fileEncodingBusinessDomainLabel(selectedBusinessDomainCode, businessDomainOptions)}
+                                        </option>
+                                    ) : null}
+                                    {businessDomainOptions.map((option) => (
+                                        <option key={option.code} value={option.code}>
+                                            {option.code} / {option.name}
+                                        </option>
+                                    ))}
+                                </select>
+                            </span>
                         ) : (
                             <span className="truncate block" title={selectedBusinessDomainCode ? fileEncodingBusinessDomainLabel(selectedBusinessDomainCode, businessDomainOptions) : EMPTY_FIELD_PLACEHOLDER}>
                                 {selectedBusinessDomainCode ? fileEncodingBusinessDomainLabel(selectedBusinessDomainCode, businessDomainOptions) : EMPTY_FIELD_PLACEHOLDER}

--- a/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.module.css
+++ b/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.module.css
@@ -1674,7 +1674,16 @@
   border-color: #165dff;
 }
 
+.detailSelectLocked {
+  display: block;
+  width: 100%;
+  min-width: 0;
+  cursor: not-allowed;
+}
+
 .detailSelect:disabled {
+  /* pointer-events:none so the wrapper title tooltip still appears on hover */
+  pointer-events: none;
   cursor: not-allowed;
   background: #f7f8fa;
   color: #86909c;
@@ -2049,6 +2058,21 @@
   background: #fff;
   color: #273142;
   font-size: 12px;
+}
+
+.uploadRecordSelectLocked {
+  display: block;
+  width: 100%;
+  min-width: 0;
+  cursor: not-allowed;
+}
+
+.uploadRecordSelect:disabled {
+  /* pointer-events:none so the wrapper title tooltip still appears on hover */
+  pointer-events: none;
+  cursor: not-allowed;
+  background: #f7f8fa;
+  color: #86909c;
 }
 
 .uploadRecordReadonlyText {

--- a/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.test.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.test.tsx
@@ -2225,6 +2225,34 @@ describe("PortalKnowledgeWorkbench", () => {
         });
     });
 
+    test("disables business domain select while file is processing in the portal file list", async () => {
+        const personalSpace = makeSpace("personal-1", "设备部", {
+            role: SpaceRole.ADMIN,
+        });
+        const file = makeFile("201", "解析中文档.pdf", {
+            type: FileType.PDF,
+            status: FileStatus.PROCESSING,
+            fileEncoding: "SGGF-STD-EM-20260600000001",
+        });
+        jest.mocked(getGroupedSpacesApi).mockResolvedValue({
+            publicSpaces: [],
+            departmentSpaces: [],
+            teamSpaces: [],
+            personalSpaces: [personalSpace],
+        } as any);
+        jest.mocked(getSpaceChildrenApi).mockResolvedValue({
+            data: [file],
+            total: 1,
+        } as any);
+
+        renderWorkbench();
+
+        const fileRow = await screen.findByTestId("file-tree-row-201");
+        const businessDomainSelect = within(fileRow).getByLabelText("修改解析中文档.pdf业务域类型 当前业务域：EM") as HTMLSelectElement;
+        expect(businessDomainSelect).toHaveDisplayValue("EM / 能源");
+        expect(businessDomainSelect).toBeDisabled();
+    });
+
     test("uses the main work area as a full file list and covers it with preview until back", async () => {
         const personalSpace = makeSpace("personal-1", "信息", {
             role: SpaceRole.ADMIN,
@@ -4839,7 +4867,9 @@ describe("PortalKnowledgeWorkbench", () => {
 
         expect(within(drawer).getByText("解析中")).toHaveClass("uploadRecordStatusInfo");
         expect(getPortalCategoryButton(drawer, "修改解析中文档.pdf文件分类", "标准规范 / 标准规范")).toBeInTheDocument();
-        expect(within(drawer).getByLabelText("修改解析中文档.pdf业务域类型 当前业务域：EM")).toHaveDisplayValue("EM / 能源");
+        const businessDomainSelect = within(drawer).getByLabelText("修改解析中文档.pdf业务域类型 当前业务域：EM") as HTMLSelectElement;
+        expect(businessDomainSelect).toHaveDisplayValue("EM / 能源");
+        expect(businessDomainSelect).toBeDisabled();
     });
 
     test("shows double dash placeholders for empty uploaded record fields", async () => {

--- a/src/frontend/client/src/pages/knowledge/portal/components/PortalInfoDrawer.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/components/PortalInfoDrawer.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Copy, X } from "lucide-react";
 import type { KnowledgeFile, KnowledgeSpace } from "~/api/knowledge";
-import { SpaceLevel, SpaceRole, VisibilityType, getFileStatsApi } from "~/api/knowledge";
+import { FileStatus, SpaceLevel, SpaceRole, VisibilityType, getFileStatsApi } from "~/api/knowledge";
 import type { PanelKey, PortalFileCategoryGroupOption } from "../types";
 import {
     type BusinessDomainOptionItem,
@@ -190,6 +190,8 @@ export function PortalInfoDrawer({
 
     const handleEncodingPartChange = async (nextDraft: EncodingDraft, fileSubcategoryCode?: string | null) => {
         if (!selectedFile || !canEditEncoding) return;
+        // Domain is part of the composed encoding; reject edits while parse is in flight.
+        if (nextDraft.businessDomainCode !== undefined && selectedFile.status === FileStatus.PROCESSING) return;
         const fileCategoryCode = normalizeEncodingCode(
             nextDraft.fileCategoryCode ?? encodingDraft.fileCategoryCode ?? parsedEncoding.fileCategoryCode,
         );
@@ -251,36 +253,46 @@ export function PortalInfoDrawer({
         </div>
     );
 
-    const renderBusinessDomainItem = () => (
-        <div className={s.detailItem}>
-            <span className={s.detailLabel}>业务域类型</span>
-            {selectedFile && canEditEncoding ? (
-                <select
-                    className={s.detailSelect}
-                    aria-label={`修改${selectedFile.name}业务域类型 当前业务域：${selectedBusinessDomainCode || "未识别"}`}
-                    value={selectedBusinessDomainCode}
-                    disabled={savingEncoding}
-                    onChange={(event) => void handleEncodingPartChange({ businessDomainCode: event.currentTarget.value })}
-                >
-                    <option value="">未识别</option>
-                    {selectedBusinessDomainCode && !hasCurrentBusinessDomainOption ? (
-                        <option value={selectedBusinessDomainCode}>
-                            {fileEncodingBusinessDomainLabel(selectedBusinessDomainCode, businessDomainOptions)}
-                        </option>
-                    ) : null}
-                    {businessDomainOptions.map((option) => (
-                        <option key={option.code} value={option.code}>
-                            {option.code} / {option.name}
-                        </option>
-                    ))}
-                </select>
-            ) : (
-                <span className={s.detailValue}>
-                    {selectedFile ? fileEncodingBusinessDomainLabel(selectedBusinessDomainCode, businessDomainOptions) : "-"}
-                </span>
-            )}
-        </div>
-    );
+    const renderBusinessDomainItem = () => {
+        // Encoding updates rewrite the composed file code; block domain edits while parse is in flight.
+        const isBusinessDomainLocked = selectedFile?.status === FileStatus.PROCESSING;
+        return (
+            <div className={s.detailItem}>
+                <span className={s.detailLabel}>业务域类型</span>
+                {selectedFile && canEditEncoding ? (
+                    // Wrap disabled select so hover tooltip still works (native title on :disabled is unreliable).
+                    <span
+                        className={isBusinessDomainLocked ? s.detailSelectLocked : undefined}
+                        title={isBusinessDomainLocked ? "文档解析中无法更改" : undefined}
+                    >
+                        <select
+                            className={s.detailSelect}
+                            aria-label={`修改${selectedFile.name}业务域类型 当前业务域：${selectedBusinessDomainCode || "未识别"}`}
+                            value={selectedBusinessDomainCode}
+                            disabled={savingEncoding || isBusinessDomainLocked}
+                            onChange={(event) => void handleEncodingPartChange({ businessDomainCode: event.currentTarget.value })}
+                        >
+                            <option value="">未识别</option>
+                            {selectedBusinessDomainCode && !hasCurrentBusinessDomainOption ? (
+                                <option value={selectedBusinessDomainCode}>
+                                    {fileEncodingBusinessDomainLabel(selectedBusinessDomainCode, businessDomainOptions)}
+                                </option>
+                            ) : null}
+                            {businessDomainOptions.map((option) => (
+                                <option key={option.code} value={option.code}>
+                                    {option.code} / {option.name}
+                                </option>
+                            ))}
+                        </select>
+                    </span>
+                ) : (
+                    <span className={s.detailValue}>
+                        {selectedFile ? fileEncodingBusinessDomainLabel(selectedBusinessDomainCode, businessDomainOptions) : "-"}
+                    </span>
+                )}
+            </div>
+        );
+    };
 
     const renderFileEncodingItem = () => (
         <div className={s.detailItem}>

--- a/src/frontend/client/src/pages/knowledge/portal/components/PortalUploadedFilesDrawer.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/components/PortalUploadedFilesDrawer.tsx
@@ -379,6 +379,9 @@ export function PortalUploadedFilesDrawer({
         nextDraft: EncodingDraft,
         fileSubcategoryCode?: string | null,
     ) => {
+        // Domain is part of the composed encoding; reject edits while parse is in flight.
+        if (nextDraft.businessDomainCode !== undefined && record.status === FileStatus.PROCESSING) return;
+
         const parsed = parseFileEncoding(record.fileEncoding, encodingPrefix);
         const currentDraft = encodingDrafts[record.id] ?? {};
         const fileCategoryCode = normalizeEncodingCode(
@@ -526,6 +529,8 @@ export function PortalUploadedFilesDrawer({
                                 ?? parsedEncoding.businessDomainCode,
                             );
                             const selectedBusinessDomainText = selectedBusinessDomainCode || EMPTY_FIELD_PLACEHOLDER;
+                            // Encoding is rewritten during parse; keep domain read-only until it finishes.
+                            const isBusinessDomainLocked = record.status === FileStatus.PROCESSING;
                             const recordBusinessDomainOptions = filterBusinessDomainOptionsByCodes(
                                 businessDomainOptions,
                                 record.businessDomainCodes,
@@ -576,12 +581,16 @@ export function PortalUploadedFilesDrawer({
                                             }}
                                         />
                                     </span>
-                                    <span>
+                                    <span
+                                        // Wrap disabled select so hover tooltip still works (native title on :disabled is unreliable).
+                                        className={isBusinessDomainLocked ? s.uploadRecordSelectLocked : undefined}
+                                        title={isBusinessDomainLocked ? "文档解析中无法更改" : undefined}
+                                    >
                                         <select
                                             className={s.uploadRecordSelect}
                                             aria-label={`修改${recordName}业务域类型 当前业务域：${selectedBusinessDomainText}`}
                                             value={selectedBusinessDomainCode}
-                                            disabled={savingEncodingFileId === record.id}
+                                            disabled={savingEncodingFileId === record.id || isBusinessDomainLocked}
                                             onChange={(event) => void handleEncodingPartChange(record, { businessDomainCode: event.currentTarget.value })}
                                         >
                                             <option value="">{EMPTY_FIELD_PLACEHOLDER}</option>


### PR DESCRIPTION
## Summary
- 知识库文件列表 / 上传记录 / 属性抽屉：状态为「解析中」时禁用业务域下拉，悬停提示「文档解析中无法更改」。
- Workstation review-tag：组织部门管理员可审批，且变更限定在其管辖空间关联范围内，避免误伤其他部门同名待审标签。

## Test plan
- [ ] 上传记录中将文件状态置为解析中（`knowledgefile.status=1`），确认业务域下拉置灰，悬停可见「文档解析中无法更改」
- [ ] 文件列表中解析中文件业务域不可改；解析完成后可正常修改
- [ ] 属性抽屉对解析中文件同样禁用业务域
- [ ] 部门管理员可 list/approve/reject 管辖空间内的 review-tag；其他部门同名 pending 不受影响
- [ ] 相关前端/后端单测通过


Made with [Cursor](https://cursor.com)