### PR TITLE
fix(llm): drop the cached model row before an on-demand status check

### DIFF
--- a/src/backend/bisheng/llm/domain/services/llm.py
+++ b/src/backend/bisheng/llm/domain/services/llm.py
@@ -57,6 +57,7 @@ from bisheng.llm.domain.schemas import (
     WSModel,
 )
 from bisheng.llm.domain.share_fallback import avalidate_system_model_refs
+from bisheng.llm.domain.utils import invalidate_llm_info_cache
 from bisheng.tenant.domain.constants import TenantAuditAction
 from bisheng.tenant.domain.services.resource_share_service import ResourceShareService
 from bisheng.utils import generate_uuid, md5_hash
@@ -935,6 +936,11 @@ class LLMService:
         exist_model = await LLMDao.aget_model_by_id(model_id)
         if not exist_model:
             raise NotFoundError.http_exception()
+        # The probe resolves the model through a 60s in-process cache that no
+        # write invalidates, so a model renamed moments ago would be called under
+        # its old name and reported back as "does not exist". Evict first — an
+        # on-demand check that answers from a minute-old snapshot is worthless.
+        invalidate_llm_info_cache(model_id=model_id, server_id=exist_model.server_id)
         # Probing ignores the online flag on purpose: a model taken offline
         # still needs checking before you decide to bring it back.
         await cls.test_model_status(exist_model, login_user)

--- a/src/backend/bisheng/llm/domain/utils.py
+++ b/src/backend/bisheng/llm/domain/utils.py
@@ -407,6 +407,20 @@ def _scoped_cache_key(key_prefix: str, unique_id: Any) -> str:
     return f"{key_prefix}t{tid}:{unique_id}"
 
 
+def invalidate_llm_info_cache(*, model_id: int | None = None, server_id: int | None = None) -> None:
+    """Drop the cached model/server rows so the next read hits the database.
+
+    ``LLM_CACHE`` is a 60s in-process TTL cache with no write-through, so a model
+    renamed a moment ago keeps resolving under its old name until the entry ages
+    out. Callers whose whole purpose is "tell me the state right now" evict first
+    rather than act on a stale config.
+    """
+    for key_prefix, unique_id in (("llm:model:", model_id), ("llm:server:", server_id)):
+        if unique_id is None:
+            continue
+        LLM_CACHE.pop(_scoped_cache_key(key_prefix, unique_id), None)
+
+
 def wrapper_bisheng_llm_info(key_prefix: str):
     """
     LLM Information Cache Decorator

--- a/src/backend/test/llm/test_model_status_verify.py
+++ b/src/backend/test/llm/test_model_status_verify.py
@@ -85,3 +85,61 @@ class TestProbeWritesStatus:
 
         _, status, _ = status_writes.call_args[0]
         assert status == STATUS_NORMAL
+
+
+class TestVerifyDefeatsTheInfoCache:
+    """An on-demand check must not answer from a minute-old snapshot.
+
+    `LLM_CACHE` is a 60s in-process TTL cache with no write-through, and the
+    probe resolves the model through it (`get_model_server_info(..., cache=True)`).
+    Renaming a model and immediately pressing "check" therefore probed the OLD
+    name and reported `model_not_found`; it only started working once the entry
+    aged out. Verify evicts the entry first.
+    """
+
+    async def test_verify_evicts_the_cached_model_and_server(self):
+        from bisheng.llm.domain.const import LLM_CACHE
+        from bisheng.llm.domain.utils import _scoped_cache_key
+
+        model = _model()
+        model_key = _scoped_cache_key("llm:model:", model.id)
+        server_key = _scoped_cache_key("llm:server:", model.server_id)
+        LLM_CACHE[model_key] = "row carrying the pre-rename model_name"
+        LLM_CACHE[server_key] = "row carrying the pre-rename server config"
+
+        with (
+            patch(
+                "bisheng.llm.domain.services.llm.LLMDao.aget_model_by_id",
+                AsyncMock(return_value=model),
+            ),
+            patch.object(LLMService, "test_model_status", AsyncMock()),
+        ):
+            await LLMService.verify_model_status(model.id, _login_user())
+
+        assert LLM_CACHE.get(model_key) is None
+        assert LLM_CACHE.get(server_key) is None
+
+    async def test_eviction_happens_before_the_probe_runs(self):
+        # Ordering is the whole fix: evicting after the probe would still have
+        # let the probe build its client from the stale row.
+        from bisheng.llm.domain.const import LLM_CACHE
+        from bisheng.llm.domain.utils import _scoped_cache_key
+
+        model = _model()
+        model_key = _scoped_cache_key("llm:model:", model.id)
+        LLM_CACHE[model_key] = "stale"
+        seen = {}
+
+        async def record_cache_state(*args, **kwargs):
+            seen["cached_at_probe_time"] = LLM_CACHE.get(model_key)
+
+        with (
+            patch(
+                "bisheng.llm.domain.services.llm.LLMDao.aget_model_by_id",
+                AsyncMock(return_value=model),
+            ),
+            patch.object(LLMService, "test_model_status", record_cache_state),
+        ):
+            await LLMService.verify_model_status(model.id, _login_user())
+
+        assert seen["cached_at_probe_time"] is None


### PR DESCRIPTION
Renaming a model and immediately pressing "check status" reported the model as missing, quoting the OLD name back: `The model 'deepseek-v4-pro1' does not exist`. Waiting a minute made it pass.

verify_model_status reads the model itself uncached, so the response carried the new name — but the probe only passes a model_id down to get_bisheng_llm, which resolves it again through `get_model_server_info(..., cache=True)`. That lands in LLM_CACHE, a 60s in-process TTLCache that nothing invalidates on write, so the probe called the provider under the pre-rename name. The two names in one response are those two read paths disagreeing.

Evict the model and its server entry before probing. An endpoint whose entire purpose is "tell me the state right now" answering from a minute-old snapshot is worthless; the server entry goes too, since editing base_url or the api key hits the same window. Chosen over threading cache=False through the five model-type entry points (two of which bypass get_class_instance).

This covers the check button only. Editing a model still leaves normal traffic on the stale config for up to 60s, and the cache is per-process, so a multi-worker deployment evicts in one worker. Both need the cache to move behind a shared store — tracked separately.

## What

简要描述做了什么改动。

## Why

为什么需要这个改动？

## How

实现方式、设计决策（如有）。

## Test

- [ ] 本地测试通过
- [ ] 114 测试服务器验证通过

## Related

- Issue/ticket:
