### PR TITLE
fix(portal): show real folder path for search-opened file preview (IK5KFE)

### DIFF
--- a/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
+++ b/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
@@ -13275,6 +13275,11 @@ class KnowledgeSpaceService(KnowledgeUtils):
             page_items,
             folder_counts_override=folder_counts_override,
         )
+        folder_path_map, source_path_map = await self._resolve_shougang_portal_source_paths(data)
+        for item in data:
+            item_id = int(item.get("id") or 0)
+            item["folder_path"] = folder_path_map.get(item_id, "")
+            item["source_path"] = source_path_map.get(item_id, "")
         return {"total": total, "page": page, "page_size": page_size, "data": data}
 
     # ──────────────────────────── Folders ─────────────────────────────────────

--- a/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.test.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.test.tsx
@@ -5919,6 +5919,43 @@ describe("PortalKnowledgeWorkbench", () => {
         expect(within(reopened).getByTestId("edit-tags-initial-ids")).toHaveTextContent("3");
     });
 
+    test("shows folder path when previewing a search result", async () => {
+        const personalSpace = makeSpace("personal-1", "我的技术文档", {
+            role: SpaceRole.ADMIN,
+        });
+        jest.mocked(getGroupedSpacesApi).mockResolvedValue({
+            publicSpaces: [],
+            departmentSpaces: [],
+            teamSpaces: [],
+            personalSpaces: [personalSpace],
+        } as any);
+        jest.mocked(getSpaceChildrenApi).mockResolvedValue({
+            data: [],
+            total: 0,
+        } as any);
+        jest.mocked(searchSpaceChildrenApi).mockResolvedValue({
+            data: [makeFile("401", "搜索结果.md", {
+                parentId: "101",
+                spaceId: "personal-1",
+                folderPath: "我的技术文档/制度文件",
+                sourcePath: "我的技术文档>制度文件/搜索结果.md",
+            })],
+            total: 1,
+        } as any);
+
+        renderWorkbench();
+
+        const input = await screen.findByPlaceholderText("com_knowledge.search_in_current_space");
+        fireEvent.change(input, { target: { value: "搜索" } });
+        fireEvent.keyDown(input, { key: "Enter" });
+
+        const workspace = await screen.findByTestId("portal-file-workspace");
+        fireEvent.click(within(workspace).getByRole("button", { name: "打开搜索结果.md" }));
+
+        const preview = await screen.findByTestId("portal-preview-page");
+        expect(preview).toHaveTextContent("全部知识库/个人知识库/我的技术文档/制度文件");
+    });
+
     test("deletes a file from search results through the backend", async () => {
         const personalSpace = makeSpace("personal-1", "我的技术文档", {
             role: SpaceRole.ADMIN,
@@ -5943,7 +5980,7 @@ describe("PortalKnowledgeWorkbench", () => {
 
         renderWorkbench();
 
-        const input = await screen.findByPlaceholderText("Search in current knowledge space");
+        const input = await screen.findByPlaceholderText("com_knowledge.search_in_current_space");
         fireEvent.change(input, { target: { value: "搜索" } });
 
         expect(await screen.findByText("搜索结果.md")).toBeInTheDocument();

--- a/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.tsx
@@ -63,6 +63,7 @@ import type {
 } from "./types";
 import {
     collectTreeFileIds,
+    buildPortalDocumentPath,
     createTreeNode,
     dedupeFilesById,
     dedupeTreeNodesByFileId,
@@ -2697,14 +2698,12 @@ export default function PortalKnowledgeWorkbench() {
         }
     }, [editingSpace, queryClient, showToast]);
 
-    const documentPath = useMemo(() => {
-        const names = [
-            "全部知识库",
-            activeGroup?.title,
-            activeSpace?.name,
-        ].filter(Boolean);
-        return names.join("/");
-    }, [activeGroup?.title, activeSpace?.name]);
+    const documentPath = useMemo(() => buildPortalDocumentPath({
+        activeGroupTitle: activeGroup?.title,
+        activeSpaceName: activeSpace?.name,
+        currentPath,
+        selectedFile,
+    }), [activeGroup?.title, activeSpace?.name, currentPath, selectedFile]);
     const aiContextLabel = currentFolderId ? "文件夹" : "知识库";
     const handleWorkbenchDrag = useCallback((event: DragEvent<HTMLDivElement>) => {
         event.preventDefault();

--- a/src/frontend/client/src/pages/knowledge/portal/utils.test.ts
+++ b/src/frontend/client/src/pages/knowledge/portal/utils.test.ts
@@ -1,6 +1,7 @@
 import { FileType, type KnowledgeFile } from "~/api/knowledge";
 import { fileEncodingCategoryLabel } from "./uploadMetadata";
 import {
+    buildPortalDocumentPath,
     createTreeNode,
     dedupeFilesById,
     dedupeTreeNodesByFileId,
@@ -203,6 +204,35 @@ describe("portal preview utils", () => {
                     { code: "CAS\u200B", label: "案例\u200B" },
                 ]),
             ).toBe("CAS / 案例");
+        });
+    });
+
+    describe("buildPortalDocumentPath", () => {
+        it("includes folder path from search result metadata when previewing a file", () => {
+            expect(buildPortalDocumentPath({
+                activeGroupTitle: "个人知识库",
+                activeSpaceName: "我的技术文档",
+                selectedFile: makeFile({
+                    id: "401",
+                    name: "搜索结果.md",
+                    type: FileType.MD,
+                    folderPath: "我的技术文档/制度文件",
+                    sourcePath: "我的技术文档>制度文件/搜索结果.md",
+                }),
+            })).toBe("全部知识库/个人知识库/我的技术文档/制度文件");
+        });
+
+        it("falls back to current folder breadcrumbs when metadata is missing", () => {
+            expect(buildPortalDocumentPath({
+                activeGroupTitle: "个人知识库",
+                activeSpaceName: "我的技术文档",
+                currentPath: [{ name: "制度文件" }],
+                selectedFile: makeFile({
+                    id: "401",
+                    name: "搜索结果.md",
+                    type: FileType.MD,
+                }),
+            })).toBe("全部知识库/个人知识库/我的技术文档/制度文件");
         });
     });
 });

--- a/src/frontend/client/src/pages/knowledge/portal/utils.ts
+++ b/src/frontend/client/src/pages/knowledge/portal/utils.ts
@@ -334,3 +334,77 @@ export function toStatusNumbers(statuses: FileStatus[]) {
         .map(fileStatusToNumber)
         .filter((status) => Number.isFinite(status));
 }
+
+function stripTrailingFileName(path: string, fileName?: string) {
+    const normalizedName = (fileName || "").trim();
+    if (!normalizedName) return path;
+    const segments = path.split("/").filter(Boolean);
+    if (segments.length && segments[segments.length - 1] === normalizedName) {
+        return segments.slice(0, -1).join("/");
+    }
+    return path;
+}
+
+function normalizePortalSourcePath(sourcePath: string, activeSpaceName?: string) {
+    const trimmed = sourcePath.trim();
+    if (!trimmed) return "";
+    const withoutSpacePrefix = trimmed.includes(">")
+        ? trimmed.split(">").slice(1).join("/")
+        : trimmed;
+    const normalized = withoutSpacePrefix.replace(/^\/+/, "");
+    if (!activeSpaceName) return normalized;
+    if (normalized === activeSpaceName) return "";
+    if (normalized.startsWith(`${activeSpaceName}/`)) {
+        return normalized.slice(activeSpaceName.length + 1);
+    }
+    return normalized;
+}
+
+function normalizePortalFolderPath(folderPath: string, activeSpaceName?: string) {
+    const trimmed = folderPath.trim().replace(/^\/+/, "");
+    if (!trimmed) return "";
+    if (/^\d+(?:\/\d+)*$/.test(trimmed)) return "";
+    if (!activeSpaceName) return trimmed;
+    if (trimmed === activeSpaceName) return "";
+    if (trimmed.startsWith(`${activeSpaceName}/`)) {
+        return trimmed.slice(activeSpaceName.length + 1);
+    }
+    return trimmed;
+}
+
+export function buildPortalDocumentPath(params: {
+    activeGroupTitle?: string;
+    activeSpaceName?: string;
+    currentPath?: Array<{ name: string }>;
+    selectedFile?: KnowledgeFile | null;
+}): string {
+    const baseNames = [
+        "全部知识库",
+        params.activeGroupTitle,
+        params.activeSpaceName,
+    ].filter(Boolean) as string[];
+
+    const folderSegments: string[] = [];
+    const file = params.selectedFile;
+    if (file) {
+        const folderPath = normalizePortalFolderPath(String(file.folderPath || ""), params.activeSpaceName);
+        if (folderPath) {
+            folderSegments.push(...folderPath.split("/").filter(Boolean));
+        } else {
+            const sourcePath = normalizePortalSourcePath(String(file.sourcePath || ""), params.activeSpaceName);
+            const locationPath = stripTrailingFileName(sourcePath, file.name);
+            if (locationPath) {
+                folderSegments.push(...locationPath.split("/").filter(Boolean));
+            }
+        }
+        if (!folderSegments.length && params.currentPath?.length) {
+            folderSegments.push(...params.currentPath.map((segment) => segment.name));
+        }
+    } else if (params.currentPath?.length) {
+        folderSegments.push(...params.currentPath.map((segment) => segment.name));
+    }
+
+    return folderSegments.length
+        ? [...baseNames, ...folderSegments].join("/")
+        : baseNames.join("/");
+}


### PR DESCRIPTION
## Summary
- Backend: `search_space_children` now resolves `folder_path` / `source_path` like other portal file listings.
- Frontend: preview breadcrumb (`documentPath`) uses file metadata or current folder path instead of stopping at the knowledge space name.

## Test plan
- [x] `npx jest src/pages/knowledge/portal/utils.test.ts -t buildPortalDocumentPath --no-watchman --coverage=false`
- [x] `npx jest src/pages/knowledge/portal/PortalKnowledgeWorkbench.test.tsx -t "shows folder path when previewing" --no-watchman --coverage=false`
- [ ] Manual: search in knowledge portal → open file in subfolder → verify header path shows space + folder

## Gitee
- Issue: IK5KFE
- State: unchanged (per team policy)

## Related
- IK5KDG (search back navigation): #2255

Made with [Cursor](https://cursor.com)