### PR TITLE
fix(knowledge): count portal category cards by bound-space files

### DIFF
--- a/src/backend/bisheng/knowledge/domain/models/knowledge_file.py
+++ b/src/backend/bisheng/knowledge/domain/models/knowledge_file.py
@@ -12,7 +12,6 @@ from bisheng.common.models.base import SQLModelSerializable
 from bisheng.core.database import get_async_db_session, get_sync_db_session
 from bisheng.core.database.dialect_helpers import UPDATE_TIME_SERVER_DEFAULT, JsonType
 from bisheng.database.base import async_get_count, get_count
-from bisheng.knowledge.domain.constants import parse_shougang_file_encoding_codes
 
 
 class KnowledgeFileStatus(int, Enum):
@@ -587,11 +586,12 @@ class KnowledgeFileDao(KnowledgeFileBase):
 
     @classmethod
     async def async_count_files_by_category_scopes(cls, category_space_ids: dict[str, set[int]]) -> dict[str, int]:
-        """Count successful files for each document-type and knowledge-space scope.
+        """Count SUCCESS files in each category card's bound spaces.
 
-        Document type comes from ``parse_shougang_file_encoding_codes`` (category segment),
-        matching portal/search filtering. LIKE prefilters may over-fetch; Python exact match
-        rejects rows whose category segment is not the requested code.
+        Aligns with portal category landing list (``aget_file_by_space_filters*``):
+        ``file_type=FILE``, ``status=SUCCESS``, ``deleted_at IS NULL``. Does **not** apply
+        ``active_inventory_predicate`` (which would hide non-primary historical rows the
+        list still shows). Category ``code`` is only the aggregation key, not an encoding filter.
         """
         normalized_scopes = {
             code.strip().upper(): {int(space_id) for space_id in space_ids if int(space_id) > 0}
@@ -599,38 +599,25 @@ class KnowledgeFileDao(KnowledgeFileBase):
             if code and code.strip()
         }
         counts = dict.fromkeys(normalized_scopes, 0)
-        conditions = [
-            and_(
-                KnowledgeFile.knowledge_id.in_(space_ids),
-                col(KnowledgeFile.file_encoding).like(f"%-{code}-%"),
-            )
-            for code, space_ids in normalized_scopes.items()
-            if space_ids
-        ]
-        if not conditions:
+        all_space_ids = sorted({space_id for space_ids in normalized_scopes.values() for space_id in space_ids})
+        if not all_space_ids:
             return counts
-        statement = select(
-            KnowledgeFile.id,
-            KnowledgeFile.reference_document_id,
-            KnowledgeFile.knowledge_id,
-            KnowledgeFile.file_encoding,
-        ).where(
-            KnowledgeFile.file_type == FileType.FILE.value,
-            KnowledgeFile.status == KnowledgeFileStatus.SUCCESS.value,
-            col(KnowledgeFile.file_encoding).is_not(None),
-            or_(*conditions),
-            cls.active_inventory_predicate(),
+        statement = (
+            select(KnowledgeFile.knowledge_id, func.count().label("cnt"))
+            .where(
+                KnowledgeFile.knowledge_id.in_(all_space_ids),
+                KnowledgeFile.file_type == FileType.FILE.value,
+                KnowledgeFile.status == KnowledgeFileStatus.SUCCESS.value,
+                col(KnowledgeFile.deleted_at).is_(None),
+            )
+            .group_by(KnowledgeFile.knowledge_id)
         )
         async with get_async_db_session() as session:
             rows = (await session.exec(statement)).all()
-        canonical_ids_by_code = {code: set() for code in normalized_scopes}
-        for file_id, document_id, knowledge_id, encoding in rows:
-            document_type, _ = parse_shougang_file_encoding_codes({"file_encoding": encoding})
-            if not document_type:
-                continue
-            if knowledge_id in normalized_scopes.get(document_type, set()):
-                canonical_ids_by_code[document_type].add(int(document_id or file_id))
-        return {code: len(canonical_ids_by_code[code]) for code in counts}
+        file_count_map = {int(row[0]): int(row[1] or 0) for row in rows}
+        for code, space_ids in normalized_scopes.items():
+            counts[code] = sum(int(file_count_map.get(space_id, 0) or 0) for space_id in space_ids)
+        return counts
 
     @classmethod
     def delete_batch(cls, file_ids: list[int]) -> bool:

--- a/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
+++ b/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
@@ -186,9 +186,9 @@ from bisheng.knowledge.domain.schemas.knowledge_space_schema import (
     KnowledgeSpaceInfoResp,
     RemoveSpaceMemberRequest,
     ShougangPortalAdvancedFileSearchReq,
+    ShougangPortalCategoryFileCountItem,
     ShougangPortalDomainBindableSpaceResp,
     ShougangPortalDomainFileCountItem,
-    ShougangPortalCategoryFileCountItem,
     ShougangPortalFavoriteCreateReq,
     ShougangPortalFavoriteCreateResp,
     ShougangPortalFavoriteFileItem,
@@ -921,9 +921,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
         required_capability: str,
     ):
         resolved = await self._resolve_document_entry(file_record)
-        if resolved is None or bool(
-            getattr(resolved.capabilities, required_capability, False)
-        ):
+        if resolved is None or bool(getattr(resolved.capabilities, required_capability, False)):
             return resolved
         if required_capability not in {"can_view", "can_preview"}:
             raise SpacePermissionDeniedError()
@@ -1329,9 +1327,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 object_type = "folder"
                 object_id = folder_id
         upload_permission_id = (
-            _UPLOAD_FILE_TO_FOLDER_PERMISSION_ID
-            if object_type == "folder"
-            else _UPLOAD_FILE_TO_SPACE_PERMISSION_ID
+            _UPLOAD_FILE_TO_FOLDER_PERMISSION_ID if object_type == "folder" else _UPLOAD_FILE_TO_SPACE_PERMISSION_ID
         )
         allowed = await PermissionService.check(
             int(login_user.user_id),
@@ -4863,6 +4859,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
         self,
         categories: list[ShougangPortalCategoryFileCountItem],
     ) -> dict[str, int]:
+        """Count SUCCESS files in each category card's visible bound spaces (list-aligned)."""
         visible_scopes: dict[str, set[int]] = {}
         for category in categories:
             spaces = await self._get_shougang_portal_visible_search_spaces(category.space_ids, None)
@@ -6544,9 +6541,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
 
         if decision.status == DepartmentFileAccessStatus.ALLOWED:
             self._portal_file_access_decision_map[int(file.id)] = decision
-            self._portal_file_download_map[int(file.id)] = bool(
-                decision.can_download
-            )
+            self._portal_file_download_map[int(file.id)] = bool(decision.can_download)
             spaces = await self._get_shougang_portal_request_spaces(
                 requested_space_ids=[space_id],
                 space_level=None,
@@ -6726,11 +6721,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
         cls,
         spaces: list[Knowledge],
     ) -> tuple[list[Knowledge], int, int]:
-        space_ids = [
-            int(space.id)
-            for space in spaces
-            if getattr(space, "id", None) is not None
-        ]
+        space_ids = [int(space.id) for space in spaces if getattr(space, "id", None) is not None]
         scopes = await KnowledgeSpaceScopeDao.aget_map_by_space_ids(space_ids)
         retained: list[Knowledge] = []
         personal_count = 0
@@ -6771,9 +6762,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                             2,
                         ),
                         "empty_reason": (
-                            "only_personal_spaces"
-                            if personal_space_excluded_count
-                            else "space_scope_unknown"
+                            "only_personal_spaces" if personal_space_excluded_count else "space_scope_unknown"
                         ),
                         "personal_space_excluded_count": personal_space_excluded_count,
                         "requested_space_count": requested_space_count,

--- a/src/backend/test/test_shougang_domain_file_counts_dao.py
+++ b/src/backend/test/test_shougang_domain_file_counts_dao.py
@@ -4,6 +4,7 @@ Counts SUCCESS document files per business-domain code (the second-from-last
 '-'-segment of file_encoding) across ALL knowledge bases, ignoring space/login
 filters.
 """
+
 from contextlib import asynccontextmanager
 from unittest.mock import patch
 
@@ -25,7 +26,7 @@ def _patch_session_factory(session):
         yield session
 
     return patch(
-        'bisheng.knowledge.domain.models.knowledge_file.get_async_db_session',
+        "bisheng.knowledge.domain.models.knowledge_file.get_async_db_session",
         _fake_factory,
     )
 
@@ -33,7 +34,7 @@ def _patch_session_factory(session):
 async def _insert(session, **kwargs):
     defaults = dict(
         user_id=1,
-        user_name='tester',
+        user_name="tester",
         file_type=FileType.FILE.value,
         status=KnowledgeFileStatus.SUCCESS.value,
     )
@@ -47,24 +48,30 @@ async def _insert(session, **kwargs):
 @pytest.mark.asyncio
 async def test_count_files_by_domain_codes_uses_second_from_last_segment_exactly(async_db_session):
     # Spread across DIFFERENT knowledge_ids to prove the filter ignores space.
-    await _insert(async_db_session, knowledge_id=10, file_name='a', file_encoding='GF-STD-PP-001')
-    await _insert(async_db_session, knowledge_id=11, file_name='b', file_encoding='GF-RPT-PP-002')
-    await _insert(async_db_session, knowledge_id=12, file_name='c', file_encoding='GF-STD-QM-003')
+    await _insert(async_db_session, knowledge_id=10, file_name="a", file_encoding="GF-STD-PP-001")
+    await _insert(async_db_session, knowledge_id=11, file_name="b", file_encoding="GF-RPT-PP-002")
+    await _insert(async_db_session, knowledge_id=12, file_name="c", file_encoding="GF-STD-QM-003")
     # FAILED status -> not counted
-    await _insert(async_db_session, knowledge_id=10, file_name='d',
-                  file_encoding='GF-STD-PP-004', status=KnowledgeFileStatus.FAILED.value)
+    await _insert(
+        async_db_session,
+        knowledge_id=10,
+        file_name="d",
+        file_encoding="GF-STD-PP-004",
+        status=KnowledgeFileStatus.FAILED.value,
+    )
     # DIR file_type -> not counted
-    await _insert(async_db_session, knowledge_id=10, file_name='e',
-                  file_encoding='GF-STD-PP-005', file_type=FileType.DIR.value)
+    await _insert(
+        async_db_session, knowledge_id=10, file_name="e", file_encoding="GF-STD-PP-005", file_type=FileType.DIR.value
+    )
     # NULL encoding -> not counted
-    await _insert(async_db_session, knowledge_id=10, file_name='f', file_encoding=None)
+    await _insert(async_db_session, knowledge_id=10, file_name="f", file_encoding=None)
     # 'PP' only appears in 1st segment; second-from-last segment is SA -> counts as SA, not PP.
-    await _insert(async_db_session, knowledge_id=13, file_name='g', file_encoding='PP-STD-SA-006')
+    await _insert(async_db_session, knowledge_id=13, file_name="g", file_encoding="PP-STD-SA-006")
 
     with _patch_session_factory(async_db_session):
-        result = await KnowledgeFileDao.async_count_files_by_domain_codes(['PP', 'QM', 'SA'])
+        result = await KnowledgeFileDao.async_count_files_by_domain_codes(["PP", "QM", "SA"])
 
-    assert result == {'PP': 2, 'QM': 1, 'SA': 1}
+    assert result == {"PP": 2, "QM": 1, "SA": 1}
 
 
 @pytest.mark.asyncio
@@ -73,29 +80,29 @@ async def test_count_files_by_domain_codes_rejects_like_overfetch_on_non_busines
     # LIKE '%-PP-%' prefilter WILL fetch this row -- but the business code
     # (second-from-last segment) is QM. The Python guard must reject the
     # over-fetch and count it as QM only, never PP.
-    await _insert(async_db_session, knowledge_id=30, file_name='a', file_encoding='GF-PP-QM-001')
+    await _insert(async_db_session, knowledge_id=30, file_name="a", file_encoding="GF-PP-QM-001")
     # Multi-segment, operator-configured prefix ('GF-PP'): the business code is
     # still the second-from-last segment (QM). Counting parts[2] here would
     # wrongly pick 'QM' for one row but generally breaks once the prefix grows;
     # the dash-surrounded 'PP' again tempts the LIKE prefilter to over-fetch.
-    await _insert(async_db_session, knowledge_id=31, file_name='b', file_encoding='GF-PP-EXTRA-QM-002')
+    await _insert(async_db_session, knowledge_id=31, file_name="b", file_encoding="GF-PP-EXTRA-QM-002")
 
     with _patch_session_factory(async_db_session):
-        result = await KnowledgeFileDao.async_count_files_by_domain_codes(['PP', 'QM'])
+        result = await KnowledgeFileDao.async_count_files_by_domain_codes(["PP", "QM"])
 
-    assert result == {'PP': 0, 'QM': 2}
+    assert result == {"PP": 0, "QM": 2}
 
 
 @pytest.mark.asyncio
 async def test_count_files_by_domain_codes_dedupes_mixed_case_codes(async_db_session):
-    await _insert(async_db_session, knowledge_id=40, file_name='a', file_encoding='GF-STD-PP-001')
-    await _insert(async_db_session, knowledge_id=41, file_name='b', file_encoding='GF-RPT-PP-002')
+    await _insert(async_db_session, knowledge_id=40, file_name="a", file_encoding="GF-STD-PP-001")
+    await _insert(async_db_session, knowledge_id=41, file_name="b", file_encoding="GF-RPT-PP-002")
 
     with _patch_session_factory(async_db_session):
-        result = await KnowledgeFileDao.async_count_files_by_domain_codes(['PP', 'pp', 'PP'])
+        result = await KnowledgeFileDao.async_count_files_by_domain_codes(["PP", "pp", "PP"])
 
     # Duplicate/mixed-case requests collapse to a single normalized key.
-    assert result == {'PP': 2}
+    assert result == {"PP": 2}
 
 
 @pytest.mark.asyncio
@@ -107,12 +114,12 @@ async def test_count_files_by_domain_codes_empty_codes_returns_empty(async_db_se
 
 @pytest.mark.asyncio
 async def test_count_files_by_domain_codes_unmatched_code_returns_zero(async_db_session):
-    await _insert(async_db_session, knowledge_id=20, file_name='a', file_encoding='GF-STD-PP-001')
+    await _insert(async_db_session, knowledge_id=20, file_name="a", file_encoding="GF-STD-PP-001")
 
     with _patch_session_factory(async_db_session):
-        result = await KnowledgeFileDao.async_count_files_by_domain_codes(['PP', 'ZZ'])
+        result = await KnowledgeFileDao.async_count_files_by_domain_codes(["PP", "ZZ"])
 
-    assert result == {'PP': 1, 'ZZ': 0}
+    assert result == {"PP": 1, "ZZ": 0}
 
 
 @pytest.mark.asyncio
@@ -120,10 +127,10 @@ async def test_count_files_by_domain_scopes_only_counts_matching_visible_spaces(
     class FakeResult:
         def all(self):
             return [
-                (10, 'GF-STD-PP-001'),
-                (11, 'GF-STD-PP-002'),
-                (20, 'GF-STD-QM-003'),
-                (10, 'GF-PP-QM-004'),
+                (10, "GF-STD-PP-001"),
+                (11, "GF-STD-PP-002"),
+                (20, "GF-STD-QM-003"),
+                (10, "GF-PP-QM-004"),
             ]
 
     class FakeSession:
@@ -134,24 +141,20 @@ async def test_count_files_by_domain_scopes_only_counts_matching_visible_spaces(
     session = FakeSession()
     with _patch_session_factory(session):
         result = await KnowledgeFileDao.async_count_files_by_domain_scopes(
-            {'PP': {10}, 'QM': {20}},
+            {"PP": {10}, "QM": {20}},
         )
 
     # 11 不在 PP 可见空间；最后一条的业务域是 QM，但 10 不在 QM 可见空间。
-    assert result == {'PP': 1, 'QM': 1}
+    assert result == {"PP": 1, "QM": 1}
 
 
 @pytest.mark.asyncio
-async def test_count_files_by_category_scopes_only_counts_matching_visible_spaces():
+async def test_count_files_by_category_scopes_sums_bound_space_file_totals():
+    """Category homepage counts SUCCESS+not-deleted files per bound space (list-aligned)."""
+
     class FakeResult:
         def all(self):
-            return [
-                (1, None, 10, 'GF-STD-PP-001'),
-                (2, None, 11, 'GF-STD-PP-002'),
-                (3, None, 20, 'GF-RPT-QM-003'),
-                # LIKE %-STD-% matches, but category segment is RPT (before QM).
-                (4, None, 10, 'GF-EXTRA-STD-RPT-QM-005'),
-            ]
+            return [(10, 3), (20, 5)]
 
     class FakeSession:
         async def exec(self, statement):
@@ -161,38 +164,13 @@ async def test_count_files_by_category_scopes_only_counts_matching_visible_space
     session = FakeSession()
     with _patch_session_factory(session):
         result = await KnowledgeFileDao.async_count_files_by_category_scopes(
-            {'STD': {10}, 'RPT': {20}},
+            {"POL": {10}, "STD": {10, 20}},
         )
 
-    # space 11 not in STD scope; GF-EXTRA-STD-RPT-QM-005 is RPT but space 10 not in RPT scope
-    assert result == {'STD': 1, 'RPT': 1}
-
-
-@pytest.mark.asyncio
-async def test_count_files_by_category_scopes_rejects_like_overfetch():
-    class FakeResult:
-        def all(self):
-            return [
-                # LIKE %-STD-% matches because STD sits in a non-category segment;
-                # parse yields document type RPT, domain QM.
-                (1, None, 10, 'GF-STD-EXTRA-RPT-QM-001'),
-                (2, None, 10, 'GF-STD-PP-002'),
-            ]
-
-    class FakeSession:
-        async def exec(self, statement):
-            return FakeResult()
-
-    session = FakeSession()
-    with _patch_session_factory(session):
-        result = await KnowledgeFileDao.async_count_files_by_category_scopes(
-            {'STD': {10}},
-        )
-
-    assert result == {'STD': 1}
+    assert result == {"POL": 3, "STD": 8}
 
 
 @pytest.mark.asyncio
 async def test_count_files_by_category_scopes_empty_space_returns_zero():
-    result = await KnowledgeFileDao.async_count_files_by_category_scopes({'STD': set()})
-    assert result == {'STD': 0}
+    result = await KnowledgeFileDao.async_count_files_by_category_scopes({"STD": set()})
+    assert result == {"STD": 0}


### PR DESCRIPTION
## Summary
- Change portal category navigation file counts to sum SUCCESS files in each card’s bound/visible spaces (aligned with the category landing list).
- Stop matching Shougang encoding category segments for category-card totals; domain counts stay encoding-based.
- Update DAO unit tests for the new aggregation semantics.

## Test plan
- [ ] `GET /api/v1/knowledge/category-file-counts` for a category with bound space (e.g. POL/人力) returns bound-space SUCCESS file total (e.g. 10), not encoding-only count
- [ ] Domain file counts still use encoding-based scopes
- [ ] Run `pytest test/test_shougang_domain_file_counts_dao.py`
- [ ] Portal home「分类导航」card count matches landing list size for the same bound spaces


Made with [Cursor](https://cursor.com)