### PR TITLE
fix(points): G4 同题同回答者只发一次采纳分

### DIFF
--- a/src/backend/bisheng/points/domain/services/points_award_facade.py
+++ b/src/backend/bisheng/points/domain/services/points_award_facade.py
@@ -55,9 +55,13 @@ class FavoriteChangedEvent:
 
 @dataclass(frozen=True)
 class AnswerAdoptedEvent:
-    """问答答案被采纳后的 G4 发分上下文。"""
+    """问答答案被采纳后的 G4 发分上下文。
+
+    同题同回答者只发一次（幂等键含 question_id + answerer_id）。
+    """
 
     tenant_id: int
+    question_id: int
     answer_id: int
     answerer_id: int
 
@@ -296,7 +300,8 @@ class PointsAwardFacade:
         score = _fixed_score(rule.score_expr)
         if score <= 0:
             return AwardOutcome(skipped=True, reason="invalid_score")
-        key = f"earn:G4:{event.answer_id}"
+        # 同题同回答者只入账一次；同题他人采纳仍各自计分。
+        key = f"earn:G4:{event.question_id}:{payee}"
         result = await self.ledger.award(
             tenant_id=event.tenant_id,
             user_id=payee,
@@ -305,12 +310,14 @@ class PointsAwardFacade:
             rule_code="G4",
             idempotency_key=key,
             daily_cap=rule.daily_cap,
-            biz_type="answer",
-            biz_id=str(event.answer_id),
+            biz_type="question",
+            biz_id=str(event.question_id),
             beneficiary_role="answerer",
         )
         if result.skipped_cap:
             return AwardOutcome(skipped=True, reason="daily_cap", result=result)
+        if result.replayed:
+            return AwardOutcome(skipped=True, reason="already_awarded_for_question", result=result)
         return AwardOutcome.success(
             result=result,
             user_id=payee,

--- a/src/backend/bisheng/points/domain/services/points_award_hooks.py
+++ b/src/backend/bisheng/points/domain/services/points_award_hooks.py
@@ -232,6 +232,7 @@ async def _run_payload_sync(payload: dict[str, Any]) -> None:
             return await facade.on_answer_adopted(
                 AnswerAdoptedEvent(
                     tenant_id=int(payload["tenant_id"]),
+                    question_id=int(payload["question_id"]),
                     answer_id=int(payload["answer_id"]),
                     answerer_id=int(payload["answerer_id"]),
                 )
@@ -349,24 +350,27 @@ async def notify_favorite_changed(
 async def notify_answer_adopted(
     *,
     tenant_id: int,
+    question_id: int,
     answer_id: int,
     answerer_id: int,
 ) -> None:
-    """问答采纳成功后触发 G4。"""
+    """问答采纳成功后触发 G4（同题同回答者幂等一次）。"""
     try:
-        if not answer_id or not answerer_id:
+        if not question_id or not answer_id or not answerer_id:
             return
         await _dispatch(
             "answer_adopted",
             {
                 "tenant_id": int(tenant_id),
+                "question_id": int(question_id),
                 "answer_id": int(answer_id),
                 "answerer_id": int(answerer_id),
             },
         )
     except Exception:
         logger.exception(
-            "points.award.hooks answer_adopted_failed answer_id=%s",
+            "points.award.hooks answer_adopted_failed question_id=%s answer_id=%s",
+            question_id,
             answer_id,
         )
 

--- a/src/backend/bisheng/qa_expert/domain/services.py
+++ b/src/backend/bisheng/qa_expert/domain/services.py
@@ -467,7 +467,7 @@ class QuestionService:
         return question
 
     async def adopt_answer(self, question_id: int, answer_id: int, operator_id: int) -> Question:
-        """采纳最佳回答：同题最多 3 条；已采纳幂等；G4 仍按 answer_id。"""
+        """采纳最佳回答：同题最多 3 条；已采纳幂等；G4 按同题同回答者只发一次。"""
         question = await self.repository.get_by_id(question_id)
         if not question:
             raise QuestionNotFoundError()
@@ -522,6 +522,7 @@ class QuestionService:
             if answerer_id:
                 await notify_answer_adopted(
                     tenant_id=int(get_current_tenant_id() or DEFAULT_TENANT_ID),
+                    question_id=int(question_id),
                     answer_id=int(answer_id),
                     answerer_id=answerer_id,
                 )

--- a/src/backend/test/points/perf_award_async.py
+++ b/src/backend/test/points/perf_award_async.py
@@ -293,7 +293,8 @@ async def _award_adopt(
 ) -> Sample:
     from bisheng.points.domain.services.points_award_hooks import notify_answer_adopted
 
-    idem = f"earn:G4:{answer_id}"
+    # 压测用 answer_id 充当 question_id，保证幂等键唯一。
+    idem = f"earn:G4:{answer_id}:{user_id}"
     ctx = (
         patch(
             "bisheng.points.domain.services.points_award_hooks._award_async_enabled",
@@ -307,6 +308,7 @@ async def _award_adopt(
         with ctx:
             await notify_answer_adopted(
                 tenant_id=TENANT_ID,
+                question_id=answer_id,
                 answer_id=answer_id,
                 answerer_id=user_id,
             )
@@ -424,6 +426,7 @@ async def run_scenario(
                 {
                     "event_type": "answer_adopted",
                     "tenant_id": TENANT_ID,
+                    "question_id": 1,
                     "answer_id": 1,
                     "answerer_id": USER_GZX01,
                 }

--- a/src/backend/test/points/test_points_award_facade.py
+++ b/src/backend/test/points/test_points_award_facade.py
@@ -272,8 +272,29 @@ async def test_g3_tier_differential_and_lifetime_cap():
 async def test_g4_answer_adopted():
     repo = FakeAwardRepository({"G4": _rule("G4", beneficiary="answerer", score=3)})
     outcome = await _facade(repo).on_answer_adopted(
-        AnswerAdoptedEvent(tenant_id=1, answer_id=55, answerer_id=6)
+        AnswerAdoptedEvent(tenant_id=1, question_id=100, answer_id=55, answerer_id=6)
     )
     assert not outcome.skipped
-    assert "earn:G4:55" in repo.logs
+    assert "earn:G4:100:6" in repo.logs
     assert repo.account.balance == 3
+
+
+@pytest.mark.asyncio
+async def test_g4_same_answerer_once_per_question():
+    """同题同人多条回答被采纳，G4 只入账一次。"""
+    repo = FakeAwardRepository({"G4": _rule("G4", beneficiary="answerer", score=3)})
+    facade = _facade(repo)
+    first = await facade.on_answer_adopted(
+        AnswerAdoptedEvent(tenant_id=1, question_id=100, answer_id=55, answerer_id=6)
+    )
+    second = await facade.on_answer_adopted(
+        AnswerAdoptedEvent(tenant_id=1, question_id=100, answer_id=56, answerer_id=6)
+    )
+    other = await facade.on_answer_adopted(
+        AnswerAdoptedEvent(tenant_id=1, question_id=100, answer_id=57, answerer_id=7)
+    )
+    assert not first.skipped
+    assert second.skipped and second.reason == "already_awarded_for_question"
+    assert not other.skipped
+    assert repo.account.balance == 6
+    assert set(repo.logs) == {"earn:G4:100:6", "earn:G4:100:7"}

--- a/src/backend/test/points/test_points_award_hooks.py
+++ b/src/backend/test/points/test_points_award_hooks.py
@@ -70,10 +70,11 @@ async def test_dispatch_falls_back_to_sync_when_enqueue_fails():
     ):
         await hooks._dispatch(
             "answer_adopted",
-            {"tenant_id": 1, "answer_id": 2, "answerer_id": 4},
+            {"tenant_id": 1, "question_id": 9, "answer_id": 2, "answerer_id": 4},
         )
     sync.assert_awaited_once()
     assert sync.await_args.args[0]["event_type"] == "answer_adopted"
+    assert sync.await_args.args[0]["question_id"] == 9
 
 
 def test_resolve_award_queue_defaults_to_points_award_celery(monkeypatch):


### PR DESCRIPTION
## Summary
- G4 幂等键由 `earn:G4:{answer_id}` 改为 `earn:G4:{question_id}:{answerer_id}`
- 同题同一回答者多条回答被采纳时只入账一次；同题不同回答者仍各自计分
- 采纳旁路事件补充 `question_id`

## Test plan
- [x] `pytest test/points/test_points_award_facade.py::test_g4_answer_adopted test/points/test_points_award_facade.py::test_g4_same_answerer_once_per_question test/points/test_points_award_hooks.py test/qa_expert/test_adopt_answer_limit.py`
- [ ] 联调：同一专家在同一题下 2 条回答均被采纳，积分流水仅 1 条 G4


Made with [Cursor](https://cursor.com)