### PR TITLE
fix(points): 修正积分站内信展示为模板文案

### DIFF
--- a/src/backend/bisheng/points/domain/services/points_notify_service.py
+++ b/src/backend/bisheng/points/domain/services/points_notify_service.py
@@ -17,6 +17,31 @@ def _notify_enabled() -> bool:
         return True
 
 
+def build_points_notify_content(*, template_code: str, message: str, values: dict) -> list[dict]:
+    """构造与站内信约定一致的积分通知 content。
+
+    system_text 必须是 action_code（供前端 i18n/路由），完整文案放在 metadata，
+    避免被当成未知 action 回退成「给你发送了一条通知」。
+    """
+    return [
+        {
+            "type": "system_text",
+            "content": POINTS_CHANGED_ACTION_CODE,
+            "metadata": {
+                "template_code": template_code,
+                "points_message": message,
+                "data": {
+                    "points_change": {
+                        "template_code": template_code,
+                        "message": message,
+                        **{k: values[k] for k in values},
+                    }
+                },
+            },
+        }
+    ]
+
+
 async def build_points_notify_service(session) -> "PointsNotifyService":
     """在 Worker / 旁路路径构造带 MessageService 的通知服务。
 
@@ -53,11 +78,15 @@ class PointsNotifyService:
             logger.info("积分通知跳过：notify_enabled=false user_id=%s", user_id)
             return
         try:
-            content = NOTIFY_TEMPLATES[template_code].format(**values)
+            message = NOTIFY_TEMPLATES[template_code].format(**values)
             await self.message_service.send_generic_notify(
                 sender=0,
                 receiver_user_ids=[user_id],
-                content_item_list=[{"type": "system_text", "content": content}],
+                content_item_list=build_points_notify_content(
+                    template_code=template_code,
+                    message=message,
+                    values=values,
+                ),
                 action_code=POINTS_CHANGED_ACTION_CODE,
             )
         except (KeyError, ValueError, TypeError) as exc:

--- a/src/backend/test/points/test_points_award_notify.py
+++ b/src/backend/test/points/test_points_award_notify.py
@@ -92,3 +92,27 @@ async def test_points_notify_respects_notify_enabled_false():
     ):
         await svc.notify(user_id=1, template_code="earn_favorite", delta=5)
     message.send_generic_notify.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_points_notify_payload_uses_action_code_in_system_text():
+    """system_text 为 action_code，完整文案放 metadata，供前端正确渲染。"""
+    from bisheng.points.domain.services.points_notify_service import PointsNotifyService
+
+    message = SimpleNamespace(send_generic_notify=AsyncMock())
+    svc = PointsNotifyService(message_service=message)
+    with patch(
+        "bisheng.points.domain.services.points_notify_service._notify_enabled",
+        return_value=True,
+    ):
+        await svc.notify(
+            user_id=4,
+            template_code="earn_publish",
+            rule_name="上传部门库文档",
+            delta=2,
+        )
+    kwargs = message.send_generic_notify.await_args.kwargs
+    assert kwargs["action_code"] == "points_changed"
+    item = kwargs["content_item_list"][0]
+    assert item["content"] == "points_changed"
+    assert item["metadata"]["points_message"] == "你因「上传部门库文档」获得 2 积分。"

--- a/src/backend/test/points/test_points_monthly_reward.py
+++ b/src/backend/test/points/test_points_monthly_reward.py
@@ -54,7 +54,9 @@ async def test_notify_earn_uses_injected_message_service():
     message.send_generic_notify.assert_awaited_once()
     kwargs = message.send_generic_notify.await_args.kwargs
     assert kwargs["receiver_user_ids"] == [10]
-    assert "200" in kwargs["content_item_list"][0]["content"]
+    assert kwargs["action_code"] == "points_changed"
+    assert kwargs["content_item_list"][0]["content"] == "points_changed"
+    assert "200" in kwargs["content_item_list"][0]["metadata"]["points_message"]
 
 
 @pytest.mark.asyncio

--- a/src/frontend/client/src/components/NotificationsDialog.test.tsx
+++ b/src/frontend/client/src/components/NotificationsDialog.test.tsx
@@ -292,6 +292,45 @@ describe("NotificationsDialog approval jump", () => {
     openSpy.mockRestore();
   });
 
+  it("renders points_changed message from metadata without empty @ prefix", async () => {
+    jest.mocked(getMessageListApi).mockResolvedValue({
+      total: 1,
+      data: [{
+        id: 802,
+        sender: 0,
+        sender_name: "",
+        message_type: "notify",
+        action_code: "points_changed",
+        status: "approved",
+        is_read: false,
+        create_time: "2026-08-11T10:00:00Z",
+        update_time: "2026-08-11T10:00:00Z",
+        content: [
+          {
+            type: "system_text",
+            content: "points_changed",
+            metadata: {
+              points_message: "你因「上传部门库文档」获得 2 积分。",
+              data: {
+                points_change: {
+                  message: "你因「上传部门库文档」获得 2 积分。",
+                  delta: 2,
+                  rule_name: "上传部门库文档",
+                },
+              },
+            },
+          },
+        ],
+      }],
+    });
+
+    render(<NotificationsDialog open />);
+
+    expect(await screen.findByText("你因「上传部门库文档」获得 2 积分。")).toBeInTheDocument();
+    expect(screen.queryByText("@")).not.toBeInTheDocument();
+    expect(screen.queryByText(/给你发送了一条通知/)).not.toBeInTheDocument();
+  });
+
   it("renders favorite change values and navigates deletion to the favorite space", async () => {
     const openSpy = jest.spyOn(window, "open").mockImplementation(() => null);
     jest.mocked(getMessageListApi).mockResolvedValue({

--- a/src/frontend/client/src/components/NotificationsDialog.tsx
+++ b/src/frontend/client/src/components/NotificationsDialog.tsx
@@ -563,9 +563,51 @@ export function NotificationsDialog({
         return getActionCode(notification);
     };
 
+    /** 积分站内信：文案在 metadata，system_text 仅为 action_code。 */
+    const getPointsNotifyText = (notification: MessageItem): string => {
+        const parts = Array.isArray(notification.content) ? notification.content : [];
+        for (const part of parts as any[]) {
+            const meta = part?.metadata ?? {};
+            const fromMeta =
+                meta?.points_message ??
+                meta?.data?.points_change?.message;
+            if (typeof fromMeta === "string" && fromMeta.trim()) {
+                return fromMeta.trim();
+            }
+        }
+        // 兼容首版错误 payload：把完整中文塞进了 system_text
+        const systemText = parts.find((c: any) => c?.type === "system_text")?.content;
+        if (
+            typeof systemText === "string" &&
+            systemText.trim() &&
+            systemText.trim() !== "points_changed" &&
+            /积分|分/.test(systemText)
+        ) {
+            return systemText.trim();
+        }
+        return "";
+    };
+
+    const isPointsChangedNotification = (notification: MessageItem): boolean => {
+        return (
+            notification.action_code === "points_changed" ||
+            getSystemTextCode(notification) === "points_changed"
+        );
+    };
+
     const getNotificationText = (notification: MessageItem) => {
         const targetName = getTargetName(notification);
         const actionCode = getSystemTextCode(notification);
+        // 积分消息优先展示后端模板文案，避免回退成「给你发送了一条通知」
+        if (
+            notification.action_code === "points_changed" ||
+            actionCode === "points_changed"
+        ) {
+            const pointsText = getPointsNotifyText(notification);
+            if (pointsText) {
+                return { text: pointsText, targetName: "", showApproval: false };
+            }
+        }
         const actionTextKey = NOTIFICATION_ACTION_TEXT_KEYS[actionCode] || (actionCode ? `com_notifications_action_${actionCode}` : "");
         const fallbackText = notification.content?.map((c) => c.content).filter(Boolean).join("") || "";
         const businessUrlPart = notification.content?.find((c: any) => c?.type === "business_url") as any;
@@ -1005,7 +1047,10 @@ export function NotificationsDialog({
 
                     {/* Message text */}
                     <div className={cn("flex min-w-0 flex-1 gap-1 text-[14px]", isTouchMobile ? "flex-col" : "flex-row flex-wrap items-center gap-1", textColor)}>
-                        <span className="shrink-0 font-medium hover:text-[#165dff]">@{userName}</span>
+                        {/* 系统积分通知无发送人：不展示空的 @ */}
+                        {userName && !isPointsChangedNotification(notification) ? (
+                            <span className="shrink-0 font-medium hover:text-[#165dff]">@{userName}</span>
+                        ) : null}
                         <span className="min-w-0">
                             {!targetSplitMatch && canNavigateTarget && (
                                 <span

--- a/src/frontend/client/src/locales/en/translation.json
+++ b/src/frontend/client/src/locales/en/translation.json
@@ -402,6 +402,7 @@
   "com_notifications_action_request_knowledge_space": "Requested to join your knowledge space — {{target}}",
   "com_notifications_action_generic": "Sent you a notification",
   "com_notifications_action_generic_with_target": "Sent you a notification — {{target}}",
+  "com_notifications_action_points_changed": "{{message}}",
   "com_notifications_action_request_menu_access": "Requested access to menu「{{target}}」",
   "com_notifications_action_approval_task_pending": "Please review the approval request for「{{target}}」",
   "com_notifications_action_approval_task_rejected": "Rejected your approval request for「{{target}}」",

--- a/src/frontend/client/src/locales/ja/translation.json
+++ b/src/frontend/client/src/locales/ja/translation.json
@@ -387,6 +387,7 @@
   "com_notifications_action_request_knowledge_space": "あなたのナレッジスペースへの参加を申請しました — {{target}}",
   "com_notifications_action_generic": "通知を送信しました",
   "com_notifications_action_generic_with_target": "通知を送信しました — {{target}}",
+  "com_notifications_action_points_changed": "{{message}}",
   "com_notifications_action_request_menu_access": "メニュー「{{target}}」へのアクセスを申請しました",
   "com_notifications_action_approval_task_pending": "「{{target}}」の審査申請を確認してください",
   "com_notifications_action_approval_task_rejected": "「{{target}}」の審査申請を却下しました",

--- a/src/frontend/client/src/locales/zh-Hans/translation.json
+++ b/src/frontend/client/src/locales/zh-Hans/translation.json
@@ -390,6 +390,7 @@
   "com_notifications_action_request_knowledge_space": "申请加入你{{target}}的知识空间",
   "com_notifications_action_generic": "给你发送了一条通知",
   "com_notifications_action_generic_with_target": "给你发送了一条通知",
+  "com_notifications_action_points_changed": "{{message}}",
   "com_notifications_action_request_menu_access": "申请访问菜单「{{target}}」",
   "com_notifications_action_approval_task_pending": "请审批「{{target}}」的申请",
   "com_notifications_action_approval_task_rejected": "拒绝了你「{{target}}」的审批申请",


### PR DESCRIPTION
## Summary
- 对齐站内信约定：`system_text` 使用 `points_changed`，完整文案放入 `metadata.points_message`
- Client 优先渲染积分模板文案，避免回退成「给你发送了一条通知」
- 系统积分通知无发送人时不展示空的 `@`
- 兼容首版错误 payload（中文误写入 `system_text`）

## Test plan
- [x] 后端：`pytest test/points/test_points_award_notify.py` 等
- [x] Client：`NotificationsDialog.test.tsx`（含 points_changed 用例）
- [ ] 联调：上传入库后站内信显示「你因「…」获得 N 积分。」且无空 `@`


Made with [Cursor](https://cursor.com)