### PR TITLE
feat(points): 临时刷榜/月奖 HTTP 接口与管理端规则校验

### DIFF
--- a/src/backend/bisheng/points/api/endpoints/admin.py
+++ b/src/backend/bisheng/points/api/endpoints/admin.py
@@ -14,8 +14,10 @@ from bisheng.points.domain.schemas.points_schema import (
     PointAdjustRequest,
     PointCopiesUpdateRequest,
     PointDeductRequest,
+    PointMonthlyRewardJobRequest,
     PointRuleRequest,
 )
+from bisheng.points.domain.services.points_admin_jobs_service import PointsAdminJobsService
 from bisheng.points.domain.services.points_query_service import PointsQueryService
 from bisheng.points.domain.services.points_rule_service import PointsRuleService
 
@@ -212,6 +214,35 @@ async def get_user_detail(
         from bisheng.common.errcode.points import PointsInvalidAdjustError
 
         return PointsInvalidAdjustError.return_resp(msg="日期格式须为 YYYY-MM-DD")
+
+
+@router.post("/admin/jobs/refresh-rank-snapshots")
+async def trigger_refresh_rank_snapshots(
+    tenant_id: int = Query(1, ge=1, description="目标租户 ID，默认 1"),
+):
+    """【临时·无鉴权】手动刷新积分榜快照（月/年/总）；Beat 任务逻辑不变，用完即删。"""
+    try:
+        data = await PointsAdminJobsService().refresh_rank_snapshots_for_tenant(tenant_id)
+        return resp_200(data)
+    except BaseErrorCode as exc:
+        return exc.return_resp_instance()
+
+
+@router.post("/admin/jobs/run-monthly-rewards")
+async def trigger_run_monthly_rewards(
+    body: PointMonthlyRewardJobRequest | None = None,
+    tenant_id: int = Query(1, ge=1, description="目标租户 ID，默认 1"),
+):
+    """【临时·无鉴权】手动结算管理员月奖；Beat 任务逻辑不变，用完即删。"""
+    try:
+        period_key = body.period_key if body else None
+        data = await PointsAdminJobsService().run_monthly_rewards_for_tenant(
+            tenant_id,
+            period_key=period_key,
+        )
+        return resp_200(data)
+    except BaseErrorCode as exc:
+        return exc.return_resp_instance()
 
 
 @router.get("/admin/audit-logs")

--- a/src/backend/bisheng/points/domain/constants/optional_fixed_score_rules.py
+++ b/src/backend/bisheng/points/domain/constants/optional_fixed_score_rules.py
@@ -1,8 +1,9 @@
-"""G5–G7 / M2/M3/M5/M7/M8：初始禁用且库内可为空；列表展示 —，启用/新增时须填分值与日上限。"""
+"""G5–G7 / M2/M3/M5/M7/M8：初始禁用且库内可为空；G* 启用须填分值与日上限，M* 月奖仅须分值。"""
 
 from __future__ import annotations
 
 DEFERRED_CONFIG_RULE_CODES = frozenset({"G5", "G6", "G7", "M2", "M3", "M5", "M7", "M8"})
+DEFERRED_DAILY_CAP_RULE_CODES = frozenset({"G5", "G6", "G7"})
 
 # 兼容旧名
 OPTIONAL_FIXED_SCORE_RULE_CODES = DEFERRED_CONFIG_RULE_CODES
@@ -25,7 +26,7 @@ def validate_deferred_config_rule_can_enable(
     daily_cap: int | None,
     status: str,
 ) -> str | None:
-    """启用校验：延迟配置规则在 status=enabled 时必须已填写分值与日上限。
+    """启用校验：延迟配置规则在 status=enabled 时必须已填写分值；G5–G7 还须日上限。
 
     Returns:
         错误文案；通过时返回 None。
@@ -35,7 +36,7 @@ def validate_deferred_config_rule_can_enable(
         return None
     if fixed_score_from_expr(score_expr) <= 0:
         return "启用规则须填写积分分值"
-    if daily_cap is None:
+    if code in DEFERRED_DAILY_CAP_RULE_CODES and daily_cap is None:
         return "启用规则须填写每日上限"
     return None
 

--- a/src/backend/bisheng/points/domain/schemas/points_schema.py
+++ b/src/backend/bisheng/points/domain/schemas/points_schema.py
@@ -206,3 +206,9 @@ class ClearCompanyRootResponse(BaseModel):
     """取消公司根并清空组织层级标签的结果。"""
 
     cleared_count: int
+
+
+class PointMonthlyRewardJobRequest(BaseModel):
+    """临时 HTTP 触发月奖；缺省 period_key 时与 Beat 一样结算上月。"""
+
+    period_key: str | None = None

--- a/src/backend/bisheng/points/domain/services/points_admin_jobs_service.py
+++ b/src/backend/bisheng/points/domain/services/points_admin_jobs_service.py
@@ -1,0 +1,45 @@
+"""积分后台临时任务触发：复用 Beat 同款 Service，无鉴权（用完即删）。"""
+
+from __future__ import annotations
+
+import re
+
+from bisheng.common.errcode.points import PointsInvalidAdjustError
+from bisheng.core.context.tenant import set_current_tenant_id
+from bisheng.points.domain.services.points_monthly_reward_service import PointsMonthlyRewardService
+from bisheng.points.domain.services.points_rank_service import PointsRankService
+
+_PERIOD_KEY_RE = re.compile(r"^\d{4}-\d{2}$")
+
+
+class PointsAdminJobsService:
+    """供测试/联调手动触发积分榜刷新与管理员月奖（不影响 Celery Beat）。"""
+
+    async def refresh_rank_snapshots_for_tenant(self, tenant_id: int) -> dict:
+        """
+        刷新指定租户月/年/总榜快照。
+
+        :param tenant_id: 目标租户 ID
+        :returns: ``PointsRankService.refresh_rank_snapshots`` 原样结果
+        """
+        set_current_tenant_id(int(tenant_id))
+        return await PointsRankService().refresh_rank_snapshots(int(tenant_id))
+
+    async def run_monthly_rewards_for_tenant(
+        self,
+        tenant_id: int,
+        *,
+        period_key: str | None = None,
+    ) -> dict:
+        """
+        对指定租户结算管理员月奖。
+
+        :param tenant_id: 目标租户 ID
+        :param period_key: 可选 ``YYYY-MM``，默认上月（与 Beat 相同）
+        :returns: ``PointsMonthlyRewardService.run_for_tenant`` 原样结果
+        """
+        if period_key is not None and not _PERIOD_KEY_RE.match(period_key.strip()):
+            raise PointsInvalidAdjustError(msg="period_key 须为 YYYY-MM 格式")
+        set_current_tenant_id(int(tenant_id))
+        key = period_key.strip() if period_key else None
+        return await PointsMonthlyRewardService().run_for_tenant(int(tenant_id), period_key=key)

--- a/src/backend/test/points/test_optional_fixed_score_rules.py
+++ b/src/backend/test/points/test_optional_fixed_score_rules.py
@@ -42,7 +42,7 @@ def test_g5_requires_score_and_daily_cap_to_enable():
     )
 
 
-def test_m2_requires_score_and_daily_cap_to_enable():
+def test_m2_requires_score_only_to_enable():
     assert (
         validate_deferred_config_rule_can_enable(
             "M2",
@@ -50,14 +50,14 @@ def test_m2_requires_score_and_daily_cap_to_enable():
             daily_cap=None,
             status="enabled",
         )
-        == "启用规则须填写每日上限"
+        is None
     )
     assert (
         validate_deferred_config_rule_can_enable(
             "M2",
-            score_expr={"mode": "fixed", "score": 150},
-            daily_cap=20,
+            score_expr={"mode": "fixed", "score": 0},
+            daily_cap=None,
             status="enabled",
         )
-        is None
+        == "启用规则须填写积分分值"
     )

--- a/src/backend/test/points/test_points_admin_jobs.py
+++ b/src/backend/test/points/test_points_admin_jobs.py
@@ -1,0 +1,37 @@
+"""积分后台临时任务 HTTP 入口（无鉴权，单租户 query）。"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from bisheng.common.errcode.points import PointsInvalidAdjustError
+from bisheng.points.domain.services.points_admin_jobs_service import PointsAdminJobsService
+
+
+@pytest.mark.asyncio
+async def test_refresh_rank_snapshots_delegates_to_rank_service():
+    service = PointsAdminJobsService()
+    with patch("bisheng.points.domain.services.points_admin_jobs_service.PointsRankService") as rank_cls:
+        rank_cls.return_value.refresh_rank_snapshots = AsyncMock(return_value={"tenant_id": 1, "rows": 3})
+        out = await service.refresh_rank_snapshots_for_tenant(1)
+    assert out["rows"] == 3
+    rank_cls.return_value.refresh_rank_snapshots.assert_awaited_once_with(1)
+
+
+@pytest.mark.asyncio
+async def test_run_monthly_rewards_delegates_to_monthly_service():
+    service = PointsAdminJobsService()
+    with patch("bisheng.points.domain.services.points_admin_jobs_service.PointsMonthlyRewardService") as monthly_cls:
+        monthly_cls.return_value.run_for_tenant = AsyncMock(
+            return_value={"tenant_id": 1, "period_key": "2026-07", "awarded": 2, "skipped": 0}
+        )
+        out = await service.run_monthly_rewards_for_tenant(1, period_key="2026-07")
+    assert out["awarded"] == 2
+    monthly_cls.return_value.run_for_tenant.assert_awaited_once_with(1, period_key="2026-07")
+
+
+@pytest.mark.asyncio
+async def test_run_monthly_rewards_rejects_bad_period_key():
+    service = PointsAdminJobsService()
+    with pytest.raises(PointsInvalidAdjustError):
+        await service.run_monthly_rewards_for_tenant(1, period_key="202607")


### PR DESCRIPTION
## Summary
- 新增临时无鉴权 HTTP 接口，供测试/联调手动触发积分榜快照刷新与管理员月奖（复用既有 Service，Celery Beat 未改动）
- M* 延迟配置规则启用时仅校验分值；G5–G7 仍要求填写日上限

## 临时接口
- `POST /api/v1/points/admin/jobs/refresh-rank-snapshots?tenant_id=1`
- `POST /api/v1/points/admin/jobs/run-monthly-rewards?tenant_id=1`（body 可选 `{ "period_key": "YYYY-MM" }`，不传则结算上月）

## Test plan
- [x] `./.venv/bin/python -m pytest test/points/test_points_admin_jobs.py`
- [x] `./.venv/bin/python -m pytest test/points/test_optional_fixed_score_rules.py`
- [ ] 联调：`curl -X POST http://127.0.0.1:7860/api/v1/points/admin/jobs/refresh-rank-snapshots?tenant_id=1`


Made with [Cursor](https://cursor.com)