### PR TITLE
fix(platform): 补全部门设置页缺失的 Input 导入

### DIFF
--- a/src/frontend/platform/src/pages/DepartmentPage/components/DepartmentSettings.tsx
+++ b/src/frontend/platform/src/pages/DepartmentPage/components/DepartmentSettings.tsx
@@ -1,6 +1,7 @@
 import { bsConfirm } from "@/components/bs-ui/alertDialog/useConfirm"
 import { Button } from "@/components/bs-ui/button"
 import { Checkbox } from "@/components/bs-ui/checkBox"
+import { Input } from "@/components/bs-ui/input"
 import { Label } from "@/components/bs-ui/label"
 import MultiSelect from "@/components/bs-ui/select/multi"
 import { Separator } from "@/components/bs-ui/separator"


### PR DESCRIPTION
## Summary
- 部门级组织打开「部门设置」时会渲染只读组织层级 `<Input>`，但 `DepartmentSettings.tsx` 漏了 import，触发 `ReferenceError: Input is not defined` 白屏。
- 补上 `@/components/bs-ui/input` 的 `Input` 导入以修复。

## Test plan
- [ ] Platform 打开系统组织页，选中公司下的部门级组织，点击「部门设置」，页面正常打开且无控制台 `Input is not defined`
- [ ] 公司级组织设置仍可编辑组织层级（Select）
- [ ] `cd src/frontend/platform && npm test -- --run src/test/departmentSettingsPayload.test.tsx`


Made with [Cursor](https://cursor.com)