### PR TITLE
fix(points): 修复新增/编辑规则保存 500

### DIFF
--- a/src/backend/bisheng/points/domain/services/points_rule_service.py
+++ b/src/backend/bisheng/points/domain/services/points_rule_service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from sqlalchemy.orm.attributes import flag_modified
+
 from bisheng.common.dependencies.user_deps import UserPayload
 from bisheng.common.errcode.points import PointsRuleConflictError, PointsRuleNotFoundError
 from bisheng.points.domain.constants.beneficiary import allowed_beneficiaries


### PR DESCRIPTION
## Summary
- 补全 `points_rule_service.update_rule` 中 `flag_modified` 的 SQLAlchemy 导入。
- 修复保存规则（含新增启用 G5–G7 等）时后端 `NameError` → HTTP 500，门户显示「服务暂时不可用，请稍后重试」。

## Test plan
- [x] `pytest src/backend/test/points/test_optional_fixed_score_rules.py`
- [ ] 门户积分管理：新增规则 → 填分值/日上限 → 保存成功


Made with [Cursor](https://cursor.com)