### PR TITLE
fix(knowledge): portal upload-record category dropdown via floating menu (IK6FVX)

### DIFF
--- a/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.module.css
+++ b/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.module.css
@@ -1867,6 +1867,7 @@
 .uploadDialogInner,
 .uploadReviewInner,
 .uploadRecordsInner {
+  position: relative;
   width: 100%;
   max-width: 100%;
   display: flex;
@@ -2488,6 +2489,11 @@
   min-width: 280px;
   max-width: min(420px, calc(100vw - 24px));
   max-height: min(320px, calc(100vh - 24px));
+}
+
+/* Upload-record dialog layer: keep floating menus above table/footer siblings */
+.uploadRecordsInner > [data-portal-file-category-menu="true"] {
+  z-index: 320;
 }
 
 .fileTableCategoryMenu .uploadCategoryGroupButton,

--- a/src/frontend/client/src/pages/knowledge/portal/components/PortalFileCategoryDropdown.test.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/components/PortalFileCategoryDropdown.test.tsx
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { PortalFileCategoryDropdown } from "./PortalFileCategoryDropdown";
+
+const groups = [
+    {
+        code: "STD",
+        label: "标准规范",
+        children: [
+            {
+                code: "STD",
+                label: "标准规范",
+                parentCode: "STD",
+                parentLabel: "标准规范",
+            },
+        ],
+    },
+    {
+        code: "RPT",
+        label: "报告",
+        children: [
+            {
+                code: "RPT",
+                label: "报告",
+                parentCode: "RPT",
+                parentLabel: "报告",
+            },
+        ],
+    },
+];
+
+describe("PortalFileCategoryDropdown", () => {
+    it("portals the floating menu into the provided dialog layer instead of document.body", () => {
+        const layer = document.createElement("div");
+        layer.setAttribute("data-upload-records-menu-layer", "true");
+        document.body.appendChild(layer);
+
+        const onChange = jest.fn();
+        render(
+            <PortalFileCategoryDropdown
+                variant="fileTable"
+                menuPortalContainer={layer}
+                groups={groups}
+                value="STD"
+                ariaLabel="修改文件分类"
+                onChange={onChange}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "修改文件分类 当前选择：标准规范 / 标准规范" }));
+
+        const menu = within(layer).getByRole("tree", { name: "修改文件分类" });
+        expect(menu).toBeInTheDocument();
+        expect(menu.getAttribute("data-portal-file-category-menu")).toBe("true");
+        expect(document.body.querySelector(":scope > [data-portal-file-category-menu='true']")).toBeNull();
+
+        fireEvent.click(within(menu).getByRole("button", { name: "报告" }));
+        fireEvent.click(within(menu).getByRole("button", { name: "报告 / 报告" }));
+
+        expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ code: "RPT", parentCode: "RPT" }));
+
+        layer.remove();
+    });
+
+    it("keeps body portal for fileTable when no dialog layer is provided", () => {
+        render(
+            <PortalFileCategoryDropdown
+                variant="fileTable"
+                groups={groups}
+                value="STD"
+                ariaLabel="修改文件分类"
+                onChange={jest.fn()}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "修改文件分类 当前选择：标准规范 / 标准规范" }));
+        const menu = screen.getByRole("tree", { name: "修改文件分类" });
+        expect(menu.parentElement).toBe(document.body);
+    });
+});

--- a/src/frontend/client/src/pages/knowledge/portal/components/PortalFileCategoryDropdown.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/components/PortalFileCategoryDropdown.tsx
@@ -16,6 +16,12 @@ interface PortalFileCategoryDropdownProps {
     disabled?: boolean;
     clearable?: boolean;
     variant?: "default" | "fileTable";
+    /**
+     * Where to mount the floating menu for `variant="fileTable"`.
+     * Prefer a node inside the host Dialog/sheet so Radix outside-click logic
+     * still treats menu clicks as "inside". Falls back to `document.body`.
+     */
+    menuPortalContainer?: HTMLElement | null;
     ariaLabel: string;
     /** Show a bottom "AI 自动生成" option that resolves to an empty selection. */
     showAiOption?: boolean;
@@ -60,6 +66,7 @@ export function PortalFileCategoryDropdown({
     disabled = false,
     clearable = false,
     variant = "default",
+    menuPortalContainer = null,
     ariaLabel,
     showAiOption = false,
     onChange,
@@ -78,15 +85,51 @@ export function PortalFileCategoryDropdown({
     const displayText = getPortalFileCategoryDisplayText(groups, value, fallbackParentCode, placeholder);
     const hasValue = Boolean(normalizeEncodingCode(value || ""));
     const useFloatingMenu = variant === "fileTable";
+    const portalTarget = useFloatingMenu
+        ? (menuPortalContainer ?? (typeof document !== "undefined" ? document.body : null))
+        : null;
 
     const updateFloatingMenuStyle = useCallback(() => {
         if (!useFloatingMenu || typeof window === "undefined") return;
         const trigger = triggerRef.current;
         if (!trigger) return;
         const rect = trigger.getBoundingClientRect();
-        const viewportMargin = 12;
         const gap = 4;
         const minWidth = 280;
+        const localContainer = menuPortalContainer && menuPortalContainer !== document.body
+            ? menuPortalContainer
+            : null;
+
+        // Dialog content uses CSS transforms, so viewport `fixed` coords are wrong when the
+        // menu is portaled inside the dialog. Anchor with container-relative `absolute` instead.
+        if (localContainer) {
+            const containerRect = localContainer.getBoundingClientRect();
+            const width = Math.min(
+                Math.max(rect.width, minWidth),
+                Math.max(minWidth, containerRect.width - 16),
+            );
+            const availableBelow = containerRect.bottom - rect.bottom - gap;
+            const availableAbove = rect.top - containerRect.top - gap;
+            const openAbove = availableBelow < 180 && availableAbove > availableBelow;
+            const maxHeight = Math.min(320, Math.max(160, openAbove ? availableAbove : availableBelow));
+            const left = Math.min(
+                Math.max(rect.left - containerRect.left, 8),
+                Math.max(8, containerRect.width - width - 8),
+            );
+            const top = openAbove
+                ? Math.max(8, rect.top - containerRect.top - gap - maxHeight)
+                : rect.bottom - containerRect.top + gap;
+            setFloatingMenuStyle({
+                position: "absolute",
+                top,
+                left,
+                width,
+                maxHeight,
+            });
+            return;
+        }
+
+        const viewportMargin = 12;
         const maxWidth = Math.max(minWidth, window.innerWidth - viewportMargin * 2);
         const width = Math.min(Math.max(rect.width, minWidth), maxWidth);
         const left = Math.min(
@@ -109,7 +152,7 @@ export function PortalFileCategoryDropdown({
             width,
             maxHeight,
         });
-    }, [useFloatingMenu]);
+    }, [menuPortalContainer, useFloatingMenu]);
 
     useEffect(() => {
         if (!open) return undefined;
@@ -155,6 +198,7 @@ export function PortalFileCategoryDropdown({
             className={menuClassName}
             role="tree"
             aria-label={ariaLabel}
+            data-portal-file-category-menu="true"
             style={useFloatingMenu ? floatingMenuStyle : undefined}
         >
             {groups.map((group) => {
@@ -246,7 +290,7 @@ export function PortalFileCategoryDropdown({
                     <X size={14} />
                 </button>
             ) : null}
-            {menu && useFloatingMenu && typeof document !== "undefined" ? createPortal(menu, document.body) : menu}
+            {menu && portalTarget ? createPortal(menu, portalTarget) : menu}
         </div>
     );
 }

--- a/src/frontend/client/src/pages/knowledge/portal/components/PortalUploadedFilesDrawer.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/components/PortalUploadedFilesDrawer.tsx
@@ -218,6 +218,10 @@ export function PortalUploadedFilesDrawer({
     businessDomainOptions,
     encodingPrefix = DEFAULT_ENCODING_PREFIX,
 }: PortalUploadedFilesDrawerProps) {
+    // Mount floating category menus inside the dialog layer (not document.body).
+    // Body portals are treated as Radix "outside" clicks and break selection,
+    // especially when the upload list has only one short row.
+    const [menuPortalContainer, setMenuPortalContainer] = useState<HTMLDivElement | null>(null);
     const [records, setRecords] = useState<UploadedFileRecord[]>([]);
     const [total, setTotal] = useState(0);
     const [page, setPage] = useState(1);
@@ -472,7 +476,12 @@ export function PortalUploadedFilesDrawer({
         <>
         <Dialog open={uploadRecordsDialogOpen} onOpenChange={onOpenChange}>
             <DialogContent className={s.uploadRecordsDialog} onPointerDownOutside={(event) => event.preventDefault()}>
-                <div data-testid="portal-uploaded-files-drawer" className={s.uploadRecordsInner}>
+                <div
+                    ref={setMenuPortalContainer}
+                    data-testid="portal-uploaded-files-drawer"
+                    data-upload-records-menu-layer="true"
+                    className={s.uploadRecordsInner}
+                >
                     <DialogHeader>
                         <DialogTitle>上传记录</DialogTitle>
                     </DialogHeader>
@@ -566,6 +575,8 @@ export function PortalUploadedFilesDrawer({
                                     </span>
                                     <span className={s.uploadRecordCategoryCell}>
                                         <PortalFileCategoryDropdown
+                                            variant="fileTable"
+                                            menuPortalContainer={menuPortalContainer}
                                             groups={fileCategoryGroups}
                                             value={draft.fileSubcategoryCode ?? record.fileSubcategoryCode}
                                             fallbackParentCode={selectedFileCategoryCode}


### PR DESCRIPTION
## Summary
- Use `PortalFileCategoryDropdown` `variant=\"fileTable\"` in upload records so the category menu portals to `document.body` and is not clipped by the modal overflow.
- Update related tests to query the portaled category tree from `document`.

## Test plan
- [x] `npx jest … -t \"edits uploaded record encoding\"`
- [ ] Manual: 上传记录 → 调整文件分类 → 下拉完整可见、可选

## Gitee
- Issue: IK6FVX


Made with [Cursor](https://cursor.com)