### PR TITLE
fix(portal): open tag-review files via postMessage without iframe remount

### DIFF
--- a/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.module.css
+++ b/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.module.css
@@ -1420,6 +1420,22 @@
   font-weight: 600;
 }
 
+/* Ant Design Spin tip style: grey regular text + thin spinner */
+.stateLoading {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #8c8c8c;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 22px;
+}
+
+.stateLoadingIcon {
+  flex-shrink: 0;
+  color: #8c8c8c;
+}
+
 .toolRail {
   width: 44px;
   min-width: 44px;

--- a/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.test.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.test.tsx
@@ -83,6 +83,19 @@ const mockHandleDirectDuplicateOverwrite = jest.fn();
 const mockUseFileUpload = jest.fn();
 const mockUpdateFileTagsApi = jest.fn();
 let mockSearchParams = "";
+const mockSearchParamsListeners = new Set<() => void>();
+const mockSetSearchParams = jest.fn((nextInit: unknown) => {
+    const prev = new URLSearchParams(mockSearchParams);
+    const next = typeof nextInit === "function"
+        ? (nextInit as (prev: URLSearchParams) => URLSearchParams | Record<string, string> | string)(prev)
+        : nextInit;
+    mockSearchParams = (
+        next instanceof URLSearchParams
+            ? next
+            : new URLSearchParams(next as string | Record<string, string>)
+    ).toString();
+    mockSearchParamsListeners.forEach((listener) => listener());
+});
 let mockCreateSpaceConfirmResult: any;
 
 function createMockFileUpload(overrides: Record<string, any> = {}) {
@@ -104,10 +117,22 @@ function createMockFileUpload(overrides: Record<string, any> = {}) {
     };
 }
 
-jest.mock("react-router-dom", () => ({
-    ...jest.requireActual("react-router-dom"),
-    useSearchParams: () => [new URLSearchParams(mockSearchParams), jest.fn()],
-}));
+jest.mock("react-router-dom", () => {
+    const React = jest.requireActual("react") as typeof import("react");
+    return {
+        ...jest.requireActual("react-router-dom"),
+        useSearchParams: () => {
+            const [, bump] = React.useReducer((value: number) => value + 1, 0);
+            React.useEffect(() => {
+                mockSearchParamsListeners.add(bump);
+                return () => {
+                    mockSearchParamsListeners.delete(bump);
+                };
+            }, []);
+            return [new URLSearchParams(mockSearchParams), mockSetSearchParams];
+        },
+    };
+});
 
 jest.mock("~/Providers", () => ({
     useToastContext: () => ({
@@ -613,6 +638,22 @@ function openMyUploadsFromPortalShell() {
     });
 }
 
+function openKnowledgeFileFromPortalShell(payload: {
+    spaceId: string;
+    fileId: string;
+    fileName?: string;
+    openNonce?: string;
+}) {
+    act(() => {
+        window.dispatchEvent(new MessageEvent("message", {
+            data: {
+                type: "shougang-portal:open-knowledge-file",
+                ...payload,
+            },
+        }));
+    });
+}
+
 function getPortalCategoryButton(scope: HTMLElement, label: string, selectedText: string) {
     return within(scope).getByRole("button", {
         name: `${label} 当前选择：${selectedText}`,
@@ -636,6 +677,8 @@ function selectPortalSubcategory(
 describe("PortalKnowledgeWorkbench", () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        mockSearchParams = "";
+        mockSearchParamsListeners.clear();
         mockUseFileUpload.mockReturnValue(createMockFileUpload());
         mockUpdateFileTagsApi.mockResolvedValue(undefined);
         localStorage.removeItem("knowledge-view-mode");
@@ -2335,6 +2378,45 @@ describe("PortalKnowledgeWorkbench", () => {
         } as any);
 
         renderWorkbench("/knowledge-portal?spaceId=personal-1&fileId=201");
+
+        const preview = await screen.findByTestId("portal-preview-page");
+        expect(preview).toHaveTextContent("后端开发.md");
+        await waitFor(() => {
+            expect(getFilePreviewApi).toHaveBeenCalledWith("personal-1", "201");
+        });
+    });
+
+    test("opens a portal file from parent open-knowledge-file postMessage", async () => {
+        const personalSpace = makeSpace("personal-1", "信息", {
+            role: SpaceRole.ADMIN,
+        });
+        const file = makeFile("201", "后端开发.md", {
+            type: FileType.MD,
+        });
+        jest.mocked(getGroupedSpacesApi).mockResolvedValue({
+            publicSpaces: [],
+            departmentSpaces: [],
+            teamSpaces: [],
+            personalSpaces: [personalSpace],
+        } as any);
+        jest.mocked(getSpaceChildrenApi).mockResolvedValue({
+            data: [file],
+            total: 1,
+        } as any);
+        jest.mocked(searchSpaceChildrenApi).mockResolvedValue({
+            data: [file],
+            total: 1,
+        } as any);
+
+        renderWorkbench("/knowledge-portal");
+        await screen.findByTestId("portal-file-workspace");
+
+        openKnowledgeFileFromPortalShell({
+            spaceId: "personal-1",
+            fileId: "201",
+            fileName: "后端开发.md",
+            openNonce: "msg-1",
+        });
 
         const preview = await screen.findByTestId("portal-preview-page");
         expect(preview).toHaveTextContent("后端开发.md");

--- a/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type Dispatch, type DragEvent, type SetStateAction } from "react";
 import { useQueryClient } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
 import { useSearchParams } from "react-router-dom";
 import { useRecoilValue } from "recoil";
 import {
@@ -223,7 +224,7 @@ export default function PortalKnowledgeWorkbench() {
     const confirm = useConfirm();
     const queryClient = useQueryClient();
     const currentUser = useRecoilValue(store.user);
-    const [searchParams] = useSearchParams();
+    const [searchParams, setSearchParams] = useSearchParams();
     const portalDeepLinkTarget = useMemo(
         () => resolvePortalDeepLinkTarget(searchParams),
         [searchParams],
@@ -1328,11 +1329,39 @@ export default function PortalKnowledgeWorkbench() {
             } else if (type === "shougang-portal:open-document-chat") {
                 setActivePanel(null);
                 setAiDrawerOpen(true);
+            } else if (type === "shougang-portal:open-knowledge-file") {
+                // Parent keeps iframe.src stable and asks us to open a file via Client
+                // search params so usePortalDeepLink can reuse the existing restore path.
+                const spaceId = String(event.data?.spaceId ?? "").trim();
+                const fileId = String(event.data?.fileId ?? "").trim();
+                if (!spaceId || !fileId) return;
+                const fileName = String(event.data?.fileName ?? "").trim();
+                const folderId = String(event.data?.folderId ?? "").trim();
+                const folderName = String(event.data?.folderName ?? "").trim();
+                const openNonce = String(event.data?.openNonce ?? "").trim() || String(Date.now());
+                setSearchParams((prev) => {
+                    const next = new URLSearchParams(prev);
+                    next.set("spaceId", spaceId);
+                    next.set("fileId", fileId);
+                    if (fileName) next.set("fileName", fileName);
+                    else next.delete("fileName");
+                    if (folderId) {
+                        next.set("folderId", folderId);
+                        if (folderName) next.set("folderName", folderName);
+                        else next.delete("folderName");
+                    } else {
+                        next.delete("folderId");
+                        next.delete("folderName");
+                    }
+                    // Prefer parent-provided nonce so retry bursts share one restore key.
+                    next.set("openNonce", openNonce);
+                    return next;
+                }, { replace: true });
             }
         };
         window.addEventListener("message", handlePortalMessage);
         return () => window.removeEventListener("message", handlePortalMessage);
-    }, []);
+    }, [setSearchParams]);
 
     const {
         uploadInputRef,
@@ -1447,6 +1476,9 @@ export default function PortalKnowledgeWorkbench() {
 
     useEffect(() => {
         if (!selectedFile) return;
+        // Deep-link restore may select a file before search results / tree rows catch up;
+        // clearing here races with usePortalDeepLink and drops the preview.
+        if (isDeepLinkRestoring) return;
         // #4 收藏原地预览：selectedFile 是来自其它源空间的合成文件（不属于当前 activeSpace，
         // 自然不在其 displayedFiles 中），不应被此“列表中已不存在则关闭预览”的守卫清空。
         if (selectedFile.spaceId && selectedFile.spaceId !== activeSpace?.id) return;
@@ -1454,7 +1486,7 @@ export default function PortalKnowledgeWorkbench() {
         if (!exists) {
             setSelectedFile(null);
         }
-    }, [displayedFiles, selectedFile, activeSpace?.id]);
+    }, [displayedFiles, selectedFile, activeSpace?.id, isDeepLinkRestoring]);
 
     useEffect(() => {
         if (!permissionTarget) return;
@@ -2555,8 +2587,11 @@ export default function PortalKnowledgeWorkbench() {
                         <main className={s.portalNativeWorkspace} data-testid="portal-file-workspace">
                             {activeSpace ? (
                                 isDeepLinkRestoring ? (
-                                    <div className={s.stateBox}>
-                                        <div className={s.stateTitle}>正在恢复知识库位置...</div>
+                                    <div className={s.stateBox} role="status" aria-live="polite">
+                                        <div className={s.stateLoading}>
+                                            <Loader2 className={`${s.stateLoadingIcon} animate-spin`} size={16} aria-hidden="true" />
+                                            <span>加载中...</span>
+                                        </div>
                                     </div>
                                 ) : isActiveSpaceFavorite ? (
                                     <PortalFavoritesPanel

--- a/src/frontend/client/src/pages/knowledge/portal/hooks/usePortalDeepLink.ts
+++ b/src/frontend/client/src/pages/knowledge/portal/hooks/usePortalDeepLink.ts
@@ -15,6 +15,8 @@ export interface PortalDeepLinkTarget {
     folderName: string;
     fileId: string;
     fileName: string;
+    /** Forces re-apply when the same file is opened again via postMessage. */
+    openNonce: string;
     key: string;
 }
 
@@ -53,13 +55,16 @@ export const resolvePortalDeepLinkTarget = (searchParams: URLSearchParams): Port
     const folderName = getQueryValue(searchParams, ["folderName", "folder_name"]);
     const fileId = getQueryValue(searchParams, ["fileId", "documentId", "document_id"]);
     const fileName = getQueryValue(searchParams, ["name", "fileName", "documentName", "document_name"]);
+    const openNonce = getQueryValue(searchParams, ["openNonce", "open_nonce"]);
     return {
         spaceId,
         folderId,
         folderName,
         fileId,
         fileName,
-        key: `${spaceId}:${folderId}:${folderName}:${fileId}:${fileName}`,
+        openNonce,
+        // openNonce lets postMessage re-open the same file after the preview was closed.
+        key: `${spaceId}:${folderId}:${folderName}:${fileId}:${fileName}:${openNonce}`,
     };
 };
 
@@ -77,6 +82,8 @@ const createDeepLinkedFile = (target: PortalDeepLinkTarget, fileId: string): Kno
         id: fileId,
         name,
         type: resolveFileTypeFromName(name),
+        // Preview APIs expect a successful parse status; omit/waiting can block the viewer.
+        status: FileStatus.SUCCESS,
         tags: [],
         path: name,
         spaceId: target.spaceId,


### PR DESCRIPTION
## Summary
- Accept parent `shougang-portal:open-knowledge-file` messages and apply Client search params (with `openNonce`) so deep-link restore reuses the existing open path without remounting the embed.
- Skip clearing `selectedFile` while deep-link restore is in progress; mark deep-link fallback files as `SUCCESS` so preview is not blocked.
- Align deep-link loading UI with grey spinner + 「加载中...」; add coverage for the postMessage open path.

## Test plan
- [ ] From portal tag review, click a file source — Client opens preview without full iframe reload
- [ ] Re-open the same file after closing preview
- [ ] Cold load Client with `?spaceId=&fileId=` still restores preview
- [ ] `npx jest --testPathPattern=PortalKnowledgeWorkbench.test --testNamePattern='opens a portal file from parent open-knowledge-file|opens a deep-linked portal file preview'`


Made with [Cursor](https://cursor.com)