### PR TITLE
fix(portal): dept-admin preview-only deep links for member personal files

### DIFF
--- a/src/backend/bisheng/knowledge/domain/services/department_admin_member_access.py
+++ b/src/backend/bisheng/knowledge/domain/services/department_admin_member_access.py
@@ -1,0 +1,69 @@
+"""Read-only dept-admin access helpers for member-owned personal knowledge spaces."""
+
+from __future__ import annotations
+
+from sqlmodel import col, select
+
+from bisheng.core.database import get_async_db_session
+from bisheng.database.models.department import DepartmentDao, UserDepartment
+from bisheng.knowledge.domain.models.knowledge import Knowledge, KnowledgeTypeEnum
+from bisheng.knowledge.domain.models.knowledge_space_scope import (
+    KnowledgeSpaceLevelEnum,
+    KnowledgeSpaceOwnerTypeEnum,
+    KnowledgeSpaceScope,
+)
+
+
+async def aget_dept_admin_scoped_user_ids(admin_user_id: int) -> set[int] | None:
+    """Return user ids under managed department subtrees; None if not a dept admin."""
+    admin_depts = await DepartmentDao.aget_user_admin_departments(int(admin_user_id))
+    if not admin_depts:
+        return None
+
+    internal_ids: set[int] = set()
+    for dept in admin_depts:
+        path = getattr(dept, "path", None) or ""
+        if not path:
+            continue
+        subtree = await DepartmentDao.aget_subtree_ids(path)
+        internal_ids.update(int(item) for item in subtree)
+    if not internal_ids:
+        return set()
+
+    async with get_async_db_session() as session:
+        stmt = select(UserDepartment.user_id).where(
+            col(UserDepartment.department_id).in_(list(internal_ids)),
+        )
+        result = await session.exec(stmt)
+        rows = result.all()
+    return {int(user_id) for user_id in rows}
+
+
+async def is_dept_admin_of_user(admin_user_id: int, target_user_id: int) -> bool:
+    """True when target_user belongs to any department subtree managed by admin_user."""
+    scoped_user_ids = await aget_dept_admin_scoped_user_ids(int(admin_user_id))
+    if scoped_user_ids is None:
+        return False
+    return int(target_user_id) in scoped_user_ids
+
+
+async def aget_member_personal_space_ids(scoped_user_ids: set[int]) -> set[int]:
+    """Personal knowledge space ids owned by users in a dept-admin member scope."""
+    if not scoped_user_ids:
+        return set()
+    owner_ids = sorted(int(user_id) for user_id in scoped_user_ids)
+    async with get_async_db_session() as session:
+        stmt = (
+            select(KnowledgeSpaceScope.space_id)
+            .join(Knowledge, Knowledge.id == KnowledgeSpaceScope.space_id)
+            .where(
+                KnowledgeSpaceScope.level == KnowledgeSpaceLevelEnum.PERSONAL.value,
+                KnowledgeSpaceScope.owner_type == KnowledgeSpaceOwnerTypeEnum.USER.value,
+                col(KnowledgeSpaceScope.owner_id).in_(owner_ids),
+                Knowledge.type == KnowledgeTypeEnum.SPACE.value,
+                Knowledge.is_favorite == False,  # noqa: E712
+            )
+        )
+        result = await session.exec(stmt)
+        rows = result.all()
+    return {int(space_id) for space_id in rows}

--- a/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
+++ b/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
@@ -226,6 +226,8 @@ from bisheng.knowledge.domain.schemas.knowledge_space_schema import (
     UploadFolderRecommendFileReq,
 )
 from bisheng.knowledge.domain.services.department_file_view_access_service import (
+    DepartmentFileAccessDecision,
+    DepartmentFileAccessSource,
     DepartmentFileAccessStatus,
 )
 from bisheng.knowledge.domain.services.favorite_notify import (
@@ -934,6 +936,17 @@ class KnowledgeSpaceService(KnowledgeUtils):
             file=file_record,
         )
         if not decision.allowed:
+            space = await KnowledgeDao.aquery_by_id(int(file_record.knowledge_id))
+            if space and await self._can_dept_admin_preview_member_personal_space(space):
+                if resolved is None:
+                    return None
+                capabilities = resolved.capabilities.model_copy(
+                    update={
+                        "can_view": True,
+                        "can_preview": True,
+                    }
+                )
+                return resolved.model_copy(update={"capabilities": capabilities})
             raise SpacePermissionDeniedError()
 
         capabilities = resolved.capabilities.model_copy(
@@ -3313,7 +3326,40 @@ class KnowledgeSpaceService(KnowledgeUtils):
             return space, True
         if self._is_square_preview_space(space):
             return space, False
+        if await self._can_dept_admin_preview_member_personal_space(space):
+            return space, False
         raise SpacePermissionDeniedError()
+
+    async def _can_dept_admin_preview_member_personal_space(self, space: Knowledge) -> bool:
+        """Dept admin read-only metadata/preview for personal spaces owned by scoped members."""
+        from bisheng.knowledge.domain.services.department_admin_member_access import is_dept_admin_of_user
+
+        owner_id = int(getattr(space, "user_id", 0) or 0)
+        if not owner_id or owner_id == int(self.login_user.user_id):
+            return False
+        level = await self._get_space_level(int(space.id))
+        if level != KnowledgeSpaceLevelEnum.PERSONAL:
+            return False
+        return await is_dept_admin_of_user(int(self.login_user.user_id), owner_id)
+
+    async def _resolve_file_preview_access(
+        self,
+        file_id: int,
+        file_record: KnowledgeFile,
+    ) -> tuple[bool, bool]:
+        """Return (allowed, can_download) for preview; dept-admin member scope is read-only."""
+        effective_permissions = await self._get_effective_permission_ids(
+            "knowledge_file",
+            file_id,
+            space_id=file_record.knowledge_id,
+        )
+        if "view_file" in effective_permissions:
+            return True, "download_file" in effective_permissions
+
+        space = await KnowledgeDao.aquery_by_id(int(file_record.knowledge_id))
+        if space and await self._can_dept_admin_preview_member_personal_space(space):
+            return True, False
+        return False, False
 
     # ──────────────────────────── Space CRUD ──────────────────────────────────
 
@@ -6285,12 +6331,16 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 return {}
         detail = KnowledgeService.get_file_share_detail(content_file)
         if resolved is None:
-            effective_permissions = await self._get_effective_permission_ids(
-                "knowledge_file",
-                int(file.id),
-                space_id=space_id,
-            )
-            detail["can_download"] = "download_file" in effective_permissions
+            allowed, can_download = await self._resolve_file_preview_access(int(file.id), file)
+            if allowed:
+                detail["can_download"] = can_download
+            else:
+                effective_permissions = await self._get_effective_permission_ids(
+                    "knowledge_file",
+                    int(file.id),
+                    space_id=space_id,
+                )
+                detail["can_download"] = "download_file" in effective_permissions
         else:
             detail.update(
                 {
@@ -6548,6 +6598,20 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 discovery_scope="public_and_department",
             )
             return (file, spaces) if spaces else (None, [])
+
+        if decision.status == DepartmentFileAccessStatus.NOT_APPLICABLE:
+            space = await KnowledgeDao.aquery_by_id(int(space_id))
+            if space and await self._can_dept_admin_preview_member_personal_space(space):
+                bypass_decision = DepartmentFileAccessDecision(
+                    file_id=int(file.id),
+                    space_id=int(space_id),
+                    status=DepartmentFileAccessStatus.ALLOWED,
+                    source=DepartmentFileAccessSource.DEPARTMENT_APPROVER,
+                    can_download=False,
+                )
+                self._portal_file_access_decision_map[int(file.id)] = bypass_decision
+                self._portal_file_download_map[int(file.id)] = False
+                return (file, [])
 
         spaces = await self._get_shougang_portal_visible_search_spaces(
             [space_id],
@@ -15083,18 +15147,36 @@ class KnowledgeSpaceService(KnowledgeUtils):
 
     async def get_file_preview(self, file_id: int) -> dict:
         file_record = await self._get_file_for_action(file_id)
-        resolved = await self._resolve_document_entry(
+        preview_allowed, preview_can_download = await self._resolve_file_preview_access(
+            file_id,
             file_record,
-            required_capability="can_preview",
         )
-        if resolved is None:
-            await self._require_file_relation(file_id, "can_read")
-            await self._require_permission_id(
-                "knowledge_file",
-                file_id,
-                "view_file",
-                space_id=file_record.knowledge_id,
+        resolved = None
+        if preview_allowed:
+            resolved = await self._resolve_document_entry(file_record, required_capability=None)
+            if resolved is not None and not bool(getattr(resolved.capabilities, "can_preview", False)):
+                resolved = None
+        else:
+            resolved = await self._resolve_document_entry(
+                file_record,
+                required_capability="can_preview",
             )
+
+        if resolved is None:
+            if not preview_allowed:
+                await self._require_file_relation(file_id, "can_read")
+                await self._require_permission_id(
+                    "knowledge_file",
+                    file_id,
+                    "view_file",
+                    space_id=file_record.knowledge_id,
+                )
+                effective_permissions = await self._get_effective_permission_ids(
+                    "knowledge_file",
+                    file_id,
+                    space_id=file_record.knowledge_id,
+                )
+                preview_can_download = "download_file" in effective_permissions
             content_file = file_record
         elif int(resolved.content_file_id) == int(file_record.id):
             content_file = file_record
@@ -15109,12 +15191,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
 
         detail = KnowledgeService.get_file_share_detail(content_file)
         if resolved is None:
-            effective_permissions = await self._get_effective_permission_ids(
-                "knowledge_file",
-                file_id,
-                space_id=file_record.knowledge_id,
-            )
-            detail["can_download"] = "download_file" in effective_permissions
+            detail["can_download"] = preview_can_download
         else:
             detail.update(
                 {

--- a/src/backend/bisheng/workstation/domain/services/workstation_tags_service.py
+++ b/src/backend/bisheng/workstation/domain/services/workstation_tags_service.py
@@ -47,7 +47,9 @@ class WorkStationTagsService(BaseService):
 
         ``None`` means full-tenant access (global super / RBAC admin / child
         tenant admin). A ``set`` (possibly empty) means org department-admin
-        scope. Raises when the caller cannot review tags at all.
+        scope, including department-bound spaces and personal spaces owned by
+        members under managed departments. Raises when the caller cannot review
+        tags at all.
         """
         login_user = self.login_user
         if bool(getattr(login_user, "is_global_super", False)):
@@ -86,7 +88,17 @@ class WorkStationTagsService(BaseService):
                 dept_ids.update(int(i) for i in await DepartmentDao.aget_subtree_ids(path))
 
         bindings = await DepartmentKnowledgeSpaceDao.aget_by_department_ids(sorted(dept_ids))
-        return {int(binding.space_id) for binding in bindings or [] if getattr(binding, "space_id", None)}
+        space_ids = {int(binding.space_id) for binding in bindings or [] if getattr(binding, "space_id", None)}
+
+        from bisheng.knowledge.domain.services.department_admin_member_access import (
+            aget_dept_admin_scoped_user_ids,
+            aget_member_personal_space_ids,
+        )
+
+        scoped_user_ids = await aget_dept_admin_scoped_user_ids(int(login_user.user_id))
+        if scoped_user_ids:
+            space_ids.update(await aget_member_personal_space_ids(scoped_user_ids))
+        return space_ids
 
     def _ensure_knowledge_in_scope(self, knowledge_id: int | None, space_ids: set[int] | None) -> None:
         """Reject approve when department admin picks a space outside scope."""

--- a/src/backend/test/knowledge/test_dept_admin_member_personal_preview.py
+++ b/src/backend/test/knowledge/test_dept_admin_member_personal_preview.py
@@ -1,0 +1,219 @@
+"""Tests for dept-admin read-only preview of member personal knowledge spaces."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bisheng.common.errcode.knowledge_space import SpacePermissionDeniedError
+from bisheng.knowledge.domain.models.knowledge import Knowledge, KnowledgeTypeEnum
+from bisheng.knowledge.domain.models.knowledge_space_scope import KnowledgeSpaceLevelEnum
+from bisheng.knowledge.domain.models.knowledge_file import FileType, KnowledgeFileStatus
+
+
+def _install_schema_stubs() -> None:
+    if "bisheng.common.services.base" not in sys.modules:
+        base_service_stub = types.ModuleType("bisheng.common.services.base")
+        base_service_stub.BaseService = type("BaseService", (), {})
+        sys.modules["bisheng.common.services.base"] = base_service_stub
+
+
+def _load_service_class():
+    _install_schema_stubs()
+    module = importlib.import_module("bisheng.knowledge.domain.services.knowledge_space_service")
+    return module.KnowledgeSpaceService
+
+
+def _make_login_user(user_id: int = 9) -> SimpleNamespace:
+    return SimpleNamespace(
+        user_id=user_id,
+        user_name="dept-admin",
+        tenant_id=1,
+        is_admin=lambda: False,
+        get_user_group_ids=AsyncMock(return_value=[]),
+    )
+
+
+def _make_personal_space(*, space_id: int = 165, owner_id: int = 42) -> Knowledge:
+    return Knowledge(
+        id=space_id,
+        user_id=owner_id,
+        name="Member Personal Space",
+        type=KnowledgeTypeEnum.SPACE.value,
+        description="",
+        model="model-1",
+        state=1,
+    )
+
+
+def _make_file(*, file_id: int = 1485, space_id: int = 165) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=file_id,
+        knowledge_id=space_id,
+        user_id=42,
+        file_type=FileType.FILE.value,
+        status=KnowledgeFileStatus.SUCCESS.value,
+        object_name="README.txt",
+        file_name="README.txt",
+    )
+
+
+@pytest.fixture
+def service():
+    return _load_service_class()(MagicMock(), _make_login_user(user_id=9))
+
+
+@pytest.mark.asyncio
+async def test_get_space_info_allows_dept_admin_member_personal_preview(service):
+    member_space = _make_personal_space(owner_id=42)
+    with (
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.KnowledgeDao.aquery_by_id",
+            new=AsyncMock(return_value=member_space),
+        ),
+        patch.object(
+            service,
+            "_get_effective_permission_ids",
+            new=AsyncMock(return_value=set()),
+        ),
+        patch.object(
+            service,
+            "_can_dept_admin_preview_member_personal_space",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.SpaceChannelMemberDao.async_count_space_members",
+            new=AsyncMock(return_value=1),
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.KnowledgeFileDao.async_count_success_files_batch",
+            new=AsyncMock(return_value={165: 1}),
+        ),
+        patch.object(service, "_decorate_auto_tag_for_info", new=AsyncMock()),
+        patch.object(service, "_get_space_level", new=AsyncMock(return_value=KnowledgeSpaceLevelEnum.PERSONAL)),
+    ):
+        result = await service.get_space_info(165)
+
+    assert result.id == 165
+    assert result.user_name is not None
+
+
+@pytest.mark.asyncio
+async def test_get_space_info_denies_dept_admin_for_non_member_personal_space(service):
+    member_space = _make_personal_space(owner_id=99)
+    with (
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.KnowledgeDao.aquery_by_id",
+            new=AsyncMock(return_value=member_space),
+        ),
+        patch.object(
+            service,
+            "_get_effective_permission_ids",
+            new=AsyncMock(return_value=set()),
+        ),
+        patch.object(
+            service,
+            "_can_dept_admin_preview_member_personal_space",
+            new=AsyncMock(return_value=False),
+        ),
+    ):
+        with pytest.raises(SpacePermissionDeniedError):
+            await service.get_space_info(165)
+
+
+@pytest.mark.asyncio
+async def test_get_file_preview_allows_dept_admin_read_only(service):
+    file_record = _make_file()
+    with (
+        patch.object(service, "_get_file_for_action", new=AsyncMock(return_value=file_record)),
+        patch.object(service, "_resolve_document_entry", new=AsyncMock(return_value=None)),
+        patch.object(
+            service,
+            "_resolve_file_preview_access",
+            new=AsyncMock(return_value=(True, False)),
+        ),
+        patch.object(service, "_log_file_preview_success", new=AsyncMock()),
+        patch.object(service, "_log_portal_document_read_success", new=AsyncMock()),
+        patch.object(service, "_is_portal_bff_proxy_request", return_value=False),
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.KnowledgeService.get_file_share_detail",
+            return_value={"preview_url": "/preview", "original_url": "/origin"},
+        ),
+    ):
+        detail = await service.get_file_preview(1485)
+
+    assert detail["can_download"] is False
+
+
+@pytest.mark.asyncio
+async def test_is_dept_admin_of_user_matches_subtree_membership():
+    from bisheng.knowledge.domain.services.department_admin_member_access import is_dept_admin_of_user
+
+    admin_dept = SimpleNamespace(id=10, path="1/10/")
+    with (
+        patch(
+            "bisheng.knowledge.domain.services.department_admin_member_access.DepartmentDao.aget_user_admin_departments",
+            new=AsyncMock(return_value=[admin_dept]),
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.department_admin_member_access.DepartmentDao.aget_subtree_ids",
+            new=AsyncMock(return_value=[10, 11]),
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.department_admin_member_access.get_async_db_session",
+        ) as mock_session_ctx,
+    ):
+        session = AsyncMock()
+        session.exec = AsyncMock(return_value=SimpleNamespace(all=lambda: [42, 43]))
+        mock_session_ctx.return_value.__aenter__ = AsyncMock(return_value=session)
+        mock_session_ctx.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        assert await is_dept_admin_of_user(9, 42) is True
+        assert await is_dept_admin_of_user(9, 999) is False
+
+
+@pytest.mark.asyncio
+async def test_get_file_preview_allows_dept_admin_before_document_entry_gate(service):
+    file_record = _make_file()
+    resolved_entry = SimpleNamespace(
+        content_file_id=999,
+        capabilities=SimpleNamespace(can_preview=False, can_download=False),
+    )
+    with (
+        patch.object(service, "_get_file_for_action", new=AsyncMock(return_value=file_record)),
+        patch.object(
+            service,
+            "_resolve_file_preview_access",
+            new=AsyncMock(return_value=(True, False)),
+        ),
+        patch.object(service, "_resolve_document_entry", new=AsyncMock(return_value=resolved_entry)),
+        patch.object(service, "_log_file_preview_success", new=AsyncMock()),
+        patch.object(service, "_log_portal_document_read_success", new=AsyncMock()),
+        patch.object(service, "_is_portal_bff_proxy_request", return_value=False),
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.KnowledgeService.get_file_share_detail",
+            return_value={"preview_url": "/preview", "original_url": "/origin"},
+        ),
+    ):
+        detail = await service.get_file_preview(1485)
+
+    assert detail["preview_url"] == "/preview"
+    service._resolve_document_entry.assert_awaited_once_with(file_record, required_capability=None)
+    from bisheng.knowledge.domain.services.department_admin_member_access import aget_member_personal_space_ids
+
+    with patch(
+        "bisheng.knowledge.domain.services.department_admin_member_access.get_async_db_session",
+    ) as mock_session_ctx:
+        session = AsyncMock()
+        session.exec = AsyncMock(return_value=SimpleNamespace(all=lambda: [165, 167]))
+        mock_session_ctx.return_value.__aenter__ = AsyncMock(return_value=session)
+        mock_session_ctx.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        space_ids = await aget_member_personal_space_ids({42})
+
+    assert space_ids == {165, 167}

--- a/src/backend/test/workstation/test_review_tag_dept_admin_scope.py
+++ b/src/backend/test/workstation/test_review_tag_dept_admin_scope.py
@@ -82,10 +82,45 @@ async def test_resolve_reviewable_space_ids_for_department_admin():
                 ]
             ),
         ),
+        patch(
+            "bisheng.knowledge.domain.services.department_admin_member_access.aget_dept_admin_scoped_user_ids",
+            new=AsyncMock(return_value={42, 43}),
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.department_admin_member_access.aget_member_personal_space_ids",
+            new=AsyncMock(return_value={165, 166}),
+        ),
     ):
         space_ids = await service.resolve_reviewable_space_ids()
 
-    assert space_ids == {100, 101}
+    assert space_ids == {100, 101, 165, 166}
+
+
+@pytest.mark.asyncio
+async def test_resolve_reviewable_space_ids_includes_member_personal_spaces_only_when_scoped_users_exist():
+    service = _build_service()
+    admin_dept = SimpleNamespace(id=10, path="1/10/")
+    with (
+        patch(
+            "bisheng.database.models.department.DepartmentDao.aget_user_admin_departments",
+            new=AsyncMock(return_value=[admin_dept]),
+        ),
+        patch(
+            "bisheng.database.models.department.DepartmentDao.aget_subtree_ids",
+            new=AsyncMock(return_value=[10]),
+        ),
+        patch(
+            "bisheng.knowledge.domain.models.department_knowledge_space.DepartmentKnowledgeSpaceDao.aget_by_department_ids",
+            new=AsyncMock(return_value=[SimpleNamespace(space_id=100)]),
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.department_admin_member_access.aget_dept_admin_scoped_user_ids",
+            new=AsyncMock(return_value=set()),
+        ),
+    ):
+        space_ids = await service.resolve_reviewable_space_ids()
+
+    assert space_ids == {100}
 
 
 @pytest.mark.asyncio

--- a/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.test.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.test.tsx
@@ -642,6 +642,9 @@ function openKnowledgeFileFromPortalShell(payload: {
     spaceId: string;
     fileId: string;
     fileName?: string;
+    folderId?: string;
+    parent_id?: string;
+    parentId?: string;
     openNonce?: string;
 }) {
     act(() => {
@@ -2593,6 +2596,56 @@ describe("PortalKnowledgeWorkbench", () => {
         }
     });
 
+    test("opens tag-review deep link to an out-of-sidebar personal space via getSpaceInfo", async () => {
+        const favoriteSpace = makeDefaultFavoriteSpace();
+        const externalPersonalSpace = makeSpace("165", "gzx0169的知识库", {
+            role: SpaceRole.ADMIN,
+            spaceLevel: SpaceLevel.PERSONAL,
+        });
+        const targetFile = makeFile("1485", "README_文件清单.txt", {
+            type: FileType.OTHER,
+            spaceId: "165",
+        });
+        jest.mocked(getGroupedSpacesApi).mockResolvedValue({
+            publicSpaces: [],
+            departmentSpaces: [],
+            teamSpaces: [],
+            personalSpaces: [favoriteSpace],
+        } as any);
+        jest.mocked(getSpaceInfoApi).mockResolvedValue(externalPersonalSpace as any);
+        jest.mocked(getSpaceChildrenApi).mockImplementation(async (params: any) => (
+            params.space_id === "165"
+                ? { data: [targetFile], total: 1 }
+                : { data: [], total: 0 }
+        ) as any);
+        jest.mocked(searchSpaceChildrenApi).mockResolvedValue({
+            data: [targetFile],
+            total: 1,
+        } as any);
+
+        renderWorkbench(
+            "/knowledge-portal?spaceId=165&fileId=1485&fileName=README_%E6%96%87%E4%BB%B6%E6%B8%85%E5%8D%95.txt",
+        );
+
+        await waitFor(() => {
+            expect(getSpaceInfoApi).toHaveBeenCalledWith("165");
+        });
+
+        const preview = await screen.findByTestId("portal-preview-page");
+        expect(preview).toHaveTextContent("README_文件清单.txt");
+        // Preview-only: sidebar stays on 我的收藏, not the foreign personal space.
+        expect(screen.getByTestId("space-row-favorite-space")).toBeInTheDocument();
+        expect(screen.queryByTestId("space-row-165")).not.toBeInTheDocument();
+        expect(getSpaceChildrenApi).not.toHaveBeenCalledWith(expect.objectContaining({
+            space_id: "165",
+            parent_id: expect.anything(),
+        }));
+        await waitFor(() => {
+            expect(getPortalFilePreviewApi).toHaveBeenCalledWith("165", "1485");
+        });
+        expect(getFilePreviewApi).not.toHaveBeenCalledWith("165", "1485");
+    });
+
     test("opens a deep-linked portal folder from query params", async () => {
         const personalSpace = makeSpace("personal-1", "信息", {
             role: SpaceRole.ADMIN,
@@ -2750,6 +2803,53 @@ describe("PortalKnowledgeWorkbench", () => {
         const restoredWorkspace = await screen.findByTestId("portal-file-workspace");
         expect(within(restoredWorkspace).getByText("目标文档.md")).toBeInTheDocument();
         expect(within(restoredWorkspace).getByText("同目录其它.md")).toBeInTheDocument();
+    });
+
+    test("tag-review postMessage accepts parent_id and navigates into the folder before preview", async () => {
+        const personalSpace = makeSpace("personal-1", "信息", {
+            role: SpaceRole.ADMIN,
+        });
+        const targetFile = makeFile("201", "目标文档.md", {
+            type: FileType.MD,
+            spaceId: "personal-1",
+            parentId: "101",
+        });
+        jest.mocked(getGroupedSpacesApi).mockResolvedValue({
+            publicSpaces: [],
+            departmentSpaces: [],
+            teamSpaces: [],
+            personalSpaces: [personalSpace],
+        } as any);
+        jest.mocked(getSpaceChildrenApi).mockImplementation(async (params: any) => {
+            if (params.parent_id === "101") {
+                return { data: [targetFile], total: 1 };
+            }
+            return { data: [], total: 0 };
+        });
+        jest.mocked(searchSpaceChildrenApi).mockResolvedValue({
+            data: [targetFile],
+            total: 1,
+        } as any);
+
+        renderWorkbench("/knowledge-portal");
+        await screen.findByTestId("portal-file-workspace");
+
+        openKnowledgeFileFromPortalShell({
+            spaceId: "personal-1",
+            fileId: "201",
+            fileName: "目标文档.md",
+            parent_id: "101",
+            openNonce: "tag-review-parent-id",
+        });
+
+        const preview = await screen.findByTestId("portal-preview-page");
+        expect(preview).toHaveTextContent("目标文档.md");
+        await waitFor(() => {
+            expect(getSpaceChildrenApi).toHaveBeenCalledWith(expect.objectContaining({
+                space_id: "personal-1",
+                parent_id: "101",
+            }));
+        });
     });
 
     test("formats table update times as full date time without relative labels", async () => {

--- a/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.tsx
@@ -324,6 +324,11 @@ export default function PortalKnowledgeWorkbench() {
     const isDeepLinkRestoring = Boolean(
         portalDeepLinkTarget && restoringDeepLinkKey === portalDeepLinkTarget.key,
     );
+    const isCrossSpacePreview = Boolean(
+        selectedFile?.spaceId
+        && activeSpace?.id
+        && String(selectedFile.spaceId) !== String(activeSpace.id),
+    );
     const selectedFileUsesPortalContentGate = Boolean(
         activeSpace
         && selectedFile
@@ -358,6 +363,10 @@ export default function PortalKnowledgeWorkbench() {
         createPermissionByLevel,
         selectableSpaces,
         spaceLoading,
+        preferredSpace,
+        preferredSpacePending,
+        preferredSpaceResolveFailed,
+        previewOnlyTargetSpace,
         activeGroup,
         getSpacePermissions,
         requestSpacePermissions,
@@ -365,28 +374,54 @@ export default function PortalKnowledgeWorkbench() {
         activeSpace,
         setActiveSpace,
         expandedGroups,
-        preferredSpaceId: isDeepLinkRestoring ? portalDeepLinkTarget?.spaceId : undefined,
+        preferredSpaceId: portalDeepLinkTarget?.spaceId,
+        deepLinkFileId: portalDeepLinkTarget?.fileId,
     });
+
+    const isPreviewOnlyDeepLink = Boolean(
+        previewOnlyTargetSpace
+        && portalDeepLinkTarget?.fileId
+        && String(previewOnlyTargetSpace.id) === portalDeepLinkTarget.spaceId,
+    );
+    const isPotentialOutOfSidebarFileDeepLink = Boolean(
+        portalDeepLinkTarget?.fileId
+        && portalDeepLinkTarget.spaceId
+        && !selectableSpaces.some((space) => String(space.id) === portalDeepLinkTarget.spaceId),
+    );
+    const preservesCrossSpaceDeepLinkPreview = isPreviewOnlyDeepLink || isPotentialOutOfSidebarFileDeepLink;
 
     const handleDeepLinkRestoreComplete = useCallback((targetKey: string) => {
         setRestoringDeepLinkKey((current) => (current === targetKey ? null : current));
     }, []);
 
     useEffect(() => {
+        if (!preferredSpaceResolveFailed || !portalDeepLinkTarget?.spaceId) return;
+        setRestoringDeepLinkKey((current) => (
+            current === portalDeepLinkTarget.key ? null : current
+        ));
+        showToast({
+            message: "无法打开目标知识库，可能没有查看权限",
+            severity: NotificationSeverity.ERROR,
+        });
+    }, [portalDeepLinkTarget?.key, portalDeepLinkTarget?.spaceId, preferredSpaceResolveFailed, showToast]);
+
+    useEffect(() => {
         if (!portalDeepLinkTarget || restoringDeepLinkKey !== portalDeepLinkTarget.key) return;
-        const targetSpaceExists = selectableSpaces.some(
+        const targetInSidebar = selectableSpaces.some(
             (space) => String(space.id) === portalDeepLinkTarget.spaceId,
         );
+        // Out-of-sidebar targets (tag review → another user's personal space) resolve via getSpaceInfo.
+        const targetResolvable = targetInSidebar || Boolean(preferredSpace) || preferredSpacePending;
 
         if (!activeSpace && !spaceLoading) {
-            // Spaces finished loading with no active space — only fail if the target is missing.
-            if (!targetSpaceExists) setRestoringDeepLinkKey(null);
+            if (!targetResolvable && !preferredSpacePending) {
+                setRestoringDeepLinkKey(null);
+            }
             return;
         }
         if (activeSpace && String(activeSpace.id) !== portalDeepLinkTarget.spaceId && !spaceLoading) {
-            // Target space is available: keep overlay while setActiveSpace catches up.
-            // Clearing here used to flash the previous/current space file list before the file opened.
-            if (targetSpaceExists) return;
+            // Keep overlay while preferredSpace / setActiveSpace catches up.
+            if (targetResolvable) return;
             setRestoringDeepLinkKey(null);
             return;
         }
@@ -401,6 +436,8 @@ export default function PortalKnowledgeWorkbench() {
     }, [
         activeSpace,
         portalDeepLinkTarget,
+        preferredSpace,
+        preferredSpacePending,
         restoringDeepLinkKey,
         selectableSpaces,
         spaceLoading,
@@ -1401,9 +1438,11 @@ export default function PortalKnowledgeWorkbench() {
                 const spaceId = String(event.data?.spaceId ?? "").trim();
                 const fileId = String(event.data?.fileId ?? "").trim();
                 if (!spaceId || !fileId) return;
-                const fileName = String(event.data?.fileName ?? "").trim();
-                const folderId = String(event.data?.folderId ?? "").trim();
-                const folderName = String(event.data?.folderName ?? "").trim();
+                const fileName = String(event.data?.fileName ?? event.data?.file_name ?? "").trim();
+                const folderId = String(
+                    event.data?.folderId ?? event.data?.parent_id ?? event.data?.parentId ?? "",
+                ).trim();
+                const folderName = String(event.data?.folderName ?? event.data?.folder_name ?? "").trim();
                 const openNonce = String(event.data?.openNonce ?? "").trim() || String(Date.now());
                 setSearchParams((prev) => {
                     const next = new URLSearchParams(prev);
@@ -1509,7 +1548,10 @@ export default function PortalKnowledgeWorkbench() {
         // settles must not re-run this effect and wipe the file we just opened.
         const openingDeepLinkedFileHere = Boolean(
             portalDeepLinkTarget?.fileId
-            && String(activeSpace.id) === portalDeepLinkTarget.spaceId,
+            && (
+                String(activeSpace.id) === portalDeepLinkTarget.spaceId
+                || preservesCrossSpaceDeepLinkPreview
+            ),
         );
 
         // While a deep-linked file open targets this space, do not wipe selection/search.
@@ -1554,6 +1596,7 @@ export default function PortalKnowledgeWorkbench() {
         activeSpace?.id,
         portalDeepLinkTarget?.fileId,
         portalDeepLinkTarget?.spaceId,
+        preservesCrossSpaceDeepLinkPreview,
         sortBy,
         sortDirection,
         statusFilterNumbers,
@@ -1569,7 +1612,10 @@ export default function PortalKnowledgeWorkbench() {
         if (
             portalDeepLinkTarget?.fileId
             && String(selectedFile.id) === portalDeepLinkTarget.fileId
-            && String(activeSpace?.id) === portalDeepLinkTarget.spaceId
+            && (
+                String(activeSpace?.id) === portalDeepLinkTarget.spaceId
+                || preservesCrossSpaceDeepLinkPreview
+            )
         ) {
             return;
         }
@@ -1587,6 +1633,7 @@ export default function PortalKnowledgeWorkbench() {
         isDeepLinkRestoring,
         portalDeepLinkTarget?.fileId,
         portalDeepLinkTarget?.spaceId,
+        preservesCrossSpaceDeepLinkPreview,
     ]);
 
     useEffect(() => {
@@ -1807,7 +1854,7 @@ export default function PortalKnowledgeWorkbench() {
             previewData: null,
         });
 
-        const loadPreview = selectedFileUsesPortalContentGate
+        const loadPreview = selectedFileUsesPortalContentGate || isCrossSpacePreview
             ? getPortalFilePreviewApi
             : getFilePreviewApi;
         loadPreview(
@@ -1862,7 +1909,7 @@ export default function PortalKnowledgeWorkbench() {
         return () => {
             cancelled = true;
         };
-    }, [activeSpace, selectedFile, selectedFileUsesPortalContentGate]);
+    }, [activeSpace, selectedFile, selectedFileUsesPortalContentGate, isCrossSpacePreview]);
 
     const showUnavailable = useCallback(() => {
         showToast({ message: "暂未开放", severity: NotificationSeverity.INFO });
@@ -2392,6 +2439,7 @@ export default function PortalKnowledgeWorkbench() {
         setSelectedFile,
         onNavigateFolder: handleNavigateFolder,
         onRestoreComplete: handleDeepLinkRestoreComplete,
+        previewOnlyTargetSpace,
     });
 
     const handleNativePageChange = useCallback((page: number) => {

--- a/src/frontend/client/src/pages/knowledge/portal/favoriteView.ts
+++ b/src/frontend/client/src/pages/knowledge/portal/favoriteView.ts
@@ -1,8 +1,21 @@
-import type { PortalFavoriteFile } from "~/api/knowledge";
+import { SpaceLevel, type KnowledgeSpace, type PortalFavoriteFile } from "~/api/knowledge";
 
 /** 判断一个知识空间是否为"我的收藏"虚拟库。 */
 export function isFavoriteSpace(space: { isFavorite?: boolean } | null | undefined): boolean {
     return Boolean(space?.isFavorite);
+}
+
+/**
+ * True when a personal space is reachable via getSpaceInfo but absent from the sidebar
+ * (e.g. another user's personal library opened from tag review).
+ */
+export function isOutOfSidebarPersonalSpace(
+    space: KnowledgeSpace,
+    selectableSpaces: KnowledgeSpace[],
+): boolean {
+    if (isFavoriteSpace(space)) return false;
+    if (space.spaceLevel !== SpaceLevel.PERSONAL) return false;
+    return !selectableSpaces.some((item) => String(item.id) === String(space.id));
 }
 
 /** 收藏列表行的展示/判定视图模型（纯数据，便于单测）。 */

--- a/src/frontend/client/src/pages/knowledge/portal/hooks/usePortalDeepLink.ts
+++ b/src/frontend/client/src/pages/knowledge/portal/hooks/usePortalDeepLink.ts
@@ -4,6 +4,7 @@ import {
     FileType,
     KnowledgeFile,
     KnowledgeSpace,
+    getSpaceChildrenApi,
     searchSpaceChildrenApi,
 } from "~/api/knowledge";
 import { TREE_PAGE_SIZE } from "../constants";
@@ -38,6 +39,8 @@ interface UsePortalDeepLinkParams {
     setSelectedFile: Dispatch<SetStateAction<KnowledgeFile | null>>;
     onNavigateFolder: (folderId?: string, folderName?: string) => void | Promise<void>;
     onRestoreComplete?: (targetKey: string) => void;
+    /** Out-of-sidebar personal space: open preview in place without switching sidebar/tree. */
+    previewOnlyTargetSpace?: KnowledgeSpace | null;
 }
 
 const getQueryValue = (searchParams: URLSearchParams, keys: string[]) => {
@@ -51,7 +54,8 @@ const getQueryValue = (searchParams: URLSearchParams, keys: string[]) => {
 export const resolvePortalDeepLinkTarget = (searchParams: URLSearchParams): PortalDeepLinkTarget | null => {
     const spaceId = getQueryValue(searchParams, ["spaceId", "knowledgeId", "knowledge_id"]);
     if (!spaceId) return null;
-    const folderId = getQueryValue(searchParams, ["folderId", "folder_id"]);
+    // Review-tag list APIs expose parent_id; portal shell may forward it unchanged.
+    const folderId = getQueryValue(searchParams, ["folderId", "folder_id", "parent_id", "parentId"]);
     const folderName = getQueryValue(searchParams, ["folderName", "folder_name"]);
     const fileId = getQueryValue(searchParams, ["fileId", "documentId", "document_id"]);
     const fileName = getQueryValue(searchParams, ["name", "fileName", "documentName", "document_name"]);
@@ -110,10 +114,16 @@ export function usePortalDeepLink({
     setSelectedFile,
     onNavigateFolder,
     onRestoreComplete,
+    previewOnlyTargetSpace = null,
 }: UsePortalDeepLinkParams) {
     const deepLinkTarget = useMemo(
         () => resolvePortalDeepLinkTarget(searchParams),
         [searchParams],
+    );
+    const isPreviewOnlyDeepLink = Boolean(
+        previewOnlyTargetSpace
+        && deepLinkTarget?.fileId
+        && String(previewOnlyTargetSpace.id) === deepLinkTarget.spaceId,
     );
     const deepLinkSpaceAppliedRef = useRef<string | null>(null);
     const deepLinkFolderAppliedRef = useRef<string | null>(null);
@@ -130,16 +140,28 @@ export function usePortalDeepLink({
 
     useEffect(() => {
         if (!deepLinkTarget || deepLinkSpaceAppliedRef.current === deepLinkTarget.key) return;
-        const targetSpace = selectableSpaces.find((space) => String(space.id) === deepLinkTarget.spaceId);
+        if (isPreviewOnlyDeepLink) {
+            deepLinkSpaceAppliedRef.current = deepLinkTarget.key;
+            return;
+        }
+        // Tag-review / admin deep links may target a space returned only by getSpaceInfo,
+        // not present in lazy-loaded sidebar lists (e.g. another user's personal library).
+        const targetSpace = selectableSpaces.find((space) => String(space.id) === deepLinkTarget.spaceId)
+            ?? (
+                activeSpace && String(activeSpace.id) === deepLinkTarget.spaceId
+                    ? activeSpace
+                    : null
+            );
         if (!targetSpace) return;
         deepLinkSpaceAppliedRef.current = deepLinkTarget.key;
         if (String(activeSpace?.id) !== deepLinkTarget.spaceId) {
             setActiveSpace(targetSpace);
         }
-    }, [activeSpace?.id, deepLinkTarget, selectableSpaces, setActiveSpace]);
+    }, [activeSpace, deepLinkTarget, isPreviewOnlyDeepLink, selectableSpaces, setActiveSpace]);
 
     useEffect(() => {
-        if (!deepLinkTarget?.folderId || !activeSpace || String(activeSpace.id) !== deepLinkTarget.spaceId) return;
+        if (!deepLinkTarget?.folderId || isPreviewOnlyDeepLink) return;
+        if (!activeSpace || String(activeSpace.id) !== deepLinkTarget.spaceId) return;
         if (deepLinkFolderAppliedRef.current === deepLinkTarget.key) return;
         deepLinkFolderAppliedRef.current = deepLinkTarget.key;
         setSelectedFile(null);
@@ -162,6 +184,75 @@ export function usePortalDeepLink({
         deepLinkTarget,
         onNavigateFolder,
         onRestoreComplete,
+        setSearchLoading,
+        setSearchMode,
+        setSearchResults,
+        setSearchText,
+        setSelectedFile,
+        setSelectedFileIds,
+        setSelectedFolderIds,
+    ]);
+
+    /** Tag-review → others' personal library: preview only, same pattern as favorites source open. */
+    useEffect(() => {
+        if (!isPreviewOnlyDeepLink || !deepLinkTarget?.fileId || !previewOnlyTargetSpace) return;
+        if (deepLinkHandledRef.current === deepLinkTarget.key) return;
+
+        deepLinkFolderAppliedRef.current = deepLinkTarget.key;
+        const target = deepLinkTarget;
+        const fallbackFile = createDeepLinkedFile(target, target.fileId);
+        setSelectedFileIds(new Set());
+        setSelectedFolderIds(new Set());
+        setSearchText("");
+        setSearchLoading(false);
+        setSearchMode(false);
+        setSearchResults([]);
+        setSelectedFile(fallbackFile);
+        deepLinkHandledRef.current = target.key;
+
+        let cancelled = false;
+        void Promise.all([
+            getSpaceChildrenApi({
+                space_id: target.spaceId,
+                file_ids: [target.fileId],
+                page_size: 1,
+                order_field: "update_time",
+                order_sort: "desc",
+            }),
+            Promise.resolve(previewOnlyTargetSpace),
+        ]).then(([fileResult, sourceSpace]) => {
+            if (cancelled || deepLinkHandledRef.current !== target.key) return;
+            const sourceFile = fileResult.data[0];
+            if (!sourceFile) return;
+            const resolvedSourceSpaceName = sourceFile.sourceSpaceName || sourceSpace?.name || "";
+            const sourcePathTail = sourceFile.sourcePath || sourceFile.folderPath || sourceFile.path || sourceFile.name;
+            const resolvedSourcePath = resolvedSourceSpaceName
+                && sourcePathTail
+                && !String(sourcePathTail).includes(resolvedSourceSpaceName)
+                ? `${resolvedSourceSpaceName}/${sourcePathTail}`
+                : sourcePathTail;
+            setSelectedFile((current) => (
+                current
+                && String(current.id) === String(target.fileId)
+                && String(current.spaceId) === String(target.spaceId)
+                    ? {
+                        ...sourceFile,
+                        sourceSpaceName: resolvedSourceSpaceName,
+                        sourcePath: resolvedSourcePath,
+                    }
+                    : current
+            ));
+        }).catch(() => {
+            // Synthetic file is enough for preview when metadata enrichment fails.
+        });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [
+        deepLinkTarget,
+        isPreviewOnlyDeepLink,
+        previewOnlyTargetSpace,
         setSearchLoading,
         setSearchMode,
         setSearchResults,
@@ -194,6 +285,7 @@ export function usePortalDeepLink({
 
     // Fast path: open when the target row is already in the current list.
     useEffect(() => {
+        if (isPreviewOnlyDeepLink) return;
         if (!deepLinkTarget?.fileId || !activeSpace || String(activeSpace.id) !== deepLinkTarget.spaceId) return;
         if (deepLinkTarget.folderId && deepLinkFolderAppliedRef.current !== deepLinkTarget.key) return;
         if (deepLinkHandledRef.current === deepLinkTarget.key) return;
@@ -218,11 +310,13 @@ export function usePortalDeepLink({
         setSelectedFileIds,
         setSelectedFolderIds,
         activeSpaceIdRef,
+        isPreviewOnlyDeepLink,
     ]);
 
     // Slow path: search once per deep-link key. Do NOT depend on displayedFiles — tree
     // updates used to cancel in-flight search and leave the space list visible without a file.
     useEffect(() => {
+        if (isPreviewOnlyDeepLink) return;
         if (!deepLinkTarget?.fileId || !activeSpace || String(activeSpace.id) !== deepLinkTarget.spaceId) return;
         if (deepLinkTarget.folderId && deepLinkFolderAppliedRef.current !== deepLinkTarget.key) return;
         if (deepLinkHandledRef.current === deepLinkTarget.key) return;
@@ -283,5 +377,6 @@ export function usePortalDeepLink({
         setSelectedFile,
         setSelectedFileIds,
         setSelectedFolderIds,
+        isPreviewOnlyDeepLink,
     ]);
 }

--- a/src/frontend/client/src/pages/knowledge/portal/hooks/usePortalSpaces.ts
+++ b/src/frontend/client/src/pages/knowledge/portal/hooks/usePortalSpaces.ts
@@ -9,6 +9,7 @@ import {
     SpaceSortType,
     type KnowledgeSpace,
 } from "~/api/knowledge";
+import { isOutOfSidebarPersonalSpace } from "../favoriteView";
 import { useAuthContext } from "~/hooks";
 import {
     hasKnowledgeSpacePermission,
@@ -53,6 +54,8 @@ interface UsePortalSpacesParams {
     setActiveSpace: Dispatch<SetStateAction<KnowledgeSpace | null>>;
     expandedGroups: Record<SpaceGroupKey, boolean>;
     preferredSpaceId?: string;
+    /** When set with preferredSpaceId, out-of-sidebar personal targets open preview-only. */
+    deepLinkFileId?: string;
 }
 
 function findDefaultPersonalSpace(spaces: KnowledgeSpace[]): KnowledgeSpace | null {
@@ -94,6 +97,7 @@ export function usePortalSpaces({
     setActiveSpace,
     expandedGroups,
     preferredSpaceId,
+    deepLinkFileId,
 }: UsePortalSpacesParams) {
     const { user } = useAuthContext();
     const preferredSpaceQuery = useQuery({
@@ -229,6 +233,28 @@ export function usePortalSpaces({
             || preferredSpaceQuery.isFetching
         ),
     );
+    /** Deep-link target absent from sidebar lists and getSpaceInfo failed (e.g. 403). */
+    const preferredSpaceResolveFailed = Boolean(
+        preferredSpaceId
+        && !preferredSpace
+        && preferredSpaceQuery.isError
+        && !preferredSpaceQuery.isFetching,
+    );
+    const previewOnlyTargetSpace = useMemo(() => {
+        if (!deepLinkFileId || !preferredSpace) return null;
+        return isOutOfSidebarPersonalSpace(preferredSpace, selectableSpaces) ? preferredSpace : null;
+    }, [deepLinkFileId, preferredSpace, selectableSpaces]);
+    const skipPreferredSpaceActivation = Boolean(
+        deepLinkFileId
+        && preferredSpaceId
+        && (
+            previewOnlyTargetSpace
+            || (
+                !preferredSpace
+                && !selectableSpaces.some((space) => String(space.id) === String(preferredSpaceId))
+            )
+        ),
+    );
     const fullAccessSpaceIds = useMemo(
         () => selectableSpaces
             .filter((space) => hasRoleBasedSpaceActionBypass(space))
@@ -259,7 +285,7 @@ export function usePortalSpaces({
     );
 
     useEffect(() => {
-        if (preferredSpace) {
+        if (preferredSpace && !skipPreferredSpaceActivation) {
             if (String(activeSpace?.id) !== String(preferredSpace.id)) {
                 setActiveSpace(preferredSpace);
             }
@@ -269,6 +295,12 @@ export function usePortalSpaces({
         // Deep-link restore: never fall back to 我的收藏 while a preferred space is requested.
         // Clear a mismatched default so the sidebar/list do not flash the favorite space.
         if (preferredSpaceId) {
+            if (skipPreferredSpaceActivation) {
+                if (!activeSpace && !personalSpacesQuery.isLoading) {
+                    setActiveSpace(defaultPersonalSpace ?? selectableSpaces[0] ?? null);
+                }
+                return;
+            }
             if (activeSpace && String(activeSpace.id) === String(preferredSpaceId)) return;
             if (activeSpace) {
                 setActiveSpace(null);
@@ -288,6 +320,7 @@ export function usePortalSpaces({
         preferredSpaceId,
         selectableSpaces,
         setActiveSpace,
+        skipPreferredSpaceActivation,
     ]);
 
     return {
@@ -296,6 +329,10 @@ export function usePortalSpaces({
         createPermissionByLevel,
         selectableSpaces,
         spaceLoading: personalSpacesQuery.isLoading || preferredSpacePending,
+        preferredSpace,
+        preferredSpacePending,
+        preferredSpaceResolveFailed,
+        previewOnlyTargetSpace,
         activeGroup,
         getSpacePermissions,
         requestSpacePermissions,

--- a/src/frontend/platform/src/controllers/API/knowledgeSpaceTagLibrary.ts
+++ b/src/frontend/platform/src/controllers/API/knowledgeSpaceTagLibrary.ts
@@ -159,6 +159,8 @@ export interface ReviewTagResourceItem {
   id?: number
   submit_time?: string
   knowledge_id?: number
+  /** Immediate parent folder id for portal deep-link navigation. */
+  parent_id?: number | null
   file_url?: string
   [key: string]: any
 }

--- a/src/frontend/platform/src/pages/BuildPage/bench/KnowledgeSpaceReviewTagSection.tsx
+++ b/src/frontend/platform/src/pages/BuildPage/bench/KnowledgeSpaceReviewTagSection.tsx
@@ -28,23 +28,25 @@ import { useTranslation } from "react-i18next";
 
 const PAGE_SIZE = 5;
 
+/** Open the file inside knowledge portal with folder context when parent_id is known. */
 function buildReviewTagFileDetailUrl(resource: ReviewTagResourceItem): string | null {
     const fileId = resource.file_id ?? resource.id;
     const spaceId = resource.knowledge_id;
     const fileName = resource.file_name?.trim();
+    const folderId = resource.parent_id ?? resource.folder_id ?? resource.folderId;
     if (!fileId || !spaceId || !fileName) {
         return null;
     }
 
-    const ext = fileName.includes(".") ? (fileName.split(".").pop() || "") : "";
     const params = new URLSearchParams();
-    params.set("name", fileName);
-    if (ext) {
-        params.set("type", ext);
-    }
     params.set("spaceId", String(spaceId));
+    params.set("fileId", String(fileId));
+    params.set("fileName", fileName);
+    if (folderId !== undefined && folderId !== null && String(folderId) !== "") {
+        params.set("folderId", String(folderId));
+    }
 
-    return getWorkspaceClientUrl(`/knowledge/file/${fileId}?${params.toString()}`);
+    return getWorkspaceClientUrl(`/knowledge-portal?${params.toString()}`);
 }
 
 function renderReviewTagFileSource(resource: ReviewTagResourceItem) {


### PR DESCRIPTION
## Summary

- Allow department admins to open tag-review files in **out-of-sidebar member personal spaces** via preview-only deep links (no sidebar/tree switch).
- Route cross-space previews through `getPortalFilePreviewApi` and add backend dept-admin read-only bypass for member personal knowledge bases (portal auth, content entry, and file preview).
- Extend review-tag scope to include personal spaces owned by users under managed departments; Platform review links pass `spaceId`/`fileId`/`folderId` for portal deep linking.

## Test plan

- [ ] Log in as dept admin (`gzx0167`), open a pending review tag file in a member personal space (e.g. space `165` / file `1485`) — preview loads without switching sidebar to the foreign space.
- [ ] Confirm same-space preview still uses `getFilePreviewApi`; department-space portal gate unchanged.
- [ ] Dept admin review-tag list includes tags on member personal libraries; approve/reject still scoped correctly.
- [ ] Non–dept-admin user cannot preview another user's personal file via deep link (403 / no preview URL).
- [ ] `npm run test:ci -- --testPathPattern=PortalKnowledgeWorkbench.test.tsx -t "out-of-sidebar personal" --coverage=false`
- [ ] Backend: `uv run pytest test/knowledge/test_dept_admin_member_personal_preview.py test/workstation/test_review_tag_dept_admin_scope.py -v` (Linux/CI)


Made with [Cursor](https://cursor.com)