### PR TITLE
fix(knowledge): restore category nav counts to bound-space totals

### DIFF
--- a/src/backend/bisheng/knowledge/domain/models/knowledge_file.py
+++ b/src/backend/bisheng/knowledge/domain/models/knowledge_file.py
@@ -10,7 +10,6 @@ from sqlmodel import Field, col, delete, func, select, update
 
 from bisheng.common.models.base import SQLModelSerializable
 from bisheng.core.database import get_async_db_session, get_sync_db_session
-from bisheng.knowledge.domain.constants import parse_shougang_file_encoding_codes
 from bisheng.core.database.dialect_helpers import UPDATE_TIME_SERVER_DEFAULT, JsonType
 from bisheng.database.base import async_get_count, get_count
 
@@ -587,12 +586,13 @@ class KnowledgeFileDao(KnowledgeFileBase):
 
     @classmethod
     async def async_count_files_by_category_scopes(cls, category_space_ids: dict[str, set[int]]) -> dict[str, int]:
-        """Count SUCCESS files per document-type category within each card's bound spaces.
+        """Count SUCCESS files in each category card's bound spaces.
 
-        Aligns with portal category landing list (``aget_file_by_space_filters*`` +
-        ``_filter_shougang_portal_files_by_document_type``): ``file_type=FILE``,
-        ``status=SUCCESS``, ``deleted_at IS NULL``, filtered by document-type code parsed
-        from ``file_encoding``. Does **not** apply ``active_inventory_predicate``.
+        Aligns with portal category landing list (``aget_file_by_space_filters*``):
+        ``file_type=FILE``, ``status=SUCCESS``, ``deleted_at IS NULL``. Does **not** apply
+        ``active_inventory_predicate`` (non-primary historical rows stay visible in the list).
+        Category ``code`` is only the aggregation key — unlike domain scopes, encoding is
+        not used as a filter. Domain counting stays in ``async_count_files_by_domain_scopes``.
         """
         normalized_scopes = {
             code.strip().upper(): {int(space_id) for space_id in space_ids if int(space_id) > 0}
@@ -600,35 +600,24 @@ class KnowledgeFileDao(KnowledgeFileBase):
             if code and code.strip()
         }
         counts = dict.fromkeys(normalized_scopes, 0)
-        conditions = [
-            and_(
-                KnowledgeFile.knowledge_id.in_(space_ids),
-                col(KnowledgeFile.file_encoding).like(f"%-{code}-%"),
-            )
-            for code, space_ids in normalized_scopes.items()
-            if space_ids
-        ]
-        if not conditions:
+        all_space_ids = sorted({space_id for space_ids in normalized_scopes.values() for space_id in space_ids})
+        if not all_space_ids:
             return counts
-        statement = select(
-            KnowledgeFile.knowledge_id,
-            KnowledgeFile.file_encoding,
-        ).where(
-            KnowledgeFile.file_type == FileType.FILE.value,
-            KnowledgeFile.status == KnowledgeFileStatus.SUCCESS.value,
-            col(KnowledgeFile.deleted_at).is_(None),
-            col(KnowledgeFile.file_encoding).is_not(None),
-            or_(*conditions),
+        statement = (
+            select(KnowledgeFile.knowledge_id, func.count().label("cnt"))
+            .where(
+                KnowledgeFile.knowledge_id.in_(all_space_ids),
+                KnowledgeFile.file_type == FileType.FILE.value,
+                KnowledgeFile.status == KnowledgeFileStatus.SUCCESS.value,
+                col(KnowledgeFile.deleted_at).is_(None),
+            )
+            .group_by(KnowledgeFile.knowledge_id)
         )
         async with get_async_db_session() as session:
             rows = (await session.exec(statement)).all()
-        for knowledge_id, encoding in rows:
-            document_code, _ = parse_shougang_file_encoding_codes({"file_encoding": encoding})
-            document_code = (document_code or "").strip().upper()
-            if not document_code:
-                continue
-            if int(knowledge_id) in normalized_scopes.get(document_code, set()):
-                counts[document_code] += 1
+        file_count_map = {int(row[0]): int(row[1] or 0) for row in rows}
+        for code, space_ids in normalized_scopes.items():
+            counts[code] = sum(int(file_count_map.get(space_id, 0) or 0) for space_id in space_ids)
         return counts
 
     @classmethod

--- a/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
+++ b/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
@@ -4859,7 +4859,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
         self,
         categories: list[ShougangPortalCategoryFileCountItem],
     ) -> dict[str, int]:
-        """Count SUCCESS files per document-type category in each card's visible spaces."""
+        """Count SUCCESS files in each category card's visible bound spaces (list-aligned)."""
         visible_scopes: dict[str, set[int]] = {}
         for category in categories:
             spaces = await self._get_shougang_portal_visible_search_spaces(category.space_ids, None)

--- a/src/backend/test/test_shougang_domain_file_counts_dao.py
+++ b/src/backend/test/test_shougang_domain_file_counts_dao.py
@@ -124,13 +124,16 @@ async def test_count_files_by_domain_codes_unmatched_code_returns_zero(async_db_
 
 @pytest.mark.asyncio
 async def test_count_files_by_domain_scopes_only_counts_matching_visible_spaces():
+    """Domain scopes still count by encoding business segment (unchanged by category fix)."""
+
     class FakeResult:
         def all(self):
+            # (file_id, reference_document_id, knowledge_id, file_encoding)
             return [
-                (10, "GF-STD-PP-001"),
-                (11, "GF-STD-PP-002"),
-                (20, "GF-STD-QM-003"),
-                (10, "GF-PP-QM-004"),
+                (1, 1, 10, "GF-STD-PP-001"),
+                (2, 2, 11, "GF-STD-PP-002"),
+                (3, 3, 20, "GF-STD-QM-003"),
+                (4, 4, 10, "GF-PP-QM-004"),
             ]
 
     class FakeSession:
@@ -149,17 +152,12 @@ async def test_count_files_by_domain_scopes_only_counts_matching_visible_spaces(
 
 
 @pytest.mark.asyncio
-async def test_count_files_by_category_scopes_filters_by_document_type_in_bound_spaces():
-    """Category homepage counts files whose document-type code matches the card code."""
+async def test_count_files_by_category_scopes_sums_bound_space_file_totals():
+    """Category homepage counts SUCCESS+not-deleted files per bound space (list-aligned)."""
 
     class FakeResult:
         def all(self):
-            return [
-                (10, "GF-STD-PP-001"),
-                (10, "GF-POL-PP-002"),
-                (20, "GF-STD-QM-003"),
-                (10, "GF-PP-QM-004"),
-            ]
+            return [(10, 3), (20, 5)]
 
     class FakeSession:
         async def exec(self, statement):
@@ -169,16 +167,16 @@ async def test_count_files_by_category_scopes_filters_by_document_type_in_bound_
     session = FakeSession()
     with _patch_session_factory(session):
         result = await KnowledgeFileDao.async_count_files_by_category_scopes(
-            {"POL": {10}, "STD": {10, 20}, "QM": {10}},
+            {"POL": {10}, "STD": {10, 20}},
         )
 
-    # Last row's document type is QM (parsed from the right), but space 10 is not in QM scope.
-    assert result == {"POL": 1, "STD": 2, "QM": 0}
+    # Encoding is ignored: POL and STD only sum files in their bound spaces.
+    assert result == {"POL": 3, "STD": 8}
 
 
 @pytest.mark.asyncio
-async def test_count_files_by_category_scopes_rejects_like_overfetch_on_non_document_segment(async_db_session):
-    # LIKE '%-POL-%' prefilter fetches this row, but the document-type segment is STD.
+async def test_count_files_by_category_scopes_does_not_use_encoding_filter(async_db_session):
+    """Category counts include all SUCCESS files in bound spaces, regardless of encoding."""
     await _insert(async_db_session, knowledge_id=10, file_name="a", file_encoding="GF-STD-POL-001")
     await _insert(async_db_session, knowledge_id=10, file_name="b", file_encoding="GF-POL-PP-002")
     await _insert(async_db_session, knowledge_id=20, file_name="c", file_encoding="GF-STD-QM-003")
@@ -188,7 +186,7 @@ async def test_count_files_by_category_scopes_rejects_like_overfetch_on_non_docu
             {"POL": {10}, "STD": {10, 20}},
         )
 
-    assert result == {"POL": 1, "STD": 2}
+    assert result == {"POL": 2, "STD": 3}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Restore portal category-navigation file counts to SUCCESS files in each card’s bound/visible spaces (aligned with the category landing list).
- Leave business-domain scope counting encoding-based and unchanged.
- Update DAO unit tests for the restored category aggregation semantics.

## Test plan
- [ ] `GET/POST` category-file-counts for「人力」(POL) returns bound-space SUCCESS total (e.g. 10), not encoding-only count (1)
- [ ] Domain file counts still use encoding business-domain scopes
- [ ] Run `pytest test/test_shougang_domain_file_counts_dao.py`
- [ ] After deploy, refresh home or wait for portal category-count cache TTL / clear Redis key if stale


Made with [Cursor](https://cursor.com)