### PR TITLE
fix(points): 自动发分与月奖入账后发送站内信

### DIFF
--- a/src/backend/bisheng/points/domain/constants/notify_templates.py
+++ b/src/backend/bisheng/points/domain/constants/notify_templates.py
@@ -9,3 +9,32 @@ NOTIFY_TEMPLATES = {
     "adjust_admin": "管理员调整了你的积分 {delta}。原因：{reason}",
 }
 POINTS_CHANGED_ACTION_CODE = "points_changed"
+
+# 自动获取类规则 → 模板；月奖等未列出的 earn 回退 earn_publish。
+EARN_RULE_NOTIFY_TEMPLATE: dict[str, str] = {
+    "G1": "earn_publish",
+    "G2": "earn_publish",
+    "G3": "earn_favorite",
+    "G4": "earn_adopt",
+    "G5": "earn_publish",
+    "G6": "earn_publish",
+    "G7": "earn_share",
+}
+
+
+def resolve_earn_notify(rule_code: str, *, rule_name: str, delta: int) -> tuple[str, dict]:
+    """按规则编码解析站内信模板与渲染参数。
+
+    Args:
+        rule_code: 积分规则编码（如 G2、M1）。
+        rule_name: 规则展示名，用于 earn_publish。
+        delta: 本次实际入账分值（正数）。
+
+    Returns:
+        (template_code, format kwargs)。
+    """
+    code = (rule_code or "").strip().upper()
+    template = EARN_RULE_NOTIFY_TEMPLATE.get(code, "earn_publish")
+    if template == "earn_publish":
+        return template, {"rule_name": rule_name or code, "delta": int(delta)}
+    return template, {"delta": int(delta)}

--- a/src/backend/bisheng/points/domain/services/points_award_facade.py
+++ b/src/backend/bisheng/points/domain/services/points_award_facade.py
@@ -69,6 +69,36 @@ class AwardOutcome:
     skipped: bool = True
     reason: str | None = None
     result: LedgerResult | None = None
+    # 入账成功后供 hooks 发站内信；skip / 重放时保持空。
+    notify_user_id: int | None = None
+    rule_code: str | None = None
+    rule_name: str | None = None
+
+    @property
+    def should_notify(self) -> bool:
+        """是否应在账本 commit 后发送积分变动站内信。"""
+        if self.skipped or self.notify_user_id is None or self.result is None:
+            return False
+        if self.result.replayed or self.result.skipped_cap:
+            return False
+        return int(self.result.applied_delta) > 0
+
+    @staticmethod
+    def success(
+        *,
+        result: LedgerResult,
+        user_id: int,
+        rule_code: str,
+        rule_name: str | None,
+    ) -> AwardOutcome:
+        """构造可通知的成功入账结果。"""
+        return AwardOutcome(
+            skipped=False,
+            result=result,
+            notify_user_id=int(user_id),
+            rule_code=rule_code,
+            rule_name=rule_name or rule_code,
+        )
 
 
 class PointsAwardFacade:
@@ -167,7 +197,12 @@ class PointsAwardFacade:
         if result.skipped_cap:
             logger.info("points.award.rejected reason=daily_cap code=%s key=%s", rule_code, key)
             return AwardOutcome(skipped=True, reason="daily_cap", result=result)
-        return AwardOutcome(skipped=False, result=result)
+        return AwardOutcome.success(
+            result=result,
+            user_id=payee,
+            rule_code=rule_code,
+            rule_name=rule.name or rule_code,
+        )
 
     async def _award_document_shared(self, event: DocumentSharedEvent) -> AwardOutcome:
         rule = await self.repository.get_rule(event.tenant_id, "G7")
@@ -201,7 +236,12 @@ class PointsAwardFacade:
         )
         if result.skipped_cap:
             return AwardOutcome(skipped=True, reason="daily_cap", result=result)
-        return AwardOutcome(skipped=False, result=result)
+        return AwardOutcome.success(
+            result=result,
+            user_id=payee,
+            rule_code="G7",
+            rule_name=rule.name or "G7",
+        )
 
     async def _award_favorite_tier(self, event: FavoriteChangedEvent) -> AwardOutcome:
         rule = await self.repository.get_rule(event.tenant_id, "G3")
@@ -239,7 +279,12 @@ class PointsAwardFacade:
                 highest_tier=highest_tier,
                 points_granted_total=s_target,
             )
-        return AwardOutcome(skipped=False, result=result)
+        return AwardOutcome.success(
+            result=result,
+            user_id=payee,
+            rule_code="G3",
+            rule_name=rule.name or "G3",
+        )
 
     async def _award_answer_adopted(self, event: AnswerAdoptedEvent) -> AwardOutcome:
         rule = await self.repository.get_rule(event.tenant_id, "G4")
@@ -266,7 +311,12 @@ class PointsAwardFacade:
         )
         if result.skipped_cap:
             return AwardOutcome(skipped=True, reason="daily_cap", result=result)
-        return AwardOutcome(skipped=False, result=result)
+        return AwardOutcome.success(
+            result=result,
+            user_id=payee,
+            rule_code="G4",
+            rule_name=rule.name or "G4",
+        )
 
     async def _should_skip_payee(self, payee: int, manager_ids: frozenset[int]) -> str | None:
         """P7=B：受益人是相关库 creator/admin，或平台超管 → skip。"""

--- a/src/backend/bisheng/points/domain/services/points_award_hooks.py
+++ b/src/backend/bisheng/points/domain/services/points_award_hooks.py
@@ -14,15 +14,18 @@ from bisheng.knowledge.domain.models.knowledge_space_scope import (
     KnowledgeSpaceLevelEnum,
     KnowledgeSpaceScopeDao,
 )
+from bisheng.points.domain.constants.notify_templates import resolve_earn_notify
 from bisheng.points.domain.repositories.points_repository import PointsRepository
 from bisheng.points.domain.services.points_award_facade import (
     AnswerAdoptedEvent,
+    AwardOutcome,
     DocumentSharedEvent,
     FavoriteChangedEvent,
     PointsAwardFacade,
     SpaceFileReadyEvent,
 )
 from bisheng.points.domain.services.points_ledger_service import PointsLedgerService
+from bisheng.points.domain.services.points_notify_service import build_points_notify_service
 
 logger = logging.getLogger(__name__)
 
@@ -86,8 +89,48 @@ def _award_async_enabled() -> bool:
         return True
 
 
-async def _run_with_facade(action) -> None:
-    """打开独立积分会话执行门面并提交。"""
+def _normalize_outcomes(raw) -> list[AwardOutcome]:
+    """将 Facade action 返回值规范为 outcome 列表。"""
+    if raw is None:
+        return []
+    if isinstance(raw, AwardOutcome):
+        return [raw]
+    if isinstance(raw, list):
+        return [item for item in raw if isinstance(item, AwardOutcome)]
+    return []
+
+
+async def _flush_award_notifies(outcomes: list[AwardOutcome]) -> None:
+    """账本已提交后发送积分站内信；失败只记日志。"""
+    pending = [item for item in outcomes if item.should_notify]
+    if not pending:
+        return
+    try:
+        async with get_async_db_session() as session:
+            notify = await build_points_notify_service(session)
+            for item in pending:
+                template, values = resolve_earn_notify(
+                    item.rule_code or "",
+                    rule_name=item.rule_name or item.rule_code or "",
+                    delta=int(item.result.applied_delta) if item.result else 0,
+                )
+                await notify.notify(
+                    user_id=int(item.notify_user_id),
+                    template_code=template,
+                    **values,
+                )
+            await session.commit()
+    except Exception:
+        # 站内信旁路：不得影响已入账积分。
+        logger.exception("points.award.notify_failed count=%s", len(pending))
+
+
+async def _run_with_facade(action) -> list[AwardOutcome]:
+    """打开独立积分会话执行门面、提交，再尽力发站内信。
+
+    MessageService 仅在 commit 后的通知会话注入，避免消息依赖故障阻断入账。
+    """
+    outcomes: list[AwardOutcome] = []
     async with get_async_db_session() as session:
         repository = PointsRepository(session)
         ledger = PointsLedgerService(repository)
@@ -96,8 +139,10 @@ async def _run_with_facade(action) -> None:
             ledger,
             is_platform_super_admin=is_platform_super_admin_user,
         )
-        await action(facade)
+        outcomes = _normalize_outcomes(await action(facade))
         await session.commit()
+    await _flush_award_notifies(outcomes)
+    return outcomes
 
 
 def _resolve_award_queue() -> str:
@@ -148,61 +193,50 @@ async def _dispatch(event_type: str, payload: dict[str, Any]) -> None:
 async def _run_payload_sync(payload: dict[str, Any]) -> None:
     """与 Celery worker 相同的事件分发，供同步路径与 enqueue fallback 复用。"""
 
-    async def _award(facade: PointsAwardFacade) -> None:
+    async def _award(facade: PointsAwardFacade) -> AwardOutcome:
         event_type = str(payload.get("event_type") or "")
         if event_type == "space_file_ready":
-            await facade.on_space_file_ready(
+            return await facade.on_space_file_ready(
                 SpaceFileReadyEvent(
                     tenant_id=int(payload["tenant_id"]),
                     space_id=int(payload["space_id"]),
                     space_level=str(payload["space_level"]),
                     file_id=int(payload["file_id"]),
                     uploader_id=int(payload["uploader_id"]),
-                    publisher_id=(
-                        int(payload["publisher_id"])
-                        if payload.get("publisher_id") is not None
-                        else None
-                    ),
+                    publisher_id=(int(payload["publisher_id"]) if payload.get("publisher_id") is not None else None),
                     is_favorite_space=bool(payload.get("is_favorite_space")),
-                    space_manager_ids=frozenset(
-                        int(x) for x in (payload.get("space_manager_ids") or [])
-                    ),
+                    space_manager_ids=frozenset(int(x) for x in (payload.get("space_manager_ids") or [])),
                 )
             )
-        elif event_type == "document_shared":
-            await facade.on_document_shared(
+        if event_type == "document_shared":
+            return await facade.on_document_shared(
                 DocumentSharedEvent(
                     tenant_id=int(payload["tenant_id"]),
                     share_entry_id=int(payload["share_entry_id"]),
                     uploader_id=int(payload["uploader_id"]),
                     sharer_id=int(payload["sharer_id"]),
-                    related_manager_ids=frozenset(
-                        int(x) for x in (payload.get("related_manager_ids") or [])
-                    ),
+                    related_manager_ids=frozenset(int(x) for x in (payload.get("related_manager_ids") or [])),
                 )
             )
-        elif event_type == "favorite_changed":
-            await facade.on_favorite_changed(
+        if event_type == "favorite_changed":
+            return await facade.on_favorite_changed(
                 FavoriteChangedEvent(
                     tenant_id=int(payload["tenant_id"]),
                     file_id=int(payload["file_id"]),
                     uploader_id=int(payload["uploader_id"]),
                     unique_favoriter_count=int(payload["unique_favoriter_count"]),
-                    space_manager_ids=frozenset(
-                        int(x) for x in (payload.get("space_manager_ids") or [])
-                    ),
+                    space_manager_ids=frozenset(int(x) for x in (payload.get("space_manager_ids") or [])),
                 )
             )
-        elif event_type == "answer_adopted":
-            await facade.on_answer_adopted(
+        if event_type == "answer_adopted":
+            return await facade.on_answer_adopted(
                 AnswerAdoptedEvent(
                     tenant_id=int(payload["tenant_id"]),
                     answer_id=int(payload["answer_id"]),
                     answerer_id=int(payload["answerer_id"]),
                 )
             )
-        else:
-            raise ValueError(f"unknown points award event_type={event_type}")
+        raise ValueError(f"unknown points award event_type={event_type}")
 
     await _run_with_facade(_award)
 
@@ -231,21 +265,25 @@ async def notify_space_files_ready(
         manager_list = sorted(int(x) for x in managers)
 
         if not _award_async_enabled():
-            # 同步：同一会话批量处理，减少连接开销。
-            async def _award(facade: PointsAwardFacade) -> None:
+            # 同步：同一会话批量处理，减少连接开销；仍按文件各发一条站内信。
+            async def _award(facade: PointsAwardFacade) -> list[AwardOutcome]:
+                outs: list[AwardOutcome] = []
                 for file_id in file_ids:
-                    await facade.on_space_file_ready(
-                        SpaceFileReadyEvent(
-                            tenant_id=int(tenant_id),
-                            space_id=int(space_id),
-                            space_level=level,
-                            file_id=file_id,
-                            uploader_id=int(uploader_id),
-                            publisher_id=int(publisher_id) if publisher_id is not None else None,
-                            is_favorite_space=bool(favorite),
-                            space_manager_ids=managers,
+                    outs.append(
+                        await facade.on_space_file_ready(
+                            SpaceFileReadyEvent(
+                                tenant_id=int(tenant_id),
+                                space_id=int(space_id),
+                                space_level=level,
+                                file_id=file_id,
+                                uploader_id=int(uploader_id),
+                                publisher_id=int(publisher_id) if publisher_id is not None else None,
+                                is_favorite_space=bool(favorite),
+                                space_manager_ids=managers,
+                            )
                         )
                     )
+                return outs
 
             await _run_with_facade(_award)
             return

--- a/src/backend/bisheng/points/domain/services/points_monthly_reward_service.py
+++ b/src/backend/bisheng/points/domain/services/points_monthly_reward_service.py
@@ -8,6 +8,8 @@ from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
+from sqlmodel import select
+
 from bisheng.common.models.space_channel_member import (
     BusinessTypeEnum,
     MembershipStatusEnum,
@@ -23,11 +25,14 @@ from bisheng.points.domain.constants.monthly_reward_rules import (
     fixed_score,
     pick_highest_reward,
 )
+from bisheng.points.domain.constants.notify_templates import resolve_earn_notify
 from bisheng.points.domain.repositories.points_repository import PointsRepository
 from bisheng.points.domain.services.points_ledger_service import PointsLedgerService
-from bisheng.points.domain.services.points_notify_service import PointsNotifyService
+from bisheng.points.domain.services.points_notify_service import (
+    PointsNotifyService,
+    build_points_notify_service,
+)
 from bisheng.user.domain.models.user_role import UserRole
-from sqlmodel import select
 
 logger = logging.getLogger(__name__)
 SHANGHAI = ZoneInfo("Asia/Shanghai")
@@ -231,6 +236,7 @@ class PointsMonthlyRewardService:
         try:
             async with get_async_db_session() as session:
                 repo = PointsRepository(session)
+                # 入账会话不挂 MessageService，避免消息依赖阻断月奖。
                 ledger = PointsLedgerService(repo)
                 result = await ledger.award(
                     tenant_id=tenant_id,
@@ -247,15 +253,12 @@ class PointsMonthlyRewardService:
                 await session.commit()
             if result.replayed or result.skipped_cap:
                 return bool(result.replayed)
-            try:
-                await self.notify.notify(
-                    user_id=user_id,
-                    template_code="earn_publish",
-                    rule_name=rule_name,
-                    delta=score,
-                )
-            except Exception:
-                logger.exception("points.monthly.notify_failed user_id=%s", user_id)
+            await self._notify_earn(
+                user_id=user_id,
+                rule_code=rule_code,
+                rule_name=rule_name,
+                delta=score,
+            )
             return True
         except Exception:
             logger.exception(
@@ -265,6 +268,38 @@ class PointsMonthlyRewardService:
                 key,
             )
             return False
+
+    async def _notify_earn(
+        self,
+        *,
+        user_id: int,
+        rule_code: str,
+        rule_name: str,
+        delta: int,
+    ) -> None:
+        """账本提交后发送月奖站内信；注入 MessageService，失败不影响入账。"""
+        template, values = resolve_earn_notify(rule_code, rule_name=rule_name, delta=delta)
+        try:
+            # 已注入可用 message_service，或单测 mock：直接发；裸 PointsNotifyService() 则走工厂。
+            if self.notify is not None and (
+                not isinstance(self.notify, PointsNotifyService) or self.notify.message_service is not None
+            ):
+                await self.notify.notify(
+                    user_id=user_id,
+                    template_code=template,
+                    **values,
+                )
+                return
+            async with get_async_db_session() as session:
+                notify = await build_points_notify_service(session)
+                await notify.notify(
+                    user_id=user_id,
+                    template_code=template,
+                    **values,
+                )
+                await session.commit()
+        except Exception:
+            logger.exception("points.monthly.notify_failed user_id=%s", user_id)
 
     async def _collect_user_candidates(
         self,
@@ -331,7 +366,5 @@ class PointsMonthlyRewardService:
     async def _load_super_admin_ids() -> set[int]:
         """平台超管不获月奖（Q16）。"""
         async with get_async_db_session() as session:
-            rows = (
-                await session.exec(select(UserRole.user_id).where(UserRole.role_id == AdminRole))
-            ).all()
+            rows = (await session.exec(select(UserRole.user_id).where(UserRole.role_id == AdminRole))).all()
         return {int(r[0] if isinstance(r, tuple) else r) for r in rows}

--- a/src/backend/bisheng/points/domain/services/points_notify_service.py
+++ b/src/backend/bisheng/points/domain/services/points_notify_service.py
@@ -7,6 +7,31 @@ from bisheng.points.domain.constants.notify_templates import NOTIFY_TEMPLATES, P
 logger = logging.getLogger(__name__)
 
 
+def _notify_enabled() -> bool:
+    """读取 points.notify_enabled；缺省为 True。"""
+    try:
+        from bisheng.common.services.config_service import settings
+
+        return bool(getattr(getattr(settings, "points", None), "notify_enabled", True))
+    except Exception:
+        return True
+
+
+async def build_points_notify_service(session) -> "PointsNotifyService":
+    """在 Worker / 旁路路径构造带 MessageService 的通知服务。
+
+    Args:
+        session: 当前异步 DB 会话；站内信写入依赖该会话，调用方负责 commit。
+
+    Returns:
+        已注入 MessageService 的 PointsNotifyService。
+    """
+    from bisheng.message.api.dependencies import get_message_service
+
+    message_service = await get_message_service(session)
+    return PointsNotifyService(message_service=message_service)
+
+
 class PointsNotifyService:
     """渲染代码模板并委托消息模块发送，不影响已提交的积分账本。"""
 
@@ -14,13 +39,24 @@ class PointsNotifyService:
         self.message_service = message_service
 
     async def notify(self, *, user_id: int, template_code: str, **values) -> None:
-        """发送积分变动站内信；消息依赖故障只记录，不回滚积分。"""
+        """发送积分变动站内信；消息依赖故障只记录，不回滚积分。
+
+        Args:
+            user_id: 接收人用户 ID。
+            template_code: NOTIFY_TEMPLATES 中的键。
+            **values: 模板 format 参数（如 delta、rule_name）。
+        """
         if not self.message_service:
+            logger.warning("积分通知跳过：未注入 message_service user_id=%s", user_id)
+            return
+        if not _notify_enabled():
+            logger.info("积分通知跳过：notify_enabled=false user_id=%s", user_id)
             return
         try:
             content = NOTIFY_TEMPLATES[template_code].format(**values)
             await self.message_service.send_generic_notify(
-                sender=0, receiver_user_ids=[user_id],
+                sender=0,
+                receiver_user_ids=[user_id],
                 content_item_list=[{"type": "system_text", "content": content}],
                 action_code=POINTS_CHANGED_ACTION_CODE,
             )

--- a/src/backend/test/points/test_notify_templates.py
+++ b/src/backend/test/points/test_notify_templates.py
@@ -1,8 +1,43 @@
 """积分通知模板测试。"""
 
-from bisheng.points.domain.constants.notify_templates import NOTIFY_TEMPLATES, POINTS_CHANGED_ACTION_CODE
+from bisheng.points.domain.constants.notify_templates import (
+    NOTIFY_TEMPLATES,
+    POINTS_CHANGED_ACTION_CODE,
+    resolve_earn_notify,
+)
 
 
 def test_templates_cover_supported_business_events():
-    assert {"earn_publish", "earn_share", "earn_favorite", "earn_adopt", "deduct_admin", "adjust_admin"} <= set(NOTIFY_TEMPLATES)
+    assert {
+        "earn_publish",
+        "earn_share",
+        "earn_favorite",
+        "earn_adopt",
+        "deduct_admin",
+        "adjust_admin",
+    } <= set(NOTIFY_TEMPLATES)
     assert POINTS_CHANGED_ACTION_CODE == "points_changed"
+
+
+def test_resolve_earn_notify_maps_g_rules():
+    """G* 规则映射到对应模板；未知编码回退 earn_publish。"""
+    assert resolve_earn_notify("G2", rule_name="上传部门库文档", delta=2) == (
+        "earn_publish",
+        {"rule_name": "上传部门库文档", "delta": 2},
+    )
+    assert resolve_earn_notify("G3", rule_name="文档被收藏", delta=5) == (
+        "earn_favorite",
+        {"delta": 5},
+    )
+    assert resolve_earn_notify("G4", rule_name="回答被采纳", delta=3) == (
+        "earn_adopt",
+        {"delta": 3},
+    )
+    assert resolve_earn_notify("G7", rule_name="分享", delta=2) == (
+        "earn_share",
+        {"delta": 2},
+    )
+    assert resolve_earn_notify("M1", rule_name="公共库所有者月奖", delta=200) == (
+        "earn_publish",
+        {"rule_name": "公共库所有者月奖", "delta": 200},
+    )

--- a/src/backend/test/points/test_points_award_facade.py
+++ b/src/backend/test/points/test_points_award_facade.py
@@ -143,6 +143,9 @@ async def test_p7b_awards_when_operator_is_manager_but_payee_is_not():
     assert not outcome.skipped
     assert repo.account.balance == 3
     assert outcome.result.applied_delta == 3
+    assert outcome.should_notify
+    assert outcome.notify_user_id == 5
+    assert outcome.rule_code == "G1"
 
 
 @pytest.mark.asyncio

--- a/src/backend/test/points/test_points_award_notify.py
+++ b/src/backend/test/points/test_points_award_notify.py
@@ -1,0 +1,94 @@
+"""自动发分站内信：outcome 判定与 commit 后 flush。"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from bisheng.points.domain.services.points_award_facade import AwardOutcome
+from bisheng.points.domain.services.points_award_hooks import _flush_award_notifies
+from bisheng.points.domain.services.points_ledger_service import LedgerResult
+
+
+def test_award_outcome_should_notify_only_on_fresh_earn():
+    """仅新入账成功才发信；skip / 重放 / 日 cap 不发。"""
+    ok = AwardOutcome.success(
+        result=LedgerResult(applied_delta=2, balance=2, log_id=1),
+        user_id=4,
+        rule_code="G2",
+        rule_name="上传部门库文档",
+    )
+    assert ok.should_notify is True
+
+    replayed = AwardOutcome.success(
+        result=LedgerResult(applied_delta=2, balance=2, log_id=1, replayed=True),
+        user_id=4,
+        rule_code="G2",
+        rule_name="上传部门库文档",
+    )
+    assert replayed.should_notify is False
+
+    capped = AwardOutcome(skipped=True, reason="daily_cap", result=LedgerResult(0, 0, skipped_cap=True))
+    assert capped.should_notify is False
+
+    skipped = AwardOutcome(skipped=True, reason="rule_disabled")
+    assert skipped.should_notify is False
+
+
+@pytest.mark.asyncio
+async def test_flush_award_notifies_sends_mapped_template():
+    """commit 后按规则模板调用 notify，并提交消息会话。"""
+    outcome = AwardOutcome.success(
+        result=LedgerResult(applied_delta=2, balance=2, log_id=9),
+        user_id=4,
+        rule_code="G2",
+        rule_name="上传部门库文档",
+    )
+    notify = AsyncMock()
+    session = AsyncMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+    session.commit = AsyncMock()
+
+    with (
+        patch(
+            "bisheng.points.domain.services.points_award_hooks.get_async_db_session",
+            return_value=session,
+        ),
+        patch(
+            "bisheng.points.domain.services.points_award_hooks.build_points_notify_service",
+            AsyncMock(return_value=notify),
+        ),
+    ):
+        await _flush_award_notifies([outcome, AwardOutcome(skipped=True, reason="x")])
+
+    notify.notify.assert_awaited_once_with(
+        user_id=4,
+        template_code="earn_publish",
+        rule_name="上传部门库文档",
+        delta=2,
+    )
+    session.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_flush_award_notifies_noop_when_empty():
+    """无可通知 outcome 时不打开消息会话。"""
+    with patch("bisheng.points.domain.services.points_award_hooks.get_async_db_session") as session_factory:
+        await _flush_award_notifies([AwardOutcome(skipped=True, reason="points_disabled")])
+    session_factory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_points_notify_respects_notify_enabled_false():
+    """notify_enabled=false 时不调用 MessageService。"""
+    from bisheng.points.domain.services.points_notify_service import PointsNotifyService
+
+    message = SimpleNamespace(send_generic_notify=AsyncMock())
+    svc = PointsNotifyService(message_service=message)
+    with patch(
+        "bisheng.points.domain.services.points_notify_service._notify_enabled",
+        return_value=False,
+    ):
+        await svc.notify(user_id=1, template_code="earn_favorite", delta=5)
+    message.send_generic_notify.assert_not_awaited()

--- a/src/backend/test/points/test_points_monthly_reward.py
+++ b/src/backend/test/points/test_points_monthly_reward.py
@@ -39,6 +39,25 @@ def test_pick_highest_reward():
 
 
 @pytest.mark.asyncio
+async def test_notify_earn_uses_injected_message_service():
+    """月奖通知优先使用已注入 MessageService 的 PointsNotifyService。"""
+    from bisheng.points.domain.services.points_notify_service import PointsNotifyService
+
+    message = SimpleNamespace(send_generic_notify=AsyncMock())
+    service = PointsMonthlyRewardService(notify=PointsNotifyService(message_service=message))
+    await service._notify_earn(
+        user_id=10,
+        rule_code="M1",
+        rule_name="公共库所有者月奖",
+        delta=200,
+    )
+    message.send_generic_notify.assert_awaited_once()
+    kwargs = message.send_generic_notify.await_args.kwargs
+    assert kwargs["receiver_user_ids"] == [10]
+    assert "200" in kwargs["content_item_list"][0]["content"]
+
+
+@pytest.mark.asyncio
 async def test_run_for_tenant_skips_no_login_and_awards_highest():
     service = PointsMonthlyRewardService(
         login_users_fn=AsyncMock(return_value={10}),


### PR DESCRIPTION
## Summary
- 自动发分（收藏/发布/部门库/团队库等 G*）在账本 commit 成功后按规则模板发送 `points_changed` 站内信
- 月奖路径注入 `MessageService`，避免裸 `PointsNotifyService()` 静默不发
- 尊重 `points.notify_enabled`；幂等重放 / skip / 日 cap 不发信

## Test plan
- [x] `pytest test/points/test_notify_templates.py test/points/test_points_award_notify.py test/points/test_points_award_facade.py test/points/test_points_award_hooks.py test/points/test_points_monthly_reward.py`（32 passed）
- [ ] 联调：部门库/团队库上传入账后，受益人站内信出现对应文案
- [ ] 确认 `points_award_celery` Worker 在跑（异步发分路径）
- [ ] `notify_enabled=false` 时不发站内信


Made with [Cursor](https://cursor.com)