### PR TITLE
fix: verify batch 2026-08-12 (IK8BNE points admin user detail)

### DIFF
--- a/src/backend/bisheng/points/api/endpoints/admin.py
+++ b/src/backend/bisheng/points/api/endpoints/admin.py
@@ -44,9 +44,7 @@ async def list_rules(
 ):
     """列出当前租户的规则。"""
     try:
-        rows = await service.list_rules(
-            resolve_tenant_id(login_user), login_user, rule_type=rule_type, status=status
-        )
+        rows = await service.list_rules(resolve_tenant_id(login_user), login_user, rule_type=rule_type, status=status)
         return resp_200([r.model_dump() for r in rows])
     except BaseErrorCode as exc:
         return exc.return_resp_instance()
@@ -156,6 +154,47 @@ async def list_users(
         return resp_200(data.model_dump())
     except BaseErrorCode as exc:
         return exc.return_resp_instance()
+
+
+@router.get("/admin/users/{user_id}/detail")
+async def get_user_detail(
+    user_id: int,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    from_date: str | None = Query(None, description="流水起始日 YYYY-MM-DD，含当日"),
+    to_date: str | None = Query(None, description="流水结束日 YYYY-MM-DD，含当日"),
+    login_user: UserPayload = Depends(UserPayload.get_login_user),
+    service: PointsQueryService = Depends(get_points_query_service),
+):
+    """用户积分详情：概况卡片 + 指定时间范围内的全量流水。"""
+    from datetime import datetime, timedelta
+
+    def _day_start(value: str | None) -> datetime | None:
+        if not value:
+            return None
+        return datetime.strptime(value, "%Y-%m-%d")
+
+    def _day_end_exclusive(value: str | None) -> datetime | None:
+        start = _day_start(value)
+        return start + timedelta(days=1) if start else None
+
+    try:
+        data = await service.admin_user_detail(
+            resolve_tenant_id(login_user),
+            login_user,
+            user_id,
+            page=page,
+            page_size=page_size,
+            from_time=_day_start(from_date),
+            to_time=_day_end_exclusive(to_date),
+        )
+        return resp_200(data.model_dump())
+    except BaseErrorCode as exc:
+        return exc.return_resp_instance()
+    except ValueError:
+        from bisheng.common.errcode.points import PointsInvalidAdjustError
+
+        return PointsInvalidAdjustError.return_resp(msg="日期格式须为 YYYY-MM-DD")
 
 
 @router.get("/admin/audit-logs")

--- a/src/backend/bisheng/points/domain/schemas/points_schema.py
+++ b/src/backend/bisheng/points/domain/schemas/points_schema.py
@@ -95,6 +95,20 @@ class PointAdminUserItem(BaseModel):
     month_score: int = 0
 
 
+class PointAdminUserDetail(BaseModel):
+    """管理端用户积分详情（弹窗：概况 + 时间范围内流水）。"""
+
+    user_id: int
+    user_name: str = ""
+    dept_name: str = "—"
+    role_label: str = "普通用户"
+    balance: int = 0
+    month_earned: int = 0
+    month_deducted: int = 0
+    logs: list[PointLogResponse] = Field(default_factory=list)
+    logs_total: int = 0
+
+
 class PointAuditLogItem(BaseModel):
     """管理端操作/审计流水行。"""
 

--- a/src/backend/bisheng/points/domain/services/points_query_service.py
+++ b/src/backend/bisheng/points/domain/services/points_query_service.py
@@ -12,6 +12,7 @@ from bisheng.common.errcode.points import PointsInvalidAdjustError, PointsRuleNo
 from bisheng.common.schemas.api import PageData
 from bisheng.points.domain.schemas.points_schema import (
     PointAdjustRequest,
+    PointAdminUserDetail,
     PointAdminUserItem,
     PointAuditLogItem,
     PointDeductRequest,
@@ -155,9 +156,7 @@ class PointsQueryService:
         )
         return [self._log_response(r) for r in rows], total
 
-    async def leaderboard(
-        self, tenant_id: int, period: str, user_id: int
-    ) -> PointLeaderboardResponse:
+    async def leaderboard(self, tenant_id: int, period: str, user_id: int) -> PointLeaderboardResponse:
         """读取当前用户所属公司的小时快照 TOP10；无公司则空榜（AC-15）。"""
         now = datetime.now(SHANGHAI)
         if period == "year":
@@ -171,9 +170,7 @@ class PointsQueryService:
         refreshed = await self.repository.latest_rank_refreshed_at(tenant_id, period, period_key)
         if company_id is None:
             return PointLeaderboardResponse(period=period, refreshed_at=refreshed, items=[])
-        rows = await self.repository.list_top_ranks(
-            tenant_id, period, "global", company_id, period_key, limit=10
-        )
+        rows = await self.repository.list_top_ranks(tenant_id, period, "global", company_id, period_key, limit=10)
         user_ids = [int(r.user_id) for r in rows]
         name_by_user, dept_by_user = await self._leaderboard_display_maps(user_ids)
         items = [
@@ -200,13 +197,9 @@ class PointsQueryService:
         from bisheng.user.domain.models.user import UserDao
 
         users = await UserDao.aget_user_by_ids(user_ids) or []
-        name_by_user = {
-            int(u.user_id): str(getattr(u, "user_name", None) or u.user_id) for u in users
-        }
+        name_by_user = {int(u.user_id): str(getattr(u, "user_name", None) or u.user_id) for u in users}
         primary_map = UserDepartmentDao.get_primary_department_map_by_user_ids(user_ids)
-        dept_by_user = {
-            uid: str(dept.name) for uid, dept in primary_map.items() if getattr(dept, "name", None)
-        }
+        dept_by_user = {uid: str(dept.name) for uid, dept in primary_map.items() if getattr(dept, "name", None)}
         return name_by_user, dept_by_user
 
     async def overview(self, tenant_id: int, user: UserPayload) -> PointOverviewResponse:
@@ -284,9 +277,7 @@ class PointsQueryService:
         name_by_user, dept_by_user = await self._leaderboard_display_maps(ids)
         start, end = self._month_bounds()
         # 只聚合当页用户；此前是对全租户整月流水做 GROUP BY 后再取子集。
-        month_scores = await self.repository.sum_deltas_by_users(
-            tenant_id, ids, start=start, end=end
-        )
+        month_scores = await self.repository.sum_deltas_by_users(tenant_id, ids, start=start, end=end)
         data = [
             PointAdminUserItem(
                 user_id=int(a.user_id),
@@ -298,6 +289,73 @@ class PointsQueryService:
             for a in accounts
         ]
         return PageData(data=data, total=total)
+
+    async def admin_user_detail(
+        self,
+        tenant_id: int,
+        user: UserPayload,
+        target_user_id: int,
+        *,
+        page: int = 1,
+        page_size: int = 20,
+        from_time: datetime | None = None,
+        to_time: datetime | None = None,
+    ) -> PointAdminUserDetail:
+        """管理端用户积分详情：身份概况 + 本月收支卡片 + 时间范围内全量流水。"""
+        require_platform_admin(user)
+        uid = int(target_user_id)
+        page = max(int(page), 1)
+        page_size = min(max(int(page_size), 1), 100)
+
+        account = await self.repository.find_account(tenant_id, uid)
+        name_by_user, dept_by_user = await self._leaderboard_display_maps([uid])
+        month_start, month_end = self._month_bounds()
+        month_earned = await self.repository.sum_user_delta(
+            tenant_id, uid, direction="earn", start=month_start, end=month_end
+        )
+        month_deducted = abs(
+            await self.repository.sum_user_delta(tenant_id, uid, direction="deduct", start=month_start, end=month_end)
+        )
+        role_label = await self._resolve_user_role_label(uid)
+
+        logs, logs_total = await self.my_logs(
+            tenant_id,
+            uid,
+            page=page,
+            page_size=page_size,
+            from_time=from_time,
+            to_time=to_time,
+        )
+        return PointAdminUserDetail(
+            user_id=uid,
+            user_name=name_by_user.get(uid, str(uid)),
+            dept_name=dept_by_user.get(uid, "—"),
+            role_label=role_label,
+            balance=int(account.balance) if account else 0,
+            month_earned=int(month_earned or 0),
+            month_deducted=int(month_deducted or 0),
+            logs=logs,
+            logs_total=int(logs_total),
+        )
+
+    @staticmethod
+    async def _resolve_user_role_label(user_id: int) -> str:
+        """解析用户角色展示名；无角色时默认「普通用户」。"""
+        try:
+            from bisheng.database.models.role import RoleDao
+            from bisheng.user.domain.models.user_role import UserRoleDao
+
+            links = await UserRoleDao.aget_user_roles(int(user_id))
+            role_ids = [int(r.role_id) for r in (links or []) if getattr(r, "role_id", None) is not None]
+            if not role_ids:
+                return "普通用户"
+            roles = await RoleDao.aget_role_by_ids(role_ids)
+            names = [str(r.role_name).strip() for r in (roles or []) if getattr(r, "role_name", None)]
+            names = [n for n in names if n]
+            return "、".join(names) if names else "普通用户"
+        except Exception:
+            logger.exception("points.admin_user_detail resolve role failed user_id=%s", user_id)
+            return "普通用户"
 
     async def admin_list_audit_logs(
         self,
@@ -340,9 +398,7 @@ class PointsQueryService:
         ]
         return PageData(data=data, total=total)
 
-    async def admin_adjust(
-        self, tenant_id: int, user: UserPayload, body: PointAdjustRequest
-    ) -> PointLogResponse:
+    async def admin_adjust(self, tenant_id: int, user: UserPayload, body: PointAdjustRequest) -> PointLogResponse:
         """平台超管手动调分；提交后再发站内信。"""
         require_platform_admin(user)
         result = await self.ledger.adjust(
@@ -367,9 +423,7 @@ class PointsQueryService:
         )
         return self._log_response(log)
 
-    async def admin_deduct(
-        self, tenant_id: int, user: UserPayload, body: PointDeductRequest
-    ) -> PointLogResponse:
+    async def admin_deduct(self, tenant_id: int, user: UserPayload, body: PointDeductRequest) -> PointLogResponse:
         """平台超管按 R* 规则扣减。"""
         require_platform_admin(user)
         rule = await self.repository.get_rule(tenant_id, body.rule_code.strip().upper())
@@ -384,9 +438,7 @@ class PointsQueryService:
             delta=-score,
             rule_code=rule.rule_code,
             title=rule.name,
-            idempotency_key=(
-                f"deduct:{rule.rule_code}:{user.user_id}:{body.user_id}:{uuid.uuid4().hex}"
-            ),
+            idempotency_key=(f"deduct:{rule.rule_code}:{user.user_id}:{body.user_id}:{uuid.uuid4().hex}"),
             operator_id=int(user.user_id),
             remark=body.remark,
             biz_type=body.biz_type,

--- a/src/backend/test/points/test_points_admin_lists.py
+++ b/src/backend/test/points/test_points_admin_lists.py
@@ -11,9 +11,7 @@ from bisheng.points.domain.services.points_query_service import PointsQueryServi
 @pytest.mark.asyncio
 async def test_admin_list_users_enriches_name_and_dept():
     repo = SimpleNamespace(
-        list_accounts_page=AsyncMock(
-            return_value=([SimpleNamespace(user_id=4, balance=28)], 1)
-        ),
+        list_accounts_page=AsyncMock(return_value=([SimpleNamespace(user_id=4, balance=28)], 1)),
         sum_deltas_by_users=AsyncMock(return_value={4: 12}),
     )
     service = PointsQueryService(session=None, repository=repo, ledger=None)
@@ -63,12 +61,69 @@ async def test_admin_list_audit_logs_filters_manual_sources():
         "_leaderboard_display_maps",
         AsyncMock(return_value=({4: "gzx01"}, {})),
     ):
-        out = await service.admin_list_audit_logs(
-            1, SimpleNamespace(is_admin=lambda: True, is_global_super=True)
-        )
+        out = await service.admin_list_audit_logs(1, SimpleNamespace(is_admin=lambda: True, is_global_super=True))
     assert out.total == 1
     assert out.data[0].source == "manual_adjust"
     assert out.data[0].user_name == "gzx01"
     repo.list_audit_logs.assert_awaited()
     kwargs = repo.list_audit_logs.await_args.kwargs
     assert kwargs["sources"] == ["manual_adjust", "manual_deduct"]
+
+
+@pytest.mark.asyncio
+async def test_admin_user_detail_returns_summary_and_filtered_logs():
+    """管理端用户详情：概况卡片 + 时间窗全量流水。"""
+    from datetime import datetime
+
+    log_row = SimpleNamespace(
+        id=3,
+        title="发布文档到部门库",
+        delta=2,
+        balance_after=1280,
+        direction="earn",
+        rule_code="E01",
+        source="rule",
+        remark=None,
+        occurred_at=datetime(2024, 1, 15, 10, 30, 1),
+    )
+    repo = SimpleNamespace(
+        find_account=AsyncMock(return_value=SimpleNamespace(balance=1280)),
+        sum_user_delta=AsyncMock(side_effect=[215, -0]),
+        list_logs=AsyncMock(return_value=([log_row], 1)),
+    )
+    service = PointsQueryService(session=None, repository=repo, ledger=None)
+    admin = SimpleNamespace(is_admin=lambda: True, is_global_super=True)
+    with (
+        patch.object(
+            PointsQueryService,
+            "_leaderboard_display_maps",
+            AsyncMock(return_value=({7: "张三"}, {7: "技术研发部"})),
+        ),
+        patch.object(
+            PointsQueryService,
+            "_resolve_user_role_label",
+            AsyncMock(return_value="普通用户"),
+        ),
+    ):
+        out = await service.admin_user_detail(
+            1,
+            admin,
+            7,
+            page=1,
+            page_size=20,
+            from_time=datetime(2024, 1, 1),
+            to_time=datetime(2024, 2, 1),
+        )
+
+    assert out.user_name == "张三"
+    assert out.dept_name == "技术研发部"
+    assert out.role_label == "普通用户"
+    assert out.balance == 1280
+    assert out.month_earned == 215
+    assert out.month_deducted == 0
+    assert out.logs_total == 1
+    assert out.logs[0].title == "发布文档到部门库"
+    assert out.logs[0].delta == 2
+    repo.list_logs.assert_awaited()
+    assert repo.list_logs.await_args.args[1] == 7
+    assert repo.sum_user_delta.await_count == 2


### PR DESCRIPTION
## Summary
- Combined verify-batch for this round's BiSheng fixes
- IK8BNE: admin user points detail API (`GET /api/v1/points/admin/users/{user_id}/detail`) with time-range filtered ledger + month summary cards

## Test plan
- [ ] Restart verify stack with portal `verify/2026-08-12-batch` + this BiSheng verify worktree
- [ ] Admin → 积分管理 → 用户积分列表 → 查看详情
- [ ] Confirm modal title「详情」, cards, table columns, default「近一个月」
- [ ] Switch 近七天 / 自定义时间 and confirm logs refresh
- [ ] Confirm modal is wide enough (identity row / cards not cramped)


Made with [Cursor](https://cursor.com)