### PR TITLE
feat(linsight): 任务模式产出区的四项后续打磨

### DIFF
--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -103,7 +103,7 @@ dependencies = [
     # Previously available transitively; the LangChain 1.x dependency graph no
     # longer pulls it in, but bisheng.user / sso_sync import it directly.
     "rsa>=4.9",
-    "deepagents>=0.6.3",
+    "deepagents>=0.6.3,<0.7",
     "pypinyin>=0.55.0",
 ]
 

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -507,7 +507,7 @@ requires-dist = [
     { name = "chromadb", specifier = ">=1.3.4" },
     { name = "cryptography", specifier = ">=46.0.3" },
     { name = "dashscope", specifier = ">=1.24.9" },
-    { name = "deepagents", specifier = ">=0.6.3" },
+    { name = "deepagents", specifier = ">=0.6.3,<0.7" },
     { name = "dmasync", marker = "sys_platform != 'darwin'" },
     { name = "dmpython", marker = "sys_platform != 'darwin'" },
     { name = "dmsqlalchemy", marker = "sys_platform != 'darwin'" },

--- a/src/frontend/client/src/components/Linsight/Artifacts/MarkdownOutline.tsx
+++ b/src/frontend/client/src/components/Linsight/Artifacts/MarkdownOutline.tsx
@@ -34,7 +34,10 @@ import { useMarkdownOutline } from './useMarkdownOutline';
 
 /** How close to the right edge the pointer must come to reveal the outline. */
 const EDGE_ZONE = 56;
-const OPEN_DELAY = 80;
+/** Opening is immediate — the right edge of the panel is a terminus rather than
+ *  a corridor, so there is no sweep-through to debounce away, and any delay here
+ *  stacks on top of the fade and reads as lag. Closing stays lazy so the pointer
+ *  has time to travel from the rail onto the card. */
 const CLOSE_DELAY = 200;
 /** Below this an outline isn't navigation, it's noise. */
 const MIN_HEADINGS = 2;
@@ -85,9 +88,19 @@ export function MarkdownOutline({ contentRef, contentKey }: MarkdownOutlineProps
         [listRef, revealListRef],
     );
 
-    const schedule = useCallback((next: boolean, delay: number) => {
+    const openNow = useCallback(() => {
         clearTimeout(timerRef.current);
-        timerRef.current = setTimeout(() => setOpen(next), delay);
+        setOpen(true);
+    }, []);
+
+    const closeSoon = useCallback(() => {
+        clearTimeout(timerRef.current);
+        timerRef.current = setTimeout(() => setOpen(false), CLOSE_DELAY);
+    }, []);
+
+    /** Cancel a pending close without opening — used while the pointer is on the card. */
+    const holdOpen = useCallback(() => {
+        clearTimeout(timerRef.current);
     }, []);
 
     useEffect(() => () => clearTimeout(timerRef.current), []);
@@ -109,21 +122,24 @@ export function MarkdownOutline({ contentRef, contentKey }: MarkdownOutlineProps
             return undefined;
         }
         const onMove = (event: PointerEvent) => {
-            const near = scroller.getBoundingClientRect().right - event.clientX <= EDGE_ZONE;
-            if (near) {
-                schedule(true, OPEN_DELAY);
-            } else if (openRef.current && !cardRef.current?.contains(event.target as Node)) {
-                schedule(false, CLOSE_DELAY);
+            if (scroller.getBoundingClientRect().right - event.clientX <= EDGE_ZONE) {
+                openNow();
+            } else if (cardRef.current?.contains(event.target as Node)) {
+                // On the card but left of the edge zone: stay open for as long as
+                // the pointer rests there, however far it is from the rail.
+                holdOpen();
+            } else if (openRef.current) {
+                closeSoon();
             }
         };
-        const onLeave = () => schedule(false, CLOSE_DELAY);
+        const onLeave = () => closeSoon();
         scroller.addEventListener('pointermove', onMove, { passive: true });
         scroller.addEventListener('pointerleave', onLeave);
         return () => {
             scroller.removeEventListener('pointermove', onMove);
             scroller.removeEventListener('pointerleave', onLeave);
         };
-    }, [coarsePointer, contentRef, headings.length, schedule]);
+    }, [closeSoon, coarsePointer, contentRef, headings.length, holdOpen, openNow]);
 
     // Tap-outside and Esc both dismiss; Esc hands focus back to the rail.
     useEffect(() => {
@@ -204,7 +220,7 @@ export function MarkdownOutline({ contentRef, contentKey }: MarkdownOutlineProps
                         }
                     }}
                     className={cn(
-                        'pointer-events-auto flex flex-col items-end py-2 pl-2 outline-none transition-opacity duration-200',
+                        'pointer-events-auto flex flex-col items-end py-2 pl-2 outline-none transition-opacity duration-100',
                         // Two-stage reveal: the ticks wake when the pointer is
                         // anywhere over the document, then hand off to the card.
                         'opacity-60 group-hover/mk:opacity-100 focus-visible:opacity-100',
@@ -233,11 +249,13 @@ export function MarkdownOutline({ contentRef, contentKey }: MarkdownOutlineProps
                     className={cn(
                         'absolute right-0 top-1/2 w-[240px] -translate-y-1/2 overflow-hidden rounded-[10px]',
                         'border border-[#ebecf0] bg-white shadow-[0px_4px_16px_rgba(0,0,0,0.08)]',
-                        'transition-[opacity,transform] duration-150 ease-out motion-reduce:transition-none',
+                        'transition-[opacity,transform] ease-out motion-reduce:transition-none',
                         'coarse-pointer:w-[min(260px,68vw)]',
+                        // Opens fast enough to feel like a direct response to the
+                        // pointer; closes a touch slower so it doesn't snap away.
                         open
-                            ? 'pointer-events-auto translate-x-0 opacity-100'
-                            : 'pointer-events-none translate-x-1.5 opacity-0',
+                            ? 'pointer-events-auto translate-x-0 opacity-100 duration-100'
+                            : 'pointer-events-none translate-x-1 opacity-0 duration-150',
                     )}
                 >
                     <div

--- a/src/frontend/client/src/components/Linsight/Artifacts/MarkdownOutline.tsx
+++ b/src/frontend/client/src/components/Linsight/Artifacts/MarkdownOutline.tsx
@@ -29,11 +29,9 @@ import {
 import { useLocalize, useScrollRevealRef } from '~/hooks';
 import { cn } from '~/utils';
 import { useScrollFade } from '../Execution/useScrollFade';
-import { TICK_LENGTHS, getScrollParent } from './markdownOutlineUtils';
+import { TICK_LENGTHS, getScrollParent, isPointerNearRail } from './markdownOutlineUtils';
 import { useMarkdownOutline } from './useMarkdownOutline';
 
-/** How close to the right edge the pointer must come to reveal the outline. */
-const EDGE_ZONE = 56;
 /** Opening is immediate — the right edge of the panel is a terminus rather than
  *  a corridor, so there is no sweep-through to debounce away, and any delay here
  *  stacks on top of the fade and reads as lag. Closing stays lazy so the pointer
@@ -122,7 +120,7 @@ export function MarkdownOutline({ contentRef, contentKey }: MarkdownOutlineProps
             return undefined;
         }
         const onMove = (event: PointerEvent) => {
-            if (scroller.getBoundingClientRect().right - event.clientX <= EDGE_ZONE) {
+            if (isPointerNearRail(railRef.current, event.clientX, event.clientY)) {
                 openNow();
             } else if (cardRef.current?.contains(event.target as Node)) {
                 // On the card but left of the edge zone: stay open for as long as

--- a/src/frontend/client/src/components/Linsight/Artifacts/ResultSection.tsx
+++ b/src/frontend/client/src/components/Linsight/Artifacts/ResultSection.tsx
@@ -41,7 +41,7 @@ export function ResultSection({ answer, files, versionId, onPreview }: ResultSec
         <div className="space-y-3">
             {/* report link row */}
             {primaryFile && (
-                <div className="group/row flex items-center gap-1.5 text-sm text-gray-800">
+                <div className="flex items-center gap-1.5 text-sm text-gray-800">
                     <span className="shrink-0">
                         {multiple
                             ? localize('com_linsight_files_ready_prefix', { 0: fileCount })
@@ -68,8 +68,14 @@ export function ResultSection({ answer, files, versionId, onPreview }: ResultSec
                         file card below only renders for multi-file runs), so the
                         download belongs here. With several files the card carries
                         one per row; repeating it after "等 N 个文件" would read as
-                        "download all", which is not what it does. */}
-                    {!multiple && <SaveAsButton file={primaryFile} versionId={versionId} />}
+                        "download all", which is not what it does.
+                        `inline` (always visible), not the list rows' hover-reveal:
+                        a lone glyph in a sentence isn't the repetition that made a
+                        column of them read as noise, and this is the only download
+                        entry a single-file run has — the exact gap this fixed. */}
+                    {!multiple && (
+                        <SaveAsButton file={primaryFile} versionId={versionId} variant="inline" />
+                    )}
                 </div>
             )}
 
@@ -123,13 +129,17 @@ export function ResultSection({ answer, files, versionId, onPreview }: ResultSec
                         {files.map((file) => (
                             <div
                                 key={file.file_id || file.file_url}
-                                className="group/row flex items-center gap-2 rounded-lg py-1.5 pl-7 pr-1.5 transition-colors hover:bg-[#f7f7f7]"
+                                className="group/row flex items-center gap-1 rounded-lg py-1.5 pl-7 pr-2 transition-colors hover:bg-[#f7f7f7]"
                             >
-                                {/* Name = preview. The rail on the right = keep the
-                                    file. Two jobs, two targets, no double duty. */}
+                                {/* Name = preview, and the action sits right after
+                                    it rather than in a far-right gutter — the name
+                                    is what the download is ABOUT, so it should not
+                                    have to be traced across the row. The name is
+                                    min-w-0 but NOT flex-1: it shrinks to its text
+                                    and only truncates when the row runs out. */}
                                 <button
                                     type="button"
-                                    className="flex min-w-0 flex-1 items-center gap-1.5 text-left text-[14px] text-[#1A1A1A] transition-colors hover:text-blue-500"
+                                    className="flex min-w-0 items-center gap-1.5 text-left text-[14px] text-[#1A1A1A] transition-colors hover:text-blue-500"
                                     onClick={() => onPreview(file)}
                                 >
                                     <span className="truncate">{file.file_name}</span>

--- a/src/frontend/client/src/components/Linsight/Artifacts/SaveAsButton.tsx
+++ b/src/frontend/client/src/components/Linsight/Artifacts/SaveAsButton.tsx
@@ -4,14 +4,26 @@
  * other type downloads the original file directly — so the label is honest per
  * type: "另存为" when there is a format choice, "下载" when there isn't.
  *
- * Two placements share the logic (`variant`):
- *   - 'rail'    the fixed trailing gutter of a file row (result card, workspace
- *               list). Reserved width, so the glyph never shifts the file name
- *               on hover, and a resting grey rather than hover-only visibility —
- *               a download you can't see until you hover is a download nobody
- *               finds, which is exactly how HTML reports ended up with no
- *               download entry at all (they open in a tab, never in the preview).
+ * Three placements share the logic (`variant`):
+ *   - 'row'     sits directly after the file name in a list, revealed on row
+ *               hover. Adjacency is the point: parked in a far-right gutter the
+ *               glyph ended up ~1000px from a short file name, and the eye had
+ *               to cross an empty row to work out which file it acted on.
+ *               Hover-reveal is what keeps a column of ten identical glyphs from
+ *               reading as noise — repetition is the noise, not the glyph.
+ *   - 'inline'  always visible, for a SINGLE action inside a sentence (the
+ *               one-deliverable result row). One instance isn't a column, so
+ *               there is nothing to quiet down, and hiding the only download
+ *               entry a run has is the failure this whole feature fixed.
  *   - 'toolbar' preview-panel toolbar icon button.
+ *
+ * 'row' hides with OPACITY, never `hidden`/`invisible`: the button keeps its
+ * box, so revealing it can't re-truncate the file name next to it. Three
+ * exceptions keep it from being a desktop-mouse-only affordance —
+ * `focus-visible` (never focus something invisible), `data-[state=open]` (the
+ * markdown menu must not fade out from under itself when the pointer leaves the
+ * row), and `(hover: none)`, where the whole gesture doesn't exist and the
+ * button simply stays put.
  */
 import { Outlined } from 'bisheng-icons';
 import { useState } from 'react';
@@ -34,12 +46,12 @@ import {
     saveConvertedBlob,
 } from './artifactUtils';
 
-type SaveAsVariant = 'rail' | 'toolbar';
+type SaveAsVariant = 'row' | 'inline' | 'toolbar';
 
 interface SaveAsButtonProps {
     file: ArtifactFile;
     versionId: string;
-    /** Trigger placement — see the file header. Defaults to the row rail. */
+    /** Trigger placement — see the file header. Defaults to the list-row action. */
     variant?: SaveAsVariant;
     className?: string;
 }
@@ -48,14 +60,21 @@ const TRIGGER_BASE =
     'flex shrink-0 items-center justify-center transition-colors focus-visible:outline-none ' +
     'focus-visible:ring-2 focus-visible:ring-blue-500/40 disabled:cursor-not-allowed disabled:opacity-50';
 
+// Shared by 'row' and 'inline': a quiet grey that turns brand on its own hover.
+// One resting grey, not the two-step the far-right gutter needed — by the time
+// a 'row' glyph is visible the row is already hovered, so there is no earlier
+// state left to distinguish.
+const ROW_GLYPH = 'size-6 rounded-md text-[#8C8C8C] hover:bg-blue-500/[0.07] hover:text-blue-500';
+
+// Reveal rules for the list-row variant. `transition-opacity` (not the base
+// `transition-colors`) so the fade is what animates.
+const ROW_REVEAL =
+    'opacity-0 transition-opacity group-hover/row:opacity-100 focus-visible:opacity-100 ' +
+    'data-[state=open]:opacity-100 [@media(hover:none)]:!opacity-100';
+
 const TRIGGER_VARIANT: Record<SaveAsVariant, string> = {
-    // Three resting states, so the action reads as available without competing
-    // with the file name (which turns brand-blue on row hover):
-    //   at rest → faint grey · row hover → grey · own hover → brand + tint.
-    // `hover:!text-blue-500` is deliberate: the row-hover and self-hover rules are
-    // both :hover-based utilities on this element, so equal specificity makes CSS
-    // source order the tiebreaker — `!` pins the winner instead of hoping.
-    rail: 'size-6 rounded-md text-[#C0C4CC] group-hover/row:text-[#8C8C8C] hover:bg-blue-500/[0.07] hover:!text-blue-500',
+    row: `${ROW_GLYPH} ${ROW_REVEAL}`,
+    inline: ROW_GLYPH,
     toolbar: 'size-7 rounded-lg text-[#8C8C8C] hover:bg-gray-100 hover:text-blue-500',
 };
 
@@ -73,7 +92,7 @@ async function readBlobError(blob: Blob): Promise<string | null> {
     return null;
 }
 
-export function SaveAsButton({ file, versionId, variant = 'rail', className }: SaveAsButtonProps) {
+export function SaveAsButton({ file, versionId, variant = 'row', className }: SaveAsButtonProps) {
     const localize = useLocalize();
     const { showToast } = useToastContext();
     const [busy, setBusy] = useState(false);

--- a/src/frontend/client/src/components/Linsight/Artifacts/WorkspaceDrawer.tsx
+++ b/src/frontend/client/src/components/Linsight/Artifacts/WorkspaceDrawer.tsx
@@ -32,17 +32,19 @@ export function WorkspaceDrawer({ open, onOpenChange, files, versionId, onPrevie
             key={file.file_id || file.file_url}
             role="button"
             tabIndex={0}
-            className="group/row flex cursor-pointer items-center gap-2.5 rounded-lg py-2.5 pl-2 pr-1.5 hover:bg-gray-50"
+            className="group/row flex cursor-pointer items-center gap-1 rounded-lg py-2.5 pl-2 pr-2 hover:bg-gray-50"
             onClick={() => onPreview(file)}
             onKeyDown={(e) => e.key === 'Enter' && onPreview(file)}
         >
             {/* eslint-disable-next-line @typescript-eslint/no-explicit-any -- FileIcon accepts more types than its union */}
-            <FileIcon type={getFileExtension(file.file_name) as any} className="size-5 min-w-5" />
-            <span className="min-w-0 flex-1 truncate text-sm text-gray-800">{file.file_name}</span>
+            <FileIcon type={getFileExtension(file.file_name) as any} className="mr-1.5 size-5 min-w-5" />
+            {/* min-w-0 without flex-1 — the action follows the NAME, not the sheet
+                edge; a 480px drawer would otherwise strand it far to the right. */}
+            <span className="min-w-0 truncate text-sm text-gray-800">{file.file_name}</span>
             <NewTabHint file={file} />
             {/* The trailing gutter used to hold a hover-only eye that just repeated
-                the row's own click. It now holds the one action the row couldn't
-                otherwise reach: keeping the file. */}
+                the row's own click. The one action the row couldn't otherwise
+                reach — keeping the file — now sits beside the name instead. */}
             <SaveAsButton file={file} versionId={versionId} />
         </div>
     );

--- a/src/frontend/client/src/components/Linsight/Artifacts/WorkspacePanel.tsx
+++ b/src/frontend/client/src/components/Linsight/Artifacts/WorkspacePanel.tsx
@@ -54,14 +54,16 @@ export function WorkspacePanel({
             key={file.file_id || file.file_url}
             role="button"
             tabIndex={0}
-            className="group/row flex cursor-pointer items-center gap-2 rounded-lg py-2 pl-1 pr-1.5 hover:bg-[#F7F7F7]"
+            className="group/row flex cursor-pointer items-center gap-1 rounded-lg py-2 pl-1 pr-2 hover:bg-[#F7F7F7]"
             onClick={() => onPreview(file)}
             onKeyDown={(e) => e.key === 'Enter' && onPreview(file)}
         >
             {/* File-type icon hidden for now; keep for an easy future re-enable. */}
             {/* eslint-disable-next-line @typescript-eslint/no-explicit-any -- FileIcon accepts more types than its union */}
             {/* <FileIcon type={getFileExtension(file.file_name) as any} className="size-5 min-w-5" /> */}
-            <span className="min-w-0 flex-1 truncate text-sm text-[#212121] group-hover/row:text-blue-500">
+            {/* min-w-0 without flex-1 so the action stays next to the NAME, not
+                pushed to the panel edge; the name truncates only when it must. */}
+            <span className="min-w-0 truncate text-sm text-[#212121] group-hover/row:text-blue-500">
                 {file.file_name}
             </span>
             <NewTabHint file={file} />

--- a/src/frontend/client/src/components/Linsight/Artifacts/markdownOutlineUtils.test.ts
+++ b/src/frontend/client/src/components/Linsight/Artifacts/markdownOutlineUtils.test.ts
@@ -3,6 +3,7 @@ import {
     collectHeadings,
     getScrollParent,
     headingsEqual,
+    isPointerNearRail,
     normalizeLevels,
     pickActiveIndex,
     scrollHeadingIntoView,
@@ -168,6 +169,43 @@ describe('headingsEqual', () => {
         expect(headingsEqual(base, render('<h1 id="a">A</h1><h2 id="b">B</h2><h2 id="c">C</h2>'))).toBe(false);
         expect(headingsEqual(base, render('<h1 id="a">A</h1><h2 id="b">B2</h2>'))).toBe(false);
         expect(headingsEqual(base, render('<h1 id="a">A</h1><h3 id="b">B</h3>'))).toBe(false);
+    });
+});
+
+describe('isPointerNearRail', () => {
+    // A rail hugging the right edge of a 700px-tall panel: 26px wide, ~200px of
+    // ticks centred vertically.
+    const rail = {
+        getBoundingClientRect: () => ({ left: 774, right: 800, top: 250, bottom: 450 }),
+    } as unknown as HTMLElement;
+
+    it('opens once the pointer is on the ticks', () => {
+        expect(isPointerNearRail(rail, 780, 350)).toBe(true);
+    });
+
+    it('allows a little approach room to the left', () => {
+        expect(isPointerNearRail(rail, 770, 350)).toBe(true); // within 6px
+        expect(isPointerNearRail(rail, 760, 350)).toBe(false);
+    });
+
+    it('stays open past the rail, where only the panel edge and scrollbar are', () => {
+        expect(isPointerNearRail(rail, 812, 350)).toBe(true);
+    });
+
+    it('ignores the right edge above and below the rail', () => {
+        // Reaching for the toolbar, or the ends of the scrollbar.
+        expect(isPointerNearRail(rail, 790, 60)).toBe(false);
+        expect(isPointerNearRail(rail, 790, 640)).toBe(false);
+    });
+
+    it('forgives vertical overshoot at either end of the rail', () => {
+        expect(isPointerNearRail(rail, 790, 235)).toBe(true); // within 20px above
+        expect(isPointerNearRail(rail, 790, 465)).toBe(true); // within 20px below
+        expect(isPointerNearRail(rail, 790, 225)).toBe(false);
+    });
+
+    it('is false before the rail exists', () => {
+        expect(isPointerNearRail(null, 790, 350)).toBe(false);
     });
 });
 

--- a/src/frontend/client/src/components/Linsight/Artifacts/markdownOutlineUtils.ts
+++ b/src/frontend/client/src/components/Linsight/Artifacts/markdownOutlineUtils.ts
@@ -156,6 +156,36 @@ export function pickActiveIndex(headings: OutlineHeading[], scroller: HTMLElemen
  *  in markdown.css, which covers the `#anchor` path). */
 const HEADING_LANDING_OFFSET = 16;
 
+/** Forgiveness around the rail's own box before the outline opens. Aiming at a
+ *  thin column is easy left-to-right and fiddly at its two ends, hence the
+ *  taller vertical allowance. */
+const RAIL_HOVER_PADDING_X = 6;
+const RAIL_HOVER_PADDING_Y = 20;
+
+/**
+ * Is the pointer on (or just beside) the rail?
+ *
+ * Derived from the rail's real geometry rather than a fixed band along the
+ * panel edge: a band wide enough to be comfortable also fires well before the
+ * pointer reaches the ticks, and one spanning the panel's full height fires
+ * when merely reaching for the toolbar or the ends of the scrollbar. Reading
+ * the box back also keeps the target honest when tick lengths change.
+ *
+ * Unbounded to the right: past the rail there is only the panel edge and the
+ * scrollbar, so there is nothing there to exclude.
+ */
+export function isPointerNearRail(rail: HTMLElement | null, x: number, y: number): boolean {
+    if (!rail) {
+        return false;
+    }
+    const box = rail.getBoundingClientRect();
+    return (
+        x >= box.left - RAIL_HOVER_PADDING_X &&
+        y >= box.top - RAIL_HOVER_PADDING_Y &&
+        y <= box.bottom + RAIL_HOVER_PADDING_Y
+    );
+}
+
 /**
  * Scroll a heading to the top of its container.
  *


### PR DESCRIPTION
PR #2263 合并时（08-07 14:01）我最后几次 push 还没到，这 4 个提交因此漏在了外面。它们是 #2263 里两个功能的后续打磨，已按当前 `hotfix/2.6.0-2` 重新 cherry-pick，零冲突。

## 四项

| 提交 | 内容 |
|---|---|
| `d4132f31e` | md 预览「章节脊」目录浮层**即时展开**，去掉开启防抖 —— 鼠标移过去要等一下才出来，手感像卡了 |
| `756dd753b` | 目录**触发区收进刻度轨自身**，不再提前开 —— 原来触发区比刻度轨宽，光标还没到就弹出来，挡正文 |
| `2d89df219` | 产物文件行的**下载按钮挪到文件名旁**，hover 才显示 —— 原来常驻在行尾，一列按钮把视线从文件名上拽走 |
| `1a6dc0d59` | `deepagents` pin 由 `>=0.6.3`（无上界）收成 `>=0.6.3,<0.7` |

## 关于那个版本上界

**不是升级** —— 下界没动，0.6.8 本来就满足新区间，`uv lock` 跑完 295 个包全部重解、锁文件只改了 specifier 一行，没有任何版本漂移。

加上界的原因是 0.7 把 `write_todos` 改成 opt-in：任务模式的进度显示完全靠它，#2263 带进来的轮次预算里 `_POST_BUDGET_ALLOWED_TOOLS` 也刻意放行它（拦掉会让做完的任务显示成 3/5）。另外轮次预算的 `_STEPS_PER_MODEL_TURN = 4` 数的是 0.6.x 图里每轮编译出的中间件节点数，节点数一变递归下限就算错。

## 验证

- 前端 jest `src/components/Linsight`：**163 passed**（这 4 个提交自带 6 条新用例）
- `check-imports` + `build` 通过
- 无后端代码改动（只有依赖 pin），故未重跑后端套件

## 与已合并的 #2265 无冲突

已核实两边**文件零重叠** —— 本 PR 只碰 `MarkdownOutline` / `markdownOutlineUtils` / `ResultSection` / `SaveAsButton` / `WorkspaceDrawer` / `WorkspacePanel` / `pyproject.toml` / `uv.lock`，#2265 碰的是 `artifactUtils` / `Markdown.tsx` / 三个 locale。

🤖 Generated with [Claude Code](https://claude.com/claude-code)