### PR TITLE
fix(portal): open tag-review files in folder without empty list

### DIFF
--- a/src/backend/bisheng/workstation/domain/repositories/review_tags_repository.py
+++ b/src/backend/bisheng/workstation/domain/repositories/review_tags_repository.py
@@ -24,6 +24,12 @@ class ReviewTagsRepositoryImpl:
         self.session = session
         self.tags_repository = tags_repository
 
+    @staticmethod
+    def _parent_folder_id_from_level_path(file_level_path: str | None) -> int | None:
+        """Return immediate parent folder id from ``file_level_path`` (empty = space root)."""
+        folder_ids = [int(part) for part in (file_level_path or "").split("/") if part.isdigit()]
+        return folder_ids[-1] if folder_ids else None
+
     def _pending_space_scope_clause(self, tenant_id: int, space_ids: set[int] | None):
         """Restrict pending review tags to associations within ``space_ids``.
 
@@ -515,6 +521,8 @@ class ReviewTagsRepositoryImpl:
                         file_info["id"] = knowledgefile.id
                         file_info["file_id"] = knowledgefile.id
                         file_info["knowledge_id"] = knowledgefile.knowledge_id
+                        # Portal deep-link opens the parent folder before previewing the file.
+                        file_info["parent_id"] = self._parent_folder_id_from_level_path(knowledgefile.file_level_path)
                         submit_time = tag_link.create_time or tag_create_time_by_id.get(tag_link.tag_id)
                         file_info["submit_time"] = submit_time.strftime("%Y-%m-%d %H:%M:%S") if submit_time else ""
                     if file_info:

--- a/src/backend/test/workstation/test_review_tag_parent_id.py
+++ b/src/backend/test/workstation/test_review_tag_parent_id.py
@@ -1,0 +1,15 @@
+"""Unit tests for review-tag resource_files parent_id parsing."""
+
+from bisheng.workstation.domain.repositories.review_tags_repository import ReviewTagsRepositoryImpl
+
+
+def test_parent_folder_id_from_level_path_root():
+    assert ReviewTagsRepositoryImpl._parent_folder_id_from_level_path(None) is None
+    assert ReviewTagsRepositoryImpl._parent_folder_id_from_level_path("") is None
+    assert ReviewTagsRepositoryImpl._parent_folder_id_from_level_path("/") is None
+
+
+def test_parent_folder_id_from_level_path_nested():
+    assert ReviewTagsRepositoryImpl._parent_folder_id_from_level_path("101") == 101
+    assert ReviewTagsRepositoryImpl._parent_folder_id_from_level_path("10/20/30") == 30
+    assert ReviewTagsRepositoryImpl._parent_folder_id_from_level_path("/10/20/") == 20

--- a/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.test.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.test.tsx
@@ -2471,12 +2471,18 @@ describe("PortalKnowledgeWorkbench", () => {
                 type: FileType.MD,
                 spaceId: "public-1",
             });
+            let resolveSpaceInfo: (value: typeof publicSpace) => void = () => undefined;
+            const spaceInfoPending = new Promise<typeof publicSpace>((resolve) => {
+                resolveSpaceInfo = resolve;
+            });
             jest.mocked(getGroupedSpacesApi).mockResolvedValue({
                 publicSpaces: [publicSpace],
                 departmentSpaces: [],
                 teamSpaces: [],
                 personalSpaces: [favoriteSpace],
             } as any);
+            // Delay preferred-space lookup: personal list must not fall back to 我的收藏 first.
+            jest.mocked(getSpaceInfoApi).mockImplementation(() => spaceInfoPending as any);
             jest.mocked(getSpaceChildrenApi).mockImplementation(async (params: any) => (
                 params.space_id === "public-1"
                     ? { data: [file], total: 1 }
@@ -2488,6 +2494,26 @@ describe("PortalKnowledgeWorkbench", () => {
             } as any);
 
             renderWorkbench("/knowledge-portal?spaceId=public-1&fileId=201&fileName=%E5%85%AC%E5%85%B1%E6%96%87%E4%BB%B6.md");
+
+            // Personal list resolves first; preferred getSpaceInfo is still pending.
+            await waitFor(() => {
+                expect(getSpacesByLevelApi).toHaveBeenCalledWith(
+                    SpaceLevel.PERSONAL,
+                    { order_by: SpaceSortType.UPDATE_TIME },
+                );
+            });
+            await act(async () => {
+                await Promise.resolve();
+            });
+            // Must not fall back to 我的收藏 while the deep-link preferred space is unresolved.
+            expect(getSpaceChildrenApi).not.toHaveBeenCalledWith(expect.objectContaining({
+                space_id: "favorite-space",
+            }));
+            expect(screen.queryByTestId("portal-favorites-panel")).not.toBeInTheDocument();
+
+            await act(async () => {
+                resolveSpaceInfo(publicSpace);
+            });
 
             const preview = await screen.findByTestId("portal-preview-page");
             expect(preview).toHaveTextContent("公共文件.md");
@@ -2556,6 +2582,130 @@ describe("PortalKnowledgeWorkbench", () => {
             }));
         });
         expect(await screen.findByText("文件夹文档.md")).toBeInTheDocument();
+    });
+
+    test("deep-link open with folderId returns to the full folder list (not search single-file)", async () => {
+        const personalSpace = makeSpace("personal-1", "信息", {
+            role: SpaceRole.ADMIN,
+        });
+        const folder = makeFile("101", "制度文件", {
+            type: FileType.FOLDER,
+            spaceId: "personal-1",
+        });
+        const targetFile = makeFile("201", "目标文档.md", {
+            type: FileType.MD,
+            spaceId: "personal-1",
+            parentId: "101",
+        });
+        const siblingFile = makeFile("202", "同目录其它.md", {
+            type: FileType.MD,
+            spaceId: "personal-1",
+            parentId: "101",
+        });
+        jest.mocked(getGroupedSpacesApi).mockResolvedValue({
+            publicSpaces: [],
+            departmentSpaces: [],
+            teamSpaces: [],
+            personalSpaces: [personalSpace],
+        } as any);
+        jest.mocked(getSpaceChildrenApi).mockImplementation(async (params: any) => (
+            params.parent_id === "101"
+                ? { data: [targetFile, siblingFile], total: 2 }
+                : { data: [folder], total: 1 }
+        ) as any);
+        // Slow-path search must not leave the UI stuck showing only the matched file.
+        jest.mocked(searchSpaceChildrenApi).mockResolvedValue({
+            data: [targetFile],
+            total: 1,
+        } as any);
+
+        renderWorkbench(
+            "/knowledge-portal?spaceId=personal-1&folderId=101&fileId=201&fileName=%E7%9B%AE%E6%A0%87%E6%96%87%E6%A1%A3.md",
+        );
+
+        const preview = await screen.findByTestId("portal-preview-page");
+        expect(preview).toHaveTextContent("目标文档.md");
+        await waitFor(() => {
+            expect(getSpaceChildrenApi).toHaveBeenCalledWith(expect.objectContaining({
+                space_id: "personal-1",
+                parent_id: "101",
+            }));
+        });
+
+        fireEvent.click(within(preview).getByRole("button", { name: "返回文件列表" }));
+
+        const restoredWorkspace = await screen.findByTestId("portal-file-workspace");
+        expect(within(restoredWorkspace).getByTestId("portal-file-table")).toBeInTheDocument();
+        expect(within(restoredWorkspace).getByText("目标文档.md")).toBeInTheDocument();
+        expect(within(restoredWorkspace).getByText("同目录其它.md")).toBeInTheDocument();
+        expect(screen.queryByTestId("portal-preview-page")).not.toBeInTheDocument();
+    });
+
+    test("tag-review deep-link keeps folder children when a late root refresh finishes during preview", async () => {
+        const personalSpace = makeSpace("personal-1", "信息", {
+            role: SpaceRole.ADMIN,
+        });
+        const folder = makeFile("101", "制度文件", {
+            type: FileType.FOLDER,
+            spaceId: "personal-1",
+        });
+        const targetFile = makeFile("201", "目标文档.md", {
+            type: FileType.MD,
+            spaceId: "personal-1",
+            parentId: "101",
+        });
+        const siblingFile = makeFile("202", "同目录其它.md", {
+            type: FileType.MD,
+            spaceId: "personal-1",
+            parentId: "101",
+        });
+        let resolveRoot: (value: { data: typeof folder[]; total: number }) => void = () => undefined;
+        const rootPending = new Promise<{ data: typeof folder[]; total: number }>((resolve) => {
+            resolveRoot = resolve;
+        });
+        jest.mocked(getGroupedSpacesApi).mockResolvedValue({
+            publicSpaces: [],
+            departmentSpaces: [],
+            teamSpaces: [],
+            personalSpaces: [personalSpace],
+        } as any);
+        jest.mocked(getSpaceChildrenApi).mockImplementation(async (params: any) => {
+            if (params.parent_id === "101") {
+                return { data: [targetFile, siblingFile], total: 2 };
+            }
+            // First root load hangs so folder navigate wins; late resolve used to wipe children.
+            return rootPending;
+        });
+        jest.mocked(searchSpaceChildrenApi).mockResolvedValue({
+            data: [targetFile],
+            total: 1,
+        } as any);
+
+        renderWorkbench(
+            "/knowledge-portal?spaceId=personal-1&folderId=101&fileId=201&fileName=%E7%9B%AE%E6%A0%87%E6%96%87%E6%A1%A3.md",
+        );
+
+        const preview = await screen.findByTestId("portal-preview-page");
+        expect(preview).toHaveTextContent("目标文档.md");
+        await waitFor(() => {
+            expect(getSpaceChildrenApi).toHaveBeenCalledWith(expect.objectContaining({
+                space_id: "personal-1",
+                parent_id: "101",
+            }));
+        });
+
+        await act(async () => {
+            resolveRoot({ data: [folder], total: 1 });
+        });
+
+        // Preview must not be auto-dismissed just because the row is not in the root listing yet.
+        expect(screen.getByTestId("portal-preview-page")).toBeInTheDocument();
+
+        fireEvent.click(within(preview).getByRole("button", { name: "返回文件列表" }));
+
+        const restoredWorkspace = await screen.findByTestId("portal-file-workspace");
+        expect(within(restoredWorkspace).getByText("目标文档.md")).toBeInTheDocument();
+        expect(within(restoredWorkspace).getByText("同目录其它.md")).toBeInTheDocument();
     });
 
     test("formats table update times as full date time without relative labels", async () => {

--- a/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.tsx
@@ -72,6 +72,7 @@ import {
     isFolder,
     isPreviewable,
     isRetryable,
+    mergeRootTreeNodesPreservingLoadedFolders,
     normalizePortalFileCategoryGroups,
     normalizePortalFileCategoryOptions,
     resolvePreviewUrl,
@@ -363,11 +364,19 @@ export default function PortalKnowledgeWorkbench() {
 
     useEffect(() => {
         if (!portalDeepLinkTarget || restoringDeepLinkKey !== portalDeepLinkTarget.key) return;
+        const targetSpaceExists = selectableSpaces.some(
+            (space) => String(space.id) === portalDeepLinkTarget.spaceId,
+        );
+
         if (!activeSpace && !spaceLoading) {
-            setRestoringDeepLinkKey(null);
+            // Spaces finished loading with no active space — only fail if the target is missing.
+            if (!targetSpaceExists) setRestoringDeepLinkKey(null);
             return;
         }
         if (activeSpace && String(activeSpace.id) !== portalDeepLinkTarget.spaceId && !spaceLoading) {
+            // Target space is available: keep overlay while setActiveSpace catches up.
+            // Clearing here used to flash the previous/current space file list before the file opened.
+            if (targetSpaceExists) return;
             setRestoringDeepLinkKey(null);
             return;
         }
@@ -383,7 +392,23 @@ export default function PortalKnowledgeWorkbench() {
         activeSpace,
         portalDeepLinkTarget,
         restoringDeepLinkKey,
+        selectableSpaces,
         spaceLoading,
+    ]);
+
+    // File deep links: keep 「加载中」until the preview request settles (not when the tree loads).
+    useEffect(() => {
+        if (!portalDeepLinkTarget?.fileId || restoringDeepLinkKey !== portalDeepLinkTarget.key) return;
+        if (!selectedFile || String(selectedFile.id) !== portalDeepLinkTarget.fileId) return;
+        if (preview.loading) return;
+        setRestoringDeepLinkKey(null);
+    }, [
+        portalDeepLinkTarget,
+        preview.error,
+        preview.fileUrl,
+        preview.loading,
+        restoringDeepLinkKey,
+        selectedFile,
     ]);
 
     useEffect(() => {
@@ -602,7 +627,18 @@ export default function PortalKnowledgeWorkbench() {
     );
     useEffect(() => {
         if (!activeSpace?.id) return;
-        if (isDeepLinkRestoring) return;
+        // Allow reporting the opened file while restore overlay is still up, so the portal
+        // parent can dismiss its own open-file loading mask.
+        if (
+            isDeepLinkRestoring
+            && !(
+                portalDeepLinkTarget?.fileId
+                && selectedFile
+                && String(selectedFile.id) === portalDeepLinkTarget.fileId
+            )
+        ) {
+            return;
+        }
         if (currentFolderId && !currentFolderNode) return;
         if (
             currentFolderNode?.file.spaceId
@@ -632,6 +668,7 @@ export default function PortalKnowledgeWorkbench() {
         currentFolderId,
         currentFolderNode,
         isDeepLinkRestoring,
+        portalDeepLinkTarget?.fileId,
         selectedFile?.id,
         selectedFile?.name,
         selectedFile?.spaceId,
@@ -995,13 +1032,12 @@ export default function PortalKnowledgeWorkbench() {
                 if (append) {
                     return dedupeTreeNodesByFileId([...prev, ...nextFiles.map(createTreeNode)]);
                 }
-                const nextNodes = dedupeFilesById(nextFiles).map(createTreeNode);
-                const folderId = currentFolderIdRef.current;
-                const currentFolderNode = folderId ? findTreeNode(prev, folderId) : null;
-                if (folderId && currentFolderNode && !findTreeNode(nextNodes, folderId)) {
-                    return dedupeTreeNodesByFileId([currentFolderNode, ...nextNodes]);
-                }
-                return nextNodes;
+                // Deep-link folder navigate can finish before this root refresh; keep loaded children.
+                return mergeRootTreeNodesPreservingLoadedFolders(
+                    prev,
+                    nextFiles,
+                    currentFolderIdRef.current,
+                );
             });
             setTreeRootPage(page);
             setTreeRootTotal((prev) => (res as any).total ?? (append ? prev + nextFiles.length : nextFiles.length));
@@ -1439,16 +1475,26 @@ export default function PortalKnowledgeWorkbench() {
             return;
         }
 
-        setSelectedFile(null);
+        // Prefer deep-link target over restoringDeepLinkKey: clearing the key after preview
+        // settles must not re-run this effect and wipe the file we just opened.
+        const openingDeepLinkedFileHere = Boolean(
+            portalDeepLinkTarget?.fileId
+            && String(activeSpace.id) === portalDeepLinkTarget.spaceId,
+        );
+
+        // While a deep-linked file open targets this space, do not wipe selection/search.
+        if (!openingDeepLinkedFileHere) {
+            setSelectedFile(null);
+            setSearchText("");
+            setSearchMode(false);
+            setSearchResults([]);
+            setSearchTagIds([]);
+            setSelectedFileIds(new Set());
+            setSelectedFolderIds(new Set());
+        }
         setActivePanel(null);
         setAiDrawerOpen(false);
         setSummaryExpanded(false);
-        setSearchText("");
-        setSearchMode(false);
-        setSearchResults([]);
-        setSearchTagIds([]);
-        setSelectedFileIds(new Set());
-        setSelectedFolderIds(new Set());
 
         const spaceChanged = String(activeSpace.id) !== previousSpaceIdRef.current;
         if (spaceChanged) {
@@ -1457,11 +1503,13 @@ export default function PortalKnowledgeWorkbench() {
             setTreeRootTotal(0);
             setTreeRootHasMore(false);
             setTreeRootNextCursor(null);
-            setCurrentFolderId(undefined);
+            if (!openingDeepLinkedFileHere) {
+                setCurrentFolderId(undefined);
+            }
             setCanCreateFolder(false);
             setCanUploadFile(false);
             void loadRootTreeRef.current(1, false, activeSpace.id);
-        } else {
+        } else if (!openingDeepLinkedFileHere) {
             // Sort/filter changed: keep the current folder and reload the same view
             // with the new ordering/filter instead of jumping back to the root.
             void reloadFilesRef.current();
@@ -1472,13 +1520,29 @@ export default function PortalKnowledgeWorkbench() {
         // above): they change for unrelated reasons such as showToast being recreated
         // after a toast, which previously triggered spurious full reloads.
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [activeSpace?.id, sortBy, sortDirection, statusFilterNumbers]);
+    }, [
+        activeSpace?.id,
+        portalDeepLinkTarget?.fileId,
+        portalDeepLinkTarget?.spaceId,
+        sortBy,
+        sortDirection,
+        statusFilterNumbers,
+    ]);
 
     useEffect(() => {
         if (!selectedFile) return;
         // Deep-link restore may select a file before search results / tree rows catch up;
         // clearing here races with usePortalDeepLink and drops the preview.
         if (isDeepLinkRestoring) return;
+        // Tag-review deep link opens preview before folder children land in displayedFiles.
+        // Clearing here "suddenly" drops the user onto an empty folder path.
+        if (
+            portalDeepLinkTarget?.fileId
+            && String(selectedFile.id) === portalDeepLinkTarget.fileId
+            && String(activeSpace?.id) === portalDeepLinkTarget.spaceId
+        ) {
+            return;
+        }
         // #4 收藏原地预览：selectedFile 是来自其它源空间的合成文件（不属于当前 activeSpace，
         // 自然不在其 displayedFiles 中），不应被此“列表中已不存在则关闭预览”的守卫清空。
         if (selectedFile.spaceId && selectedFile.spaceId !== activeSpace?.id) return;
@@ -1486,7 +1550,14 @@ export default function PortalKnowledgeWorkbench() {
         if (!exists) {
             setSelectedFile(null);
         }
-    }, [displayedFiles, selectedFile, activeSpace?.id, isDeepLinkRestoring]);
+    }, [
+        displayedFiles,
+        selectedFile,
+        activeSpace?.id,
+        isDeepLinkRestoring,
+        portalDeepLinkTarget?.fileId,
+        portalDeepLinkTarget?.spaceId,
+    ]);
 
     useEffect(() => {
         if (!permissionTarget) return;
@@ -1991,7 +2062,21 @@ export default function PortalKnowledgeWorkbench() {
         setAiDrawerOpen(false);
         setSummaryExpanded(false);
         setPreview({ loading: false, fileUrl: "", fileType: "", error: "", previewData: null });
-    }, []);
+        // Deep-link open used to leave searchMode with a single-file result set.
+        setSearchMode(false);
+        setSearchResults([]);
+        setSearchText("");
+        setSearchTagIds([]);
+        // Early back during tag-review deep link must not stick on the restore overlay.
+        setRestoringDeepLinkKey(null);
+        // Folder children may still be loading / wiped by a late root refresh — refetch.
+        const folderId = currentFolderIdRef.current;
+        if (!folderId) return;
+        const folderNode = findTreeNode(treeNodes, folderId);
+        if (!folderNode?.loaded || folderNode.loading) {
+            void reloadFilesRef.current();
+        }
+    }, [treeNodes]);
 
     // 从"我的收藏"只读面板打开源文件：#4 原地预览——不切换 activeSpace（不跳转到源知识空间），
     // 以携带源空间 id 的合成文件项触发预览流程。预览/下载按 selectedFile.spaceId(源空间) 定位、

--- a/src/frontend/client/src/pages/knowledge/portal/hooks/usePortalDeepLink.ts
+++ b/src/frontend/client/src/pages/knowledge/portal/hooks/usePortalDeepLink.ts
@@ -118,11 +118,14 @@ export function usePortalDeepLink({
     const deepLinkSpaceAppliedRef = useRef<string | null>(null);
     const deepLinkFolderAppliedRef = useRef<string | null>(null);
     const deepLinkHandledRef = useRef<string | null>(null);
+    /** Prevents restarting search when displayedFiles churns during tree load. */
+    const deepLinkFileSearchKeyRef = useRef<string | null>(null);
 
     useEffect(() => {
         deepLinkSpaceAppliedRef.current = null;
         deepLinkFolderAppliedRef.current = null;
         deepLinkHandledRef.current = null;
+        deepLinkFileSearchKeyRef.current = null;
     }, [deepLinkTarget?.key]);
 
     useEffect(() => {
@@ -138,7 +141,6 @@ export function usePortalDeepLink({
     useEffect(() => {
         if (!deepLinkTarget?.folderId || !activeSpace || String(activeSpace.id) !== deepLinkTarget.spaceId) return;
         if (deepLinkFolderAppliedRef.current === deepLinkTarget.key) return;
-        let cancelled = false;
         deepLinkFolderAppliedRef.current = deepLinkTarget.key;
         setSelectedFile(null);
         setSelectedFileIds(new Set());
@@ -149,13 +151,12 @@ export function usePortalDeepLink({
         setSearchResults([]);
         void Promise.resolve(onNavigateFolder(deepLinkTarget.folderId, deepLinkTarget.folderName))
             .finally(() => {
-                if (!cancelled && !deepLinkTarget.fileId) {
+                // Folder-only links must clear the restore overlay even if this effect
+                // was cleaned up (onNavigateFolder identity often churns after tree load).
+                if (!deepLinkTarget.fileId) {
                     onRestoreComplete?.(deepLinkTarget.key);
                 }
             });
-        return () => {
-            cancelled = true;
-        };
     }, [
         activeSpace,
         deepLinkTarget,
@@ -170,73 +171,42 @@ export function usePortalDeepLink({
         setSelectedFolderIds,
     ]);
 
+    /** Select preview without entering searchMode — return-to-list must show the folder tree. */
+    const openDeepLinkedFile = (
+        target: PortalDeepLinkTarget,
+        spaceId: string,
+        file: KnowledgeFile,
+    ) => {
+        if (String(activeSpaceIdRef.current) !== String(spaceId)) return false;
+        if (deepLinkHandledRef.current === target.key) return true;
+        setCurrentFolderId(target.folderId || undefined);
+        setSelectedFileIds(new Set());
+        setSelectedFolderIds(new Set());
+        setSearchText("");
+        setSearchLoading(false);
+        setSearchMode(false);
+        setSearchResults([]);
+        setSelectedFile(file);
+        deepLinkHandledRef.current = target.key;
+        // Workbench clears the loading overlay after selectedFile matches (and preview settles).
+        return true;
+    };
+
+    // Fast path: open when the target row is already in the current list.
     useEffect(() => {
         if (!deepLinkTarget?.fileId || !activeSpace || String(activeSpace.id) !== deepLinkTarget.spaceId) return;
         if (deepLinkTarget.folderId && deepLinkFolderAppliedRef.current !== deepLinkTarget.key) return;
         if (deepLinkHandledRef.current === deepLinkTarget.key) return;
-
-        let cancelled = false;
-
-        const openDeepLinkedFile = (file: KnowledgeFile, searchResults?: KnowledgeFile[]) => {
-            if (cancelled || String(activeSpaceIdRef.current) !== String(activeSpace.id)) return false;
-            setCurrentFolderId(deepLinkTarget.folderId || undefined);
-            setSelectedFileIds(new Set());
-            setSelectedFolderIds(new Set());
-            setSearchText(deepLinkTarget.fileName || file.name);
-            setSearchLoading(false);
-            if (searchResults) {
-                setSearchMode(true);
-                setSearchResults(searchResults);
-            }
-            setSelectedFile(file);
-            deepLinkHandledRef.current = deepLinkTarget.key;
-            onRestoreComplete?.(deepLinkTarget.key);
-            return true;
-        };
 
         const existingFile = displayedFiles.find((file) => (
             String(file.id) === deepLinkTarget.fileId
             && String(file.spaceId || activeSpace.id) === deepLinkTarget.spaceId
             && !isFolder(file)
         ));
-        if (existingFile) {
-            openDeepLinkedFile(existingFile);
-            return () => {
-                cancelled = true;
-            };
-        }
-
-        const fallbackFile = createDeepLinkedFile(deepLinkTarget, deepLinkTarget.fileId);
-        const keyword = deepLinkTarget.fileName || deepLinkTarget.fileId;
-        setSearchLoading(true);
-        searchSpaceChildrenApi({
-            space_id: deepLinkTarget.spaceId,
-            parent_id: deepLinkTarget.folderId || undefined,
-            keyword,
-            page: 1,
-            page_size: TREE_PAGE_SIZE,
-            file_status: statusFilterNumbers,
-        }).then((res) => {
-            const matchedFile = res.data.find((file) => (
-                String(file.id) === deepLinkTarget.fileId
-                && !isFolder(file)
-            ));
-            const nextResults = matchedFile ? res.data : [fallbackFile];
-            openDeepLinkedFile(matchedFile ?? fallbackFile, nextResults);
-        }).catch(() => {
-            openDeepLinkedFile(fallbackFile, [fallbackFile]);
-        }).finally(() => {
-            if (!cancelled && String(activeSpaceIdRef.current) === String(activeSpace.id)) {
-                setSearchLoading(false);
-            }
-        });
-
-        return () => {
-            cancelled = true;
-        };
+        if (!existingFile) return;
+        openDeepLinkedFile(deepLinkTarget, String(activeSpace.id), existingFile);
     }, [
         activeSpace,
-        activeSpaceIdRef,
         deepLinkTarget,
         displayedFiles,
         setCurrentFolderId,
@@ -247,7 +217,71 @@ export function usePortalDeepLink({
         setSelectedFile,
         setSelectedFileIds,
         setSelectedFolderIds,
-        onRestoreComplete,
+        activeSpaceIdRef,
+    ]);
+
+    // Slow path: search once per deep-link key. Do NOT depend on displayedFiles — tree
+    // updates used to cancel in-flight search and leave the space list visible without a file.
+    useEffect(() => {
+        if (!deepLinkTarget?.fileId || !activeSpace || String(activeSpace.id) !== deepLinkTarget.spaceId) return;
+        if (deepLinkTarget.folderId && deepLinkFolderAppliedRef.current !== deepLinkTarget.key) return;
+        if (deepLinkHandledRef.current === deepLinkTarget.key) return;
+        if (deepLinkFileSearchKeyRef.current === deepLinkTarget.key) return;
+
+        deepLinkFileSearchKeyRef.current = deepLinkTarget.key;
+        const target = deepLinkTarget;
+        const spaceId = String(activeSpace.id);
+        const fallbackFile = createDeepLinkedFile(target, target.fileId);
+        const keyword = target.fileName || target.fileId;
+        let cancelled = false;
+        setSearchLoading(true);
+        searchSpaceChildrenApi({
+            space_id: target.spaceId,
+            parent_id: target.folderId || undefined,
+            keyword,
+            page: 1,
+            page_size: TREE_PAGE_SIZE,
+            file_status: statusFilterNumbers,
+        }).then((res) => {
+            if (cancelled) return;
+            const matchedFile = res.data.find((file) => (
+                String(file.id) === target.fileId
+                && !isFolder(file)
+            ));
+            // Search is metadata lookup only — do not leave the workbench in searchMode.
+            openDeepLinkedFile(target, spaceId, matchedFile ?? fallbackFile);
+        }).catch(() => {
+            if (cancelled) return;
+            openDeepLinkedFile(target, spaceId, fallbackFile);
+        }).finally(() => {
+            if (!cancelled && String(activeSpaceIdRef.current) === spaceId) {
+                setSearchLoading(false);
+            }
+        });
+
+        return () => {
+            // Cancel only when this effect re-runs for a new key/space/filters (deps below).
+            cancelled = true;
+            if (deepLinkFileSearchKeyRef.current === target.key) {
+                deepLinkFileSearchKeyRef.current = null;
+            }
+        };
+    }, [
+        activeSpace?.id,
+        deepLinkTarget?.key,
+        deepLinkTarget?.fileId,
+        deepLinkTarget?.folderId,
+        deepLinkTarget?.fileName,
+        deepLinkTarget?.spaceId,
         statusFilterNumbers,
+        activeSpaceIdRef,
+        setCurrentFolderId,
+        setSearchLoading,
+        setSearchMode,
+        setSearchResults,
+        setSearchText,
+        setSelectedFile,
+        setSelectedFileIds,
+        setSelectedFolderIds,
     ]);
 }

--- a/src/frontend/client/src/pages/knowledge/portal/hooks/usePortalSpaces.ts
+++ b/src/frontend/client/src/pages/knowledge/portal/hooks/usePortalSpaces.ts
@@ -252,10 +252,19 @@ export function usePortalSpaces({
             }
             return;
         }
-        if (preferredSpacePending) return;
+
+        // Deep-link restore: never fall back to 我的收藏 while a preferred space is requested.
+        // Clear a mismatched default so the sidebar/list do not flash the favorite space.
+        if (preferredSpaceId) {
+            if (activeSpace && String(activeSpace.id) === String(preferredSpaceId)) return;
+            if (activeSpace) {
+                setActiveSpace(null);
+            }
+            return;
+        }
+
         // 用 String() 兜底：新建返回的 space id 可能是数字，避免与列表里的字符串 id 不匹配而误重置
         if (activeSpace && selectableSpaces.some((space) => String(space.id) === String(activeSpace.id))) return;
-        if (activeSpace && preferredSpaceId && String(activeSpace.id) === String(preferredSpaceId)) return;
         if (personalSpacesQuery.isLoading) return;
         setActiveSpace(defaultPersonalSpace ?? selectableSpaces[0] ?? null);
     }, [
@@ -264,7 +273,6 @@ export function usePortalSpaces({
         personalSpacesQuery.isLoading,
         preferredSpace,
         preferredSpaceId,
-        preferredSpacePending,
         selectableSpaces,
         setActiveSpace,
     ]);

--- a/src/frontend/client/src/pages/knowledge/portal/utils.test.ts
+++ b/src/frontend/client/src/pages/knowledge/portal/utils.test.ts
@@ -5,6 +5,7 @@ import {
     dedupeFilesById,
     dedupeTreeNodesByFileId,
     extractExt,
+    mergeRootTreeNodesPreservingLoadedFolders,
     normalizePortalFileCategoryGroups,
     normalizePortalFileCategoryOptions,
 } from "./utils";
@@ -49,6 +50,52 @@ describe("portal preview utils", () => {
 
         it("falls back to the display name extension when no preview URL is available", () => {
             expect(extractExt("VCU告警操作文档.docx")).toBe("docx");
+        });
+    });
+
+    describe("mergeRootTreeNodesPreservingLoadedFolders", () => {
+        it("keeps loaded folder children when the folder also appears in the root listing", () => {
+            const child = createTreeNode(makeFile({ id: "201", name: "child.md", type: FileType.MD }));
+            const loadedFolder = {
+                ...createTreeNode(makeFile({ id: "101", name: "folder" })),
+                children: [child],
+                expanded: true,
+                loaded: true,
+                total: 1,
+            };
+            const rootFolder = makeFile({ id: "101", name: "folder (root meta)" });
+            const sibling = makeFile({ id: "102", name: "other.md", type: FileType.MD });
+
+            const merged = mergeRootTreeNodesPreservingLoadedFolders(
+                [loadedFolder],
+                [rootFolder, sibling],
+                "101",
+            );
+
+            expect(merged).toHaveLength(2);
+            expect(merged[0].file.name).toBe("folder (root meta)");
+            expect(merged[0].loaded).toBe(true);
+            expect(merged[0].children).toEqual([child]);
+            expect(merged[1].file.id).toBe("102");
+        });
+
+        it("keeps the current folder node when it is missing from the root page", () => {
+            const child = createTreeNode(makeFile({ id: "201", name: "child.md", type: FileType.MD }));
+            const deepFolder = {
+                ...createTreeNode(makeFile({ id: "101", name: "deep" })),
+                children: [child],
+                loaded: true,
+            };
+            const rootFile = makeFile({ id: "102", name: "root.md", type: FileType.MD });
+
+            const merged = mergeRootTreeNodesPreservingLoadedFolders(
+                [deepFolder],
+                [rootFile],
+                "101",
+            );
+
+            expect(merged.map((node) => node.file.id)).toEqual(["101", "102"]);
+            expect(merged[0].children).toEqual([child]);
         });
     });
 

--- a/src/frontend/client/src/pages/knowledge/portal/utils.ts
+++ b/src/frontend/client/src/pages/knowledge/portal/utils.ts
@@ -162,6 +162,40 @@ export function createTreeNode(file: KnowledgeFile): PortalFileTreeNode {
     };
 }
 
+/**
+ * Merge a fresh root listing with the previous tree so already-loaded folder
+ * children survive a late root refresh (deep-link navigate vs loadRootTree race).
+ */
+export function mergeRootTreeNodesPreservingLoadedFolders(
+    previous: PortalFileTreeNode[],
+    rootFiles: KnowledgeFile[],
+    currentFolderId?: string,
+): PortalFileTreeNode[] {
+    const nextNodes = dedupeFilesById(rootFiles).map((file) => {
+        const next = createTreeNode(file);
+        if (!isFolder(file)) return next;
+        const prevNode = findTreeNode(previous, String(file.id));
+        // Keep expanded folder contents; refresh folder row metadata from root.
+        if (!prevNode?.loaded) return next;
+        return {
+            ...next,
+            children: prevNode.children,
+            expanded: prevNode.expanded,
+            loaded: prevNode.loaded,
+            loading: prevNode.loading,
+            page: prevNode.page,
+            total: prevNode.total,
+            hasMore: prevNode.hasMore,
+            nextCursor: prevNode.nextCursor,
+        };
+    });
+    if (!currentFolderId) return nextNodes;
+    if (findTreeNode(nextNodes, currentFolderId)) return nextNodes;
+    const currentFolderNode = findTreeNode(previous, currentFolderId);
+    if (!currentFolderNode) return nextNodes;
+    return dedupeTreeNodesByFileId([currentFolderNode, ...nextNodes]);
+}
+
 export function dedupeFilesById(files: KnowledgeFile[]): KnowledgeFile[] {
     const seen = new Set<string>();
     return files.filter((file) => {


### PR DESCRIPTION
## Summary
- Review-tag `resource_files` now include `parent_id` so Portal can deep-link into the file's folder.
- Client deep-link navigates the folder before preview, skips `searchMode`, preserves loaded folder children across late root refresh, and does not fall back to 我的收藏 while restoring.
- Returning to the list clears restore/search state and refetches the folder when it was not loaded yet.

## Test plan
- [ ] From Portal tag review, open a file in a nested folder → lands in that folder, preview opens
- [ ] During preview load, return / bounce back → folder list shows siblings (not empty / not single search hit)
- [ ] Deep-link restore does not briefly activate 我的收藏 or fetch its children
- [ ] `npm test` Client: deep-link / favorite-restore / mergeRootTree cases
- [ ] `pytest test/workstation/test_review_tag_parent_id.py`


Made with [Cursor](https://cursor.com)