### PR TITLE
fix(portal): restore file parent folder after search preview back (IK5KDG)

### DIFF
--- a/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
+++ b/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
@@ -11085,6 +11085,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                     "space_level_label": level_labels.get(level, str(level)),
                     "space_level_order": level_order.get(level, 99),
                     "folder_path": folder_segments,
+                    "parent_id": self._parent_folder_id_from_level_path(f.file_level_path),
                 }
             )
 
@@ -12621,6 +12622,9 @@ class KnowledgeSpaceService(KnowledgeUtils):
         result = []
         for one in res:
             item = one.model_dump()
+            # parent_id is not a DB column — derive from file_level_path so clients can
+            # navigate back to the containing folder after search/preview.
+            item["parent_id"] = self._parent_folder_id_from_level_path(one.file_level_path)
             if one.file_type == FileType.DIR:
                 if include_folder_counts:
                     counts = folder_counts.get(
@@ -12977,6 +12981,12 @@ class KnowledgeSpaceService(KnowledgeUtils):
         )
         extra_info_ms = (time.perf_counter() - extra_info_start) * 1000
 
+        folder_path_map, source_path_map = await self._resolve_shougang_portal_source_paths(data)
+        for item in data:
+            item_id = int(item.get("id") or 0)
+            item["folder_path"] = folder_path_map.get(item_id, "")
+            item["source_path"] = source_path_map.get(item_id, "")
+
         next_cursor: str | None = None
         if has_more and visible_page_items:
             last = visible_page_items[-1]
@@ -13275,6 +13285,11 @@ class KnowledgeSpaceService(KnowledgeUtils):
             page_items,
             folder_counts_override=folder_counts_override,
         )
+        folder_path_map, source_path_map = await self._resolve_shougang_portal_source_paths(data)
+        for item in data:
+            item_id = int(item.get("id") or 0)
+            item["folder_path"] = folder_path_map.get(item_id, "")
+            item["source_path"] = source_path_map.get(item_id, "")
         return {"total": total, "page": page, "page_size": page_size, "data": data}
 
     # ──────────────────────────── Folders ─────────────────────────────────────

--- a/src/frontend/client/src/api/knowledge.test.ts
+++ b/src/frontend/client/src/api/knowledge.test.ts
@@ -720,6 +720,30 @@ describe("updateFileEncoding", () => {
 });
 
 describe("mapChild", () => {
+  it("prefers parent_id and falls back to file_level_path for parentId", () => {
+    expect(mapChild({
+      id: 1,
+      file_name: "a.md",
+      file_type: 1,
+      parent_id: 42,
+      file_level_path: "/10/20",
+    }, "9").parentId).toBe("42");
+
+    expect(mapChild({
+      id: 2,
+      file_name: "b.md",
+      file_type: 1,
+      file_level_path: "/10/20",
+    }, "9").parentId).toBe("20");
+
+    expect(mapChild({
+      id: 3,
+      file_name: "c.md",
+      file_type: 1,
+      file_level_path: "",
+    }, "9").parentId).toBeUndefined();
+  });
+
   it("maps distribution identity, projection state, and server capabilities", () => {
     const file = mapChild(
       {

--- a/src/frontend/client/src/api/knowledge.ts
+++ b/src/frontend/client/src/api/knowledge.ts
@@ -1038,6 +1038,16 @@ export function isWebLinkKnowledgeFile(file: Pick<KnowledgeFile, "fileSource" | 
     return file.fileSource === "web_link" || file.type === FileType.WEB;
 }
 
+/** Derive parent folder id from file_level_path (`/a/b` → last segment) when API omits parent_id. */
+export function resolveParentIdFromRaw(raw: any): string | undefined {
+    if (raw?.parent_id !== undefined && raw?.parent_id !== null && String(raw.parent_id) !== "") {
+        return String(raw.parent_id);
+    }
+    const levelPath = String(raw?.file_level_path ?? "");
+    const parts = levelPath.split("/").filter((part) => /^\d+$/.test(part));
+    return parts.length ? parts[parts.length - 1] : undefined;
+}
+
 /** Map a raw space child (file/folder) to the frontend KnowledgeFile model */
 export function mapChild(raw: any, spaceId: string): KnowledgeFile {
     // Backend keys in children response usually look like:
@@ -1103,7 +1113,7 @@ export function mapChild(raw: any, spaceId: string): KnowledgeFile {
         status,
         tags,
         path: raw?.path ?? raw?.file_level_path ?? String(nameVal),
-        parentId: raw?.parent_id !== undefined && raw?.parent_id !== null ? String(raw.parent_id) : undefined,
+        parentId: resolveParentIdFromRaw(raw),
         spaceId: String(raw?.space_id ?? raw?.knowledge_id ?? spaceId),
         createdAt: raw?.create_time ?? "",
         updatedAt: raw?.update_time ?? "",
@@ -3620,6 +3630,7 @@ export interface GlobalSearchFileResult {
     space_level_label: string;
     space_level_order: number;
     folder_path: string[];
+    parent_id?: number | null;
 }
 
 export interface GlobalSearchResult {

--- a/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.test.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.test.tsx
@@ -48,6 +48,7 @@ import {
     getSpaceFolderStatsApi,
     getSpaceInfoApi,
     getSpaceTagsApi,
+    globalSearchSpaceFilesApi,
     importWebLinkApi,
     linkAsNewVersionApi,
     listMyUploadedFilesApi,
@@ -454,6 +455,7 @@ jest.mock("~/api/knowledge", () => ({
     getSpaceFolderStatsApi: jest.fn(),
     getSpaceTagsApi: jest.fn(),
     searchSpaceChildrenApi: jest.fn(),
+    globalSearchSpaceFilesApi: jest.fn(),
     importWebLinkApi: jest.fn(),
     uploadFileToServerApi: jest.fn(),
     addFilesApi: jest.fn(),
@@ -715,6 +717,7 @@ describe("PortalKnowledgeWorkbench", () => {
         jest.mocked(getPortalSpaceFolderStatsApi).mockResolvedValue([] as any);
         jest.mocked(getSpaceFolderStatsApi).mockResolvedValue([] as any);
         jest.mocked(searchSpaceChildrenApi).mockResolvedValue({ data: [], total: 0 } as any);
+        jest.mocked(globalSearchSpaceFilesApi).mockResolvedValue({ data: [], total: 0, page: 1, page_size: 30 } as any);
         jest.mocked(importWebLinkApi).mockResolvedValue(makeFile("web-1", "网页链接", {
             type: FileType.MD,
         }) as any);
@@ -5976,6 +5979,236 @@ describe("PortalKnowledgeWorkbench", () => {
         expect(within(reopened).getByTestId("edit-tags-initial-ids")).toHaveTextContent("3");
     });
 
+    test("shows folder path when previewing a search result", async () => {
+        const personalSpace = makeSpace("personal-1", "我的技术文档", {
+            role: SpaceRole.ADMIN,
+        });
+        jest.mocked(getGroupedSpacesApi).mockResolvedValue({
+            publicSpaces: [],
+            departmentSpaces: [],
+            teamSpaces: [],
+            personalSpaces: [personalSpace],
+        } as any);
+        jest.mocked(getSpaceChildrenApi).mockResolvedValue({
+            data: [],
+            total: 0,
+        } as any);
+        jest.mocked(searchSpaceChildrenApi).mockResolvedValue({
+            data: [makeFile("401", "搜索结果.md", {
+                parentId: "101",
+                spaceId: "personal-1",
+                folderPath: "我的技术文档/制度文件",
+                sourcePath: "我的技术文档>制度文件/搜索结果.md",
+            })],
+            total: 1,
+        } as any);
+
+        renderWorkbench();
+
+        const input = await screen.findByPlaceholderText("com_knowledge.search_in_current_space");
+        fireEvent.change(input, { target: { value: "搜索" } });
+        fireEvent.keyDown(input, { key: "Enter" });
+
+        const workspace = await screen.findByTestId("portal-file-workspace");
+        fireEvent.click(within(workspace).getByRole("button", { name: "打开搜索结果.md" }));
+
+        const preview = await screen.findByTestId("portal-preview-page");
+        expect(preview).toHaveTextContent("全部知识库/个人知识库/我的技术文档/制度文件");
+    });
+
+    test("returns from global search preview to the file parent folder list", async () => {
+        const personalSpace = makeSpace("1", "我的技术文档", {
+            role: SpaceRole.ADMIN,
+        });
+        const folder = makeFile("101", "制度文件", {
+            type: FileType.FOLDER,
+            spaceId: "1",
+        });
+        const targetFile = makeFile("401", "全局搜索结果.md", {
+            parentId: "101",
+            spaceId: "1",
+        });
+        const siblingFile = makeFile("402", "同目录其它.md", {
+            parentId: "101",
+            spaceId: "1",
+        });
+        jest.mocked(getGroupedSpacesApi).mockResolvedValue({
+            publicSpaces: [],
+            departmentSpaces: [],
+            teamSpaces: [],
+            personalSpaces: [personalSpace],
+        } as any);
+        jest.mocked(getSpaceInfoApi).mockResolvedValue(personalSpace as any);
+        jest.mocked(getSpaceChildrenApi).mockImplementation(async (params: any) => {
+            if (params.file_ids?.length) {
+                return { data: [targetFile], total: 1 };
+            }
+            return params.parent_id === "101"
+                ? { data: [targetFile, siblingFile], total: 2 }
+                : { data: [folder], total: 1 };
+        });
+        jest.mocked(globalSearchSpaceFilesApi).mockResolvedValue({
+            total: 1,
+            page: 1,
+            page_size: 30,
+            data: [{
+                file_id: 401,
+                file_name: "全局搜索结果.md",
+                file_type_ext: "md",
+                space_id: 1,
+                space_name: "我的技术文档",
+                space_level: "personal",
+                space_level_label: "个人知识库",
+                space_level_order: 4,
+                folder_path: ["制度文件"],
+                parent_id: 101,
+            }],
+        } as any);
+
+        renderWorkbench();
+
+        expect(await screen.findByText("制度文件")).toBeInTheDocument();
+
+        const globalInput = await screen.findByPlaceholderText("搜索所有知识库文件");
+        fireEvent.change(globalInput, { target: { value: "全局" } });
+
+        expect(await screen.findByText("全局搜索结果.md")).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: /全局搜索结果\.md/ }));
+
+        const preview = await screen.findByTestId("portal-preview-page");
+        expect(preview).toHaveTextContent("全局搜索结果.md");
+
+        fireEvent.click(within(preview).getByRole("button", { name: "返回文件列表" }));
+
+        const restoredWorkspace = await screen.findByTestId("portal-file-workspace");
+        expect(within(restoredWorkspace).getByText("全局搜索结果.md")).toBeInTheDocument();
+        expect(within(restoredWorkspace).getByText("同目录其它.md")).toBeInTheDocument();
+        expect(screen.queryByTestId("portal-preview-page")).not.toBeInTheDocument();
+    });
+
+    test("returns from global search preview to source folder when active space is favorites", async () => {
+        const favoriteSpace = makeDefaultFavoriteSpace();
+        const personalSpace = makeSpace("1", "我的技术文档", {
+            role: SpaceRole.ADMIN,
+        });
+        const folder = makeFile("101", "制度文件", {
+            type: FileType.FOLDER,
+            spaceId: "1",
+        });
+        const targetFile = makeFile("401", "全局搜索结果.md", {
+            parentId: "101",
+            spaceId: "1",
+        });
+        const siblingFile = makeFile("402", "同目录其它.md", {
+            parentId: "101",
+            spaceId: "1",
+        });
+        jest.mocked(getGroupedSpacesApi).mockResolvedValue({
+            publicSpaces: [],
+            departmentSpaces: [],
+            teamSpaces: [],
+            personalSpaces: [favoriteSpace, personalSpace],
+        } as any);
+        jest.mocked(getSpaceInfoApi).mockResolvedValue(personalSpace as any);
+        jest.mocked(getSpaceChildrenApi).mockImplementation(async (params: any) => {
+            if (params.file_ids?.length) {
+                return { data: [targetFile], total: 1 };
+            }
+            return params.parent_id === "101"
+                ? { data: [targetFile, siblingFile], total: 2 }
+                : params.space_id === "1"
+                    ? { data: [folder], total: 1 }
+                    : { data: [], total: 0 };
+        });
+        jest.mocked(globalSearchSpaceFilesApi).mockResolvedValue({
+            total: 1,
+            page: 1,
+            page_size: 30,
+            data: [{
+                file_id: 401,
+                file_name: "全局搜索结果.md",
+                file_type_ext: "md",
+                space_id: 1,
+                space_name: "我的技术文档",
+                space_level: "personal",
+                space_level_label: "个人知识库",
+                space_level_order: 4,
+                folder_path: ["制度文件"],
+                parent_id: 101,
+            }],
+        } as any);
+
+        renderWorkbench();
+
+        expect(await screen.findByTestId("portal-favorites-panel")).toBeInTheDocument();
+
+        const globalInput = await screen.findByPlaceholderText("搜索所有知识库文件");
+        fireEvent.change(globalInput, { target: { value: "全局" } });
+        fireEvent.click(await screen.findByRole("button", { name: /全局搜索结果\.md/ }));
+
+        const preview = await screen.findByTestId("portal-preview-page");
+        expect(preview).toHaveTextContent("全局搜索结果.md");
+
+        fireEvent.click(within(preview).getByRole("button", { name: "返回文件列表" }));
+
+        const restoredWorkspace = await screen.findByTestId("portal-file-workspace");
+        expect(screen.queryByTestId("portal-favorites-panel")).not.toBeInTheDocument();
+        expect(within(restoredWorkspace).getByText("全局搜索结果.md")).toBeInTheDocument();
+        expect(within(restoredWorkspace).getByText("同目录其它.md")).toBeInTheDocument();
+    });
+
+    test("shows folder path when previewing a global search result", async () => {
+        const personalSpace = makeSpace("1", "我的技术文档", {
+            role: SpaceRole.ADMIN,
+        });
+        const targetFile = makeFile("401", "全局搜索结果.md", {
+            parentId: "101",
+            spaceId: "1",
+            folderPath: "我的技术文档/制度文件",
+            sourcePath: "我的技术文档>制度文件/全局搜索结果.md",
+        });
+        jest.mocked(getGroupedSpacesApi).mockResolvedValue({
+            publicSpaces: [],
+            departmentSpaces: [],
+            teamSpaces: [],
+            personalSpaces: [personalSpace],
+        } as any);
+        jest.mocked(getSpaceInfoApi).mockResolvedValue(personalSpace as any);
+        jest.mocked(getSpaceChildrenApi).mockImplementation(async (params: any) => (
+            params.file_ids?.length
+                ? { data: [targetFile], total: 1 }
+                : { data: [], total: 0 }
+        ) as any);
+        jest.mocked(globalSearchSpaceFilesApi).mockResolvedValue({
+            total: 1,
+            page: 1,
+            page_size: 30,
+            data: [{
+                file_id: 401,
+                file_name: "全局搜索结果.md",
+                file_type_ext: "md",
+                space_id: 1,
+                space_name: "我的技术文档",
+                space_level: "personal",
+                space_level_label: "个人知识库",
+                space_level_order: 4,
+                folder_path: ["制度文件"],
+                parent_id: 101,
+            }],
+        } as any);
+
+        renderWorkbench();
+
+        const globalInput = await screen.findByPlaceholderText("搜索所有知识库文件");
+        fireEvent.change(globalInput, { target: { value: "全局" } });
+
+        fireEvent.click(await screen.findByRole("button", { name: /全局搜索结果\.md/ }));
+
+        const preview = await screen.findByTestId("portal-preview-page");
+        expect(preview).toHaveTextContent("全部知识库/个人知识库/我的技术文档/制度文件");
+    });
+
     test("deletes a file from search results through the backend", async () => {
         const personalSpace = makeSpace("personal-1", "我的技术文档", {
             role: SpaceRole.ADMIN,
@@ -6000,7 +6233,7 @@ describe("PortalKnowledgeWorkbench", () => {
 
         renderWorkbench();
 
-        const input = await screen.findByPlaceholderText("Search in current knowledge space");
+        const input = await screen.findByPlaceholderText("com_knowledge.search_in_current_space");
         fireEvent.change(input, { target: { value: "搜索" } });
 
         expect(await screen.findByText("搜索结果.md")).toBeInTheDocument();

--- a/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.test.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.test.tsx
@@ -5864,6 +5864,63 @@ describe("PortalKnowledgeWorkbench", () => {
         expect(screen.queryByText("搜索结果.md")).not.toBeInTheDocument();
     });
 
+    test("returns from search preview to the file parent folder list instead of root", async () => {
+        const personalSpace = makeSpace("personal-1", "我的技术文档", {
+            role: SpaceRole.ADMIN,
+        });
+        const folder = makeFile("101", "制度文件", {
+            type: FileType.FOLDER,
+            spaceId: "personal-1",
+        });
+        const targetFile = makeFile("401", "搜索结果.md", {
+            parentId: "101",
+            spaceId: "personal-1",
+        });
+        const siblingFile = makeFile("402", "同目录其它.md", {
+            parentId: "101",
+            spaceId: "personal-1",
+        });
+        jest.mocked(getGroupedSpacesApi).mockResolvedValue({
+            publicSpaces: [],
+            departmentSpaces: [],
+            teamSpaces: [],
+            personalSpaces: [personalSpace],
+        } as any);
+        jest.mocked(getSpaceChildrenApi).mockImplementation(async (params: any) => (
+            params.parent_id === "101"
+                ? { data: [targetFile, siblingFile], total: 2 }
+                : { data: [folder], total: 1 }
+        ) as any);
+        jest.mocked(searchSpaceChildrenApi).mockResolvedValue({
+            data: [targetFile],
+            total: 1,
+        } as any);
+
+        renderWorkbench();
+
+        expect(await screen.findByText("制度文件")).toBeInTheDocument();
+
+        const input = await screen.findByPlaceholderText("com_knowledge.search_in_current_space");
+        fireEvent.change(input, { target: { value: "搜索" } });
+        fireEvent.keyDown(input, { key: "Enter" });
+
+        expect(await screen.findByText("搜索结果.md")).toBeInTheDocument();
+        expect(screen.queryByText("制度文件")).not.toBeInTheDocument();
+
+        const workspace = await screen.findByTestId("portal-file-workspace");
+        fireEvent.click(within(workspace).getByRole("button", { name: "打开搜索结果.md" }));
+
+        const preview = await screen.findByTestId("portal-preview-page");
+        expect(preview).toHaveTextContent("搜索结果.md");
+
+        fireEvent.click(within(preview).getByRole("button", { name: "返回文件列表" }));
+
+        const restoredWorkspace = await screen.findByTestId("portal-file-workspace");
+        expect(within(restoredWorkspace).getByText("搜索结果.md")).toBeInTheDocument();
+        expect(within(restoredWorkspace).getByText("同目录其它.md")).toBeInTheDocument();
+        expect(screen.queryByTestId("portal-preview-page")).not.toBeInTheDocument();
+    });
+
     test("keeps search keyword and results after editing tags in search results", async () => {
         const personalSpace = makeSpace("personal-1", "我的技术文档", {
             role: SpaceRole.ADMIN,

--- a/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.tsx
@@ -63,6 +63,7 @@ import type {
 } from "./types";
 import {
     collectTreeFileIds,
+    buildPortalDocumentPath,
     createTreeNode,
     dedupeFilesById,
     dedupeTreeNodesByFileId,
@@ -282,6 +283,13 @@ export default function PortalKnowledgeWorkbench() {
     const [searchResults, setSearchResults] = useState<KnowledgeFile[]>([]);
     const searchModeRef = useRef(searchMode);
     searchModeRef.current = searchMode;
+    const openedFromGlobalSearchRef = useRef(false);
+    const globalSearchReturnRef = useRef<{ spaceId: string; parentId?: string } | null>(null);
+    const pendingSearchReturnRef = useRef<{ spaceId: string; folderId?: string } | null>(null);
+    const [globalSearchPathContext, setGlobalSearchPathContext] = useState<{
+        groupTitle?: string;
+        spaceName?: string;
+    } | null>(null);
     const [searchTagIds, setSearchTagIds] = useState<number[]>([]);
     const [searchLoading, setSearchLoading] = useState(false);
     const [statusFilter, setStatusFilter] = useState<FileStatus[]>([]);
@@ -1178,6 +1186,9 @@ export default function PortalKnowledgeWorkbench() {
 
     const reloadFilesRef = useRef(reloadFiles);
     reloadFilesRef.current = reloadFiles;
+    const handleNavigateFolderRef = useRef<(folderId?: string, folderName?: string) => Promise<void>>(
+        async () => {},
+    );
 
     const fileUpload = useFileUpload({
         activeSpace,
@@ -1580,7 +1591,12 @@ export default function PortalKnowledgeWorkbench() {
             }
             setCanCreateFolder(false);
             setCanUploadFile(false);
-            void loadRootTreeRef.current(1, false, activeSpace.id);
+            void loadRootTreeRef.current(1, false, activeSpace.id).then(() => {
+                const pending = pendingSearchReturnRef.current;
+                if (!pending || String(activeSpace.id) !== pending.spaceId) return;
+                pendingSearchReturnRef.current = null;
+                void handleNavigateFolderRef.current(pending.folderId || undefined);
+            });
         } else if (!openingDeepLinkedFileHere) {
             // Sort/filter changed: keep the current folder and reload the same view
             // with the new ordering/filter instead of jumping back to the root.
@@ -1622,6 +1638,8 @@ export default function PortalKnowledgeWorkbench() {
         // #4 收藏原地预览：selectedFile 是来自其它源空间的合成文件（不属于当前 activeSpace，
         // 自然不在其 displayedFiles 中），不应被此“列表中已不存在则关闭预览”的守卫清空。
         if (selectedFile.spaceId && selectedFile.spaceId !== activeSpace?.id) return;
+        // 侧边栏全局搜索打开的文件同样不在当前文件夹列表中。
+        if (openedFromGlobalSearchRef.current) return;
         const exists = displayedFiles.some((file) => file.id === selectedFile.id);
         if (!exists) {
             setSelectedFile(null);
@@ -2398,26 +2416,72 @@ export default function PortalKnowledgeWorkbench() {
             showToast({ message: "文件夹加载失败", severity: NotificationSeverity.ERROR });
         }
     }, [activeSpace?.id, loadFolderStats, loadRootTree, showToast, sortBy, sortDirection, statusFilterNumbers, treeNodes]);
+    handleNavigateFolderRef.current = handleNavigateFolder;
 
     const handleBackToFileList = useCallback(() => {
         const previewedFile = selectedFile;
-        const openedFromSearch = searchModeRef.current;
+        const openedFromInSpaceSearch = searchModeRef.current;
+        const openedFromGlobalSearch = openedFromGlobalSearchRef.current;
 
         setSelectedFile(null);
         setActivePanel(null);
         setAiDrawerOpen(false);
         setSummaryExpanded(false);
         setPreview({ loading: false, fileUrl: "", fileType: "", error: "", previewData: null });
-        // Deep-link open used to leave searchMode with a single-file result set.
         setSearchMode(false);
         setSearchResults([]);
         setSearchText("");
         setSearchTagIds([]);
-        // Early back during tag-review deep link must not stick on the restore overlay.
         setRestoringDeepLinkKey(null);
+        setGlobalSearchPathContext(null);
+        // Capture return context before clearing refs — remounts/effects must not wipe it mid-handler.
+        const globalSearchReturn = globalSearchReturnRef.current;
+        const fromGlobalSearch = openedFromGlobalSearch || Boolean(globalSearchReturn?.spaceId);
+        openedFromGlobalSearchRef.current = false;
+        globalSearchReturnRef.current = null;
 
-        if (openedFromSearch && previewedFile && !isFolder(previewedFile)) {
+        if (openedFromInSpaceSearch && previewedFile && !isFolder(previewedFile)) {
             void handleNavigateFolder(previewedFile.parentId || undefined);
+            return;
+        }
+
+        if (fromGlobalSearch && previewedFile && !isFolder(previewedFile)) {
+            const targetSpaceId = String(
+                globalSearchReturn?.spaceId
+                || previewedFile.spaceId
+                || "",
+            );
+            const parentFolderId = previewedFile.parentId || globalSearchReturn?.parentId;
+            if (!targetSpaceId) return;
+
+            // Favorites (and any mismatched active space) must switch to the file's real space.
+            const mustSwitchSpace = isFavoriteSpace(activeSpace)
+                || String(activeSpace?.id) !== targetSpaceId;
+            if (mustSwitchSpace) {
+                pendingSearchReturnRef.current = {
+                    spaceId: targetSpaceId,
+                    folderId: parentFolderId,
+                };
+                const targetSpace = selectableSpaces.find(
+                    (space) => String(space.id) === targetSpaceId,
+                ) ?? null;
+                if (targetSpace) {
+                    setActiveSpace(targetSpace);
+                } else {
+                    void getSpaceInfoApi(targetSpaceId).then((space) => {
+                        pendingSearchReturnRef.current = {
+                            spaceId: targetSpaceId,
+                            folderId: parentFolderId,
+                        };
+                        setActiveSpace(space);
+                    }).catch(() => {
+                        pendingSearchReturnRef.current = null;
+                    });
+                }
+                return;
+            }
+
+            void handleNavigateFolder(parentFolderId || undefined);
             return;
         }
 
@@ -2428,7 +2492,103 @@ export default function PortalKnowledgeWorkbench() {
         if (!folderNode?.loaded || folderNode.loading) {
             void reloadFilesRef.current();
         }
-    }, [handleNavigateFolder, selectedFile, treeNodes]);
+    }, [activeSpace?.id, handleNavigateFolder, selectableSpaces, selectedFile, treeNodes]);
+
+    const handleGlobalSearchSelectFile = useCallback(
+        (
+            sourceSpaceId: string,
+            sourceFileId: string,
+            fileName?: string,
+            meta?: {
+                spaceName: string;
+                spaceLevelLabel: string;
+                folderPathSegments: string[];
+                parentId?: string;
+            },
+        ) => {
+            const initialParentId = meta?.parentId || undefined;
+            openedFromGlobalSearchRef.current = true;
+            globalSearchReturnRef.current = {
+                spaceId: String(sourceSpaceId),
+                parentId: initialParentId,
+            };
+            setSearchMode(false);
+            setSearchResults([]);
+            setSearchText("");
+            setSearchTagIds([]);
+            setGlobalSearchPathContext({
+                groupTitle: meta?.spaceLevelLabel,
+                spaceName: meta?.spaceName,
+            });
+
+            const displayName = (fileName || "").trim() || "源文件";
+            const resolvedSpaceName = meta?.spaceName || "";
+            const folderPath = meta?.folderPathSegments?.length
+                ? [resolvedSpaceName, ...meta.folderPathSegments].filter(Boolean).join("/")
+                : resolvedSpaceName;
+            const syntheticFile: KnowledgeFile = {
+                id: String(sourceFileId),
+                name: displayName,
+                type: FileType.OTHER,
+                tags: [],
+                path: displayName,
+                spaceId: String(sourceSpaceId),
+                parentId: initialParentId,
+                createdAt: "",
+                updatedAt: "",
+                sourceSpaceName: resolvedSpaceName,
+                sourcePath: "",
+                folderPath,
+            };
+            setActivePanel(null);
+            setAiDrawerOpen(false);
+            setSummaryExpanded(false);
+            setSelectedFile(syntheticFile);
+            void Promise.all([
+                getSpaceChildrenApi({
+                    space_id: String(sourceSpaceId),
+                    file_ids: [sourceFileId],
+                    page_size: 1,
+                    order_field: "update_time",
+                    order_sort: "desc",
+                }),
+                getSpaceInfoApi(String(sourceSpaceId)).catch(() => null),
+            ]).then(([fileResult, sourceSpace]) => {
+                const sourceFile = fileResult.data[0];
+                if (!sourceFile) return;
+                const enrichedSpaceName = sourceFile.sourceSpaceName || sourceSpace?.name || resolvedSpaceName;
+                const sourcePathTail = sourceFile.sourcePath || sourceFile.folderPath || folderPath || sourceFile.path || sourceFile.name;
+                const resolvedSourcePath = enrichedSpaceName
+                    && sourcePathTail
+                    && !String(sourcePathTail).includes(enrichedSpaceName)
+                    ? `${enrichedSpaceName}/${sourcePathTail}`
+                    : sourcePathTail;
+                const resolvedParentId = sourceFile.parentId || initialParentId;
+                const enrichedFile: KnowledgeFile = {
+                    ...sourceFile,
+                    spaceId: String(sourceSpaceId),
+                    parentId: resolvedParentId,
+                    sourceSpaceName: enrichedSpaceName,
+                    sourcePath: resolvedSourcePath,
+                    folderPath: sourceFile.folderPath || folderPath,
+                };
+                globalSearchReturnRef.current = {
+                    spaceId: String(sourceSpaceId),
+                    parentId: resolvedParentId,
+                };
+                setSelectedFile((current) => (
+                    current
+                    && String(current.id) === String(sourceFileId)
+                    && String(current.spaceId) === String(sourceSpaceId)
+                        ? enrichedFile
+                        : current
+                ));
+            }).catch(() => {
+                // Keep synthetic metadata so preview still works.
+            });
+        },
+        [],
+    );
 
     usePortalDeepLink({
         searchParams,
@@ -2706,14 +2866,12 @@ export default function PortalKnowledgeWorkbench() {
         }
     }, [editingSpace, queryClient, showToast]);
 
-    const documentPath = useMemo(() => {
-        const names = [
-            "全部知识库",
-            activeGroup?.title,
-            activeSpace?.name,
-        ].filter(Boolean);
-        return names.join("/");
-    }, [activeGroup?.title, activeSpace?.name]);
+    const documentPath = useMemo(() => buildPortalDocumentPath({
+        activeGroupTitle: globalSearchPathContext?.groupTitle ?? activeGroup?.title,
+        activeSpaceName: globalSearchPathContext?.spaceName ?? selectedFile?.sourceSpaceName ?? activeSpace?.name,
+        currentPath,
+        selectedFile,
+    }), [activeGroup?.title, activeSpace?.name, currentPath, globalSearchPathContext, selectedFile]);
     const aiContextLabel = currentFolderId ? "文件夹" : "知识库";
     const handleWorkbenchDrag = useCallback((event: DragEvent<HTMLDivElement>) => {
         event.preventDefault();
@@ -2758,8 +2916,8 @@ export default function PortalKnowledgeWorkbench() {
                         }
                         onDeleteSpace={(space) => void handleDeleteSpace(space)}
                         onLeaveSpace={(space) => void handleLeaveSpace(space)}
-                        onGlobalSearchSelectFile={(spaceId, fileId, fileName) =>
-                            handleOpenSourceFile(String(spaceId), String(fileId), fileName)
+                        onGlobalSearchSelectFile={(spaceId, fileId, fileName, meta) =>
+                            handleGlobalSearchSelectFile(String(spaceId), String(fileId), fileName, meta)
                         }
                     />
 

--- a/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.tsx
@@ -2139,28 +2139,6 @@ export default function PortalKnowledgeWorkbench() {
         [],
     );
 
-    const handleBackToFileList = useCallback(() => {
-        setSelectedFile(null);
-        setActivePanel(null);
-        setAiDrawerOpen(false);
-        setSummaryExpanded(false);
-        setPreview({ loading: false, fileUrl: "", fileType: "", error: "", previewData: null });
-        // Deep-link open used to leave searchMode with a single-file result set.
-        setSearchMode(false);
-        setSearchResults([]);
-        setSearchText("");
-        setSearchTagIds([]);
-        // Early back during tag-review deep link must not stick on the restore overlay.
-        setRestoringDeepLinkKey(null);
-        // Folder children may still be loading / wiped by a late root refresh — refetch.
-        const folderId = currentFolderIdRef.current;
-        if (!folderId) return;
-        const folderNode = findTreeNode(treeNodes, folderId);
-        if (!folderNode?.loaded || folderNode.loading) {
-            void reloadFilesRef.current();
-        }
-    }, [treeNodes]);
-
     // 从"我的收藏"只读面板打开源文件：#4 原地预览——不切换 activeSpace（不跳转到源知识空间），
     // 以携带源空间 id 的合成文件项触发预览流程。预览/下载按 selectedFile.spaceId(源空间) 定位、
     // 由后端鉴权（无访问权限时预览接口自然报错），关闭预览后仍回到「我的收藏」列表。
@@ -2420,6 +2398,37 @@ export default function PortalKnowledgeWorkbench() {
             showToast({ message: "文件夹加载失败", severity: NotificationSeverity.ERROR });
         }
     }, [activeSpace?.id, loadFolderStats, loadRootTree, showToast, sortBy, sortDirection, statusFilterNumbers, treeNodes]);
+
+    const handleBackToFileList = useCallback(() => {
+        const previewedFile = selectedFile;
+        const openedFromSearch = searchModeRef.current;
+
+        setSelectedFile(null);
+        setActivePanel(null);
+        setAiDrawerOpen(false);
+        setSummaryExpanded(false);
+        setPreview({ loading: false, fileUrl: "", fileType: "", error: "", previewData: null });
+        // Deep-link open used to leave searchMode with a single-file result set.
+        setSearchMode(false);
+        setSearchResults([]);
+        setSearchText("");
+        setSearchTagIds([]);
+        // Early back during tag-review deep link must not stick on the restore overlay.
+        setRestoringDeepLinkKey(null);
+
+        if (openedFromSearch && previewedFile && !isFolder(previewedFile)) {
+            void handleNavigateFolder(previewedFile.parentId || undefined);
+            return;
+        }
+
+        // Folder children may still be loading / wiped by a late root refresh — refetch.
+        const folderId = currentFolderIdRef.current;
+        if (!folderId) return;
+        const folderNode = findTreeNode(treeNodes, folderId);
+        if (!folderNode?.loaded || folderNode.loading) {
+            void reloadFilesRef.current();
+        }
+    }, [handleNavigateFolder, selectedFile, treeNodes]);
 
     usePortalDeepLink({
         searchParams,

--- a/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.tsx
@@ -286,6 +286,8 @@ export default function PortalKnowledgeWorkbench() {
     const openedFromGlobalSearchRef = useRef(false);
     const globalSearchReturnRef = useRef<{ spaceId: string; parentId?: string } | null>(null);
     const pendingSearchReturnRef = useRef<{ spaceId: string; folderId?: string } | null>(null);
+    /** Prevents usePortalSpaces from resetting to 我的收藏 during search-return space switch. */
+    const preserveActiveSpaceIdRef = useRef<string | null>(null);
     const [globalSearchPathContext, setGlobalSearchPathContext] = useState<{
         groupTitle?: string;
         spaceName?: string;
@@ -384,6 +386,7 @@ export default function PortalKnowledgeWorkbench() {
         expandedGroups,
         preferredSpaceId: portalDeepLinkTarget?.spaceId,
         deepLinkFileId: portalDeepLinkTarget?.fileId,
+        preserveActiveSpaceIdRef,
     });
 
     const isPreviewOnlyDeepLink = Boolean(
@@ -1591,12 +1594,7 @@ export default function PortalKnowledgeWorkbench() {
             }
             setCanCreateFolder(false);
             setCanUploadFile(false);
-            void loadRootTreeRef.current(1, false, activeSpace.id).then(() => {
-                const pending = pendingSearchReturnRef.current;
-                if (!pending || String(activeSpace.id) !== pending.spaceId) return;
-                pendingSearchReturnRef.current = null;
-                void handleNavigateFolderRef.current(pending.folderId || undefined);
-            });
+            void loadRootTreeRef.current(1, false, activeSpace.id);
         } else if (!openingDeepLinkedFileHere) {
             // Sort/filter changed: keep the current folder and reload the same view
             // with the new ordering/filter instead of jumping back to the root.
@@ -1617,6 +1615,22 @@ export default function PortalKnowledgeWorkbench() {
         sortDirection,
         statusFilterNumbers,
     ]);
+
+    // Complete global-search "back to folder" after activeSpace has actually switched
+    // (and usePortalSpaces has not bounced us back to 我的收藏).
+    useEffect(() => {
+        const pending = pendingSearchReturnRef.current;
+        if (!pending || !activeSpace?.id) return;
+        if (String(activeSpace.id) !== pending.spaceId) return;
+        if (isFavoriteSpace(activeSpace)) return;
+        pendingSearchReturnRef.current = null;
+        const folderId = pending.folderId;
+        void Promise.resolve(handleNavigateFolderRef.current(folderId || undefined)).finally(() => {
+            if (preserveActiveSpaceIdRef.current === pending.spaceId) {
+                preserveActiveSpaceIdRef.current = null;
+            }
+        });
+    }, [activeSpace?.id, activeSpace?.isFavorite]);
 
     useEffect(() => {
         if (!selectedFile) return;
@@ -2458,6 +2472,7 @@ export default function PortalKnowledgeWorkbench() {
             const mustSwitchSpace = isFavoriteSpace(activeSpace)
                 || String(activeSpace?.id) !== targetSpaceId;
             if (mustSwitchSpace) {
+                preserveActiveSpaceIdRef.current = targetSpaceId;
                 pendingSearchReturnRef.current = {
                     spaceId: targetSpaceId,
                     folderId: parentFolderId,
@@ -2465,22 +2480,43 @@ export default function PortalKnowledgeWorkbench() {
                 const targetSpace = selectableSpaces.find(
                     (space) => String(space.id) === targetSpaceId,
                 ) ?? null;
+                const activate = (space: KnowledgeSpace) => {
+                    const level = getPortalSpaceLevel(space);
+                    const groupKey: SpaceGroupKey | null = level === SpaceLevel.PUBLIC
+                        ? "public"
+                        : level === SpaceLevel.DEPARTMENT
+                            ? "department"
+                            : level === SpaceLevel.TEAM || level === SpaceLevel.TEAM_KS
+                                ? "team"
+                                : level === SpaceLevel.PERSONAL
+                                    ? "personal"
+                                    : null;
+                    if (groupKey) {
+                        setExpandedGroups((prev) => (
+                            prev[groupKey] ? prev : { ...prev, [groupKey]: true }
+                        ));
+                    }
+                    setActiveSpace(space);
+                };
                 if (targetSpace) {
-                    setActiveSpace(targetSpace);
+                    activate(targetSpace);
                 } else {
                     void getSpaceInfoApi(targetSpaceId).then((space) => {
+                        preserveActiveSpaceIdRef.current = targetSpaceId;
                         pendingSearchReturnRef.current = {
                             spaceId: targetSpaceId,
                             folderId: parentFolderId,
                         };
-                        setActiveSpace(space);
+                        activate(space);
                     }).catch(() => {
                         pendingSearchReturnRef.current = null;
+                        preserveActiveSpaceIdRef.current = null;
                     });
                 }
                 return;
             }
 
+            preserveActiveSpaceIdRef.current = null;
             void handleNavigateFolder(parentFolderId || undefined);
             return;
         }

--- a/src/frontend/client/src/pages/knowledge/portal/components/GlobalSearchPanel.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/components/GlobalSearchPanel.tsx
@@ -4,7 +4,17 @@ import { type GlobalSearchFileResult, globalSearchSpaceFilesApi } from "~/api/kn
 import s from "./GlobalSearchPanel.module.css";
 
 interface Props {
-    onSelectFile: (spaceId: number, fileId: number, fileName: string) => void;
+    onSelectFile: (
+        spaceId: number,
+        fileId: number,
+        fileName: string,
+        meta?: {
+            spaceName: string;
+            spaceLevelLabel: string;
+            folderPathSegments: string[];
+            parentId?: string;
+        },
+    ) => void;
 }
 
 interface SpaceGroup {
@@ -178,7 +188,19 @@ export function GlobalSearchPanel({ onSelectFile }: Props) {
                                                             className={s.treeFile}
                                                             title={file.file_name}
                                                             onClick={() =>
-                                                                onSelectFile(file.space_id, file.file_id, file.file_name)
+                                                                onSelectFile(
+                                                                    file.space_id,
+                                                                    file.file_id,
+                                                                    file.file_name,
+                                                                    {
+                                                                        spaceName: file.space_name,
+                                                                        spaceLevelLabel: file.space_level_label,
+                                                                        folderPathSegments: file.folder_path,
+                                                                        parentId: file.parent_id != null
+                                                                            ? String(file.parent_id)
+                                                                            : undefined,
+                                                                    },
+                                                                )
                                                             }
                                                         >
                                                             {file.folder_path.length > 0 ? (

--- a/src/frontend/client/src/pages/knowledge/portal/components/SpaceSidebar.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/components/SpaceSidebar.tsx
@@ -90,7 +90,17 @@ interface SpaceSidebarProps {
     ) => void;
     onDeleteSpace: (space: KnowledgeSpace) => void;
     onLeaveSpace: (space: KnowledgeSpace) => void;
-    onGlobalSearchSelectFile: (spaceId: number, fileId: number, fileName: string) => void;
+    onGlobalSearchSelectFile: (
+        spaceId: number,
+        fileId: number,
+        fileName: string,
+        meta?: {
+            spaceName: string;
+            spaceLevelLabel: string;
+            folderPathSegments: string[];
+            parentId?: string;
+        },
+    ) => void;
 }
 
 /** Where a dragged space would land relative to the row under the pointer. */

--- a/src/frontend/client/src/pages/knowledge/portal/hooks/usePortalSpaces.ts
+++ b/src/frontend/client/src/pages/knowledge/portal/hooks/usePortalSpaces.ts
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useMemo, useState, type Dispatch, type SetStateAction } from "react";
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useState,
+    type Dispatch,
+    type RefObject,
+    type SetStateAction,
+} from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
     getCreateSpaceOptionsApi,
@@ -56,6 +64,11 @@ interface UsePortalSpacesParams {
     preferredSpaceId?: string;
     /** When set with preferredSpaceId, out-of-sidebar personal targets open preview-only. */
     deepLinkFileId?: string;
+    /**
+     * While set, do not auto-fallback activeSpace to 我的收藏 when the space is
+     * briefly missing from sidebar lists (global-search return navigation).
+     */
+    preserveActiveSpaceIdRef?: RefObject<string | null>;
 }
 
 function findDefaultPersonalSpace(spaces: KnowledgeSpace[]): KnowledgeSpace | null {
@@ -98,6 +111,7 @@ export function usePortalSpaces({
     expandedGroups,
     preferredSpaceId,
     deepLinkFileId,
+    preserveActiveSpaceIdRef,
 }: UsePortalSpacesParams) {
     const { user } = useAuthContext();
     const preferredSpaceQuery = useQuery({
@@ -310,6 +324,16 @@ export function usePortalSpaces({
 
         // 用 String() 兜底：新建返回的 space id 可能是数字，避免与列表里的字符串 id 不匹配而误重置
         if (activeSpace && selectableSpaces.some((space) => String(space.id) === String(activeSpace.id))) return;
+        // Global-search / return-nav may set a valid space that is temporarily absent
+        // from sidebar lists (group not expanded / still loading). Do not bounce to 我的收藏.
+        const preservedId = preserveActiveSpaceIdRef?.current;
+        if (
+            activeSpace
+            && preservedId
+            && String(activeSpace.id) === String(preservedId)
+        ) {
+            return;
+        }
         if (personalSpacesQuery.isLoading) return;
         setActiveSpace(defaultPersonalSpace ?? selectableSpaces[0] ?? null);
     }, [
@@ -318,6 +342,7 @@ export function usePortalSpaces({
         personalSpacesQuery.isLoading,
         preferredSpace,
         preferredSpaceId,
+        preserveActiveSpaceIdRef,
         selectableSpaces,
         setActiveSpace,
         skipPreferredSpaceActivation,

--- a/src/frontend/client/src/pages/knowledge/portal/utils.test.ts
+++ b/src/frontend/client/src/pages/knowledge/portal/utils.test.ts
@@ -1,6 +1,7 @@
 import { FileType, type KnowledgeFile } from "~/api/knowledge";
 import { fileEncodingCategoryLabel } from "./uploadMetadata";
 import {
+    buildPortalDocumentPath,
     createTreeNode,
     dedupeFilesById,
     dedupeTreeNodesByFileId,
@@ -203,6 +204,35 @@ describe("portal preview utils", () => {
                     { code: "CAS\u200B", label: "案例\u200B" },
                 ]),
             ).toBe("CAS / 案例");
+        });
+    });
+
+    describe("buildPortalDocumentPath", () => {
+        it("includes folder path from search result metadata when previewing a file", () => {
+            expect(buildPortalDocumentPath({
+                activeGroupTitle: "个人知识库",
+                activeSpaceName: "我的技术文档",
+                selectedFile: makeFile({
+                    id: "401",
+                    name: "搜索结果.md",
+                    type: FileType.MD,
+                    folderPath: "我的技术文档/制度文件",
+                    sourcePath: "我的技术文档>制度文件/搜索结果.md",
+                }),
+            })).toBe("全部知识库/个人知识库/我的技术文档/制度文件");
+        });
+
+        it("falls back to current folder breadcrumbs when metadata is missing", () => {
+            expect(buildPortalDocumentPath({
+                activeGroupTitle: "个人知识库",
+                activeSpaceName: "我的技术文档",
+                currentPath: [{ name: "制度文件" }],
+                selectedFile: makeFile({
+                    id: "401",
+                    name: "搜索结果.md",
+                    type: FileType.MD,
+                }),
+            })).toBe("全部知识库/个人知识库/我的技术文档/制度文件");
         });
     });
 });

--- a/src/frontend/client/src/pages/knowledge/portal/utils.ts
+++ b/src/frontend/client/src/pages/knowledge/portal/utils.ts
@@ -334,3 +334,77 @@ export function toStatusNumbers(statuses: FileStatus[]) {
         .map(fileStatusToNumber)
         .filter((status) => Number.isFinite(status));
 }
+
+function stripTrailingFileName(path: string, fileName?: string) {
+    const normalizedName = (fileName || "").trim();
+    if (!normalizedName) return path;
+    const segments = path.split("/").filter(Boolean);
+    if (segments.length && segments[segments.length - 1] === normalizedName) {
+        return segments.slice(0, -1).join("/");
+    }
+    return path;
+}
+
+function normalizePortalSourcePath(sourcePath: string, activeSpaceName?: string) {
+    const trimmed = sourcePath.trim();
+    if (!trimmed) return "";
+    const withoutSpacePrefix = trimmed.includes(">")
+        ? trimmed.split(">").slice(1).join("/")
+        : trimmed;
+    const normalized = withoutSpacePrefix.replace(/^\/+/, "");
+    if (!activeSpaceName) return normalized;
+    if (normalized === activeSpaceName) return "";
+    if (normalized.startsWith(`${activeSpaceName}/`)) {
+        return normalized.slice(activeSpaceName.length + 1);
+    }
+    return normalized;
+}
+
+function normalizePortalFolderPath(folderPath: string, activeSpaceName?: string) {
+    const trimmed = folderPath.trim().replace(/^\/+/, "");
+    if (!trimmed) return "";
+    if (/^\d+(?:\/\d+)*$/.test(trimmed)) return "";
+    if (!activeSpaceName) return trimmed;
+    if (trimmed === activeSpaceName) return "";
+    if (trimmed.startsWith(`${activeSpaceName}/`)) {
+        return trimmed.slice(activeSpaceName.length + 1);
+    }
+    return trimmed;
+}
+
+export function buildPortalDocumentPath(params: {
+    activeGroupTitle?: string;
+    activeSpaceName?: string;
+    currentPath?: Array<{ name: string }>;
+    selectedFile?: KnowledgeFile | null;
+}): string {
+    const baseNames = [
+        "全部知识库",
+        params.activeGroupTitle,
+        params.activeSpaceName,
+    ].filter(Boolean) as string[];
+
+    const folderSegments: string[] = [];
+    const file = params.selectedFile;
+    if (file) {
+        const folderPath = normalizePortalFolderPath(String(file.folderPath || ""), params.activeSpaceName);
+        if (folderPath) {
+            folderSegments.push(...folderPath.split("/").filter(Boolean));
+        } else {
+            const sourcePath = normalizePortalSourcePath(String(file.sourcePath || ""), params.activeSpaceName);
+            const locationPath = stripTrailingFileName(sourcePath, file.name);
+            if (locationPath) {
+                folderSegments.push(...locationPath.split("/").filter(Boolean));
+            }
+        }
+        if (!folderSegments.length && params.currentPath?.length) {
+            folderSegments.push(...params.currentPath.map((segment) => segment.name));
+        }
+    } else if (params.currentPath?.length) {
+        folderSegments.push(...params.currentPath.map((segment) => segment.name));
+    }
+
+    return folderSegments.length
+        ? [...baseNames, ...folderSegments].join("/")
+        : baseNames.join("/");
+}


### PR DESCRIPTION
## Summary
- When a user opens a file from in-space search results and clicks「返回文件列表」, navigate to the file's parent folder list instead of staying on the wrong root or stale folder view.
- Added regression test covering search → preview → back for a file inside a subfolder.

## Test plan
- [x] `npx jest src/pages/knowledge/portal/PortalKnowledgeWorkbench.test.tsx -t "returns from search preview" --no-watchman --coverage=false`
- [x] `npx jest src/pages/knowledge/portal/PortalKnowledgeWorkbench.test.tsx -t "deep-link open with folderId returns" --no-watchman --coverage=false`
- [ ] Manual: search in knowledge portal → open matched file in subfolder → back → verify parent folder file list

## Gitee
- Issue: IK5KDG
- State: unchanged (per team policy)

Made with [Cursor](https://cursor.com)