### PR TITLE
fix(points): 补回被 COMMENT 迁移剥掉的主键自增

### DIFF
--- a/src/backend/bisheng/core/database/alembic/versions/v2_6_0_f084_points_column_comments.py
+++ b/src/backend/bisheng/core/database/alembic/versions/v2_6_0_f084_points_column_comments.py
@@ -1,3 +1,4 @@
+# ruff: noqa: RUF002, RUF003
 """为全部积分表列补齐中文 COMMENT（库侧字段说明）。
 
 Revision ID: f084_points_column_comments
@@ -45,47 +46,66 @@ def _escape_sql_literal(value: str) -> str:
     return value.replace("'", "''")
 
 
-def _apply_mysql_comment(bind, table: str, column: str, comment: str) -> None:
+def _column_needs_autoincrement(column) -> bool:
+    """ORM 主键是否应按自增列发出 AUTO_INCREMENT / IDENTITY。"""
+    autoincrement = getattr(column, "autoincrement", False)
+    return bool(getattr(column, "primary_key", False) and autoincrement in (True, "auto"))
+
+
+def _apply_mysql_comment(
+    bind,
+    table: str,
+    column: str,
+    comment: str,
+    *,
+    needs_autoincrement: bool = False,
+) -> None:
     """MySQL/MariaDB：用 information_schema 拼 MODIFY，避免 alter_column 二次转义 DEFAULT。
 
     inspector 返回的 default 形如 ``'1'``（已含引号）；若原样传给
     ``existing_server_default`` 会变成 ``DEFAULT '''1'''`` 并触发 1067。
-    同时保留 EXTRA（如 ON UPDATE CURRENT_TIMESTAMP / auto_increment）。
+    同时保留 EXTRA（如 ON UPDATE CURRENT_TIMESTAMP）。
+    主键自增列必须显式带 AUTO_INCREMENT：MySQL MODIFY 省略该子句会把自增剥掉；
+    COMMENT 已到位也不能跳过，否则中断重跑无法补回。
     """
-    row = bind.execute(
-        sa.text(
-            """
+    row = (
+        bind.execute(
+            sa.text(
+                """
             SELECT COLUMN_TYPE, IS_NULLABLE, COLUMN_DEFAULT, EXTRA, COLUMN_COMMENT
             FROM information_schema.COLUMNS
             WHERE TABLE_SCHEMA = DATABASE()
               AND TABLE_NAME = :table
               AND COLUMN_NAME = :column
             """
-        ),
-        {"table": table, "column": column},
-    ).mappings().first()
+            ),
+            {"table": table, "column": column},
+        )
+        .mappings()
+        .first()
+    )
     if row is None:
         return
-    # 已是目标文案则跳过，支持中断后重跑
-    if (row["COLUMN_COMMENT"] or "") == comment:
+    extra_l = (row["EXTRA"] or "").lower()
+    has_autoincrement = "auto_increment" in extra_l
+    comment_ok = (row["COLUMN_COMMENT"] or "") == comment
+    # COMMENT 已匹配且自增状态正确才跳过；缺自增时仍要 MODIFY 补回。
+    if comment_ok and (has_autoincrement or not needs_autoincrement):
         return
 
     null_sql = "NULL" if row["IS_NULLABLE"] == "YES" else "NOT NULL"
     default = row["COLUMN_DEFAULT"]
     # MySQL 8 EXTRA 可能含 DEFAULT_GENERATED，不能原样拼进 MODIFY
-    extra_l = (row["EXTRA"] or "").lower()
     parts = [f"ALTER TABLE `{table}` MODIFY COLUMN `{column}` {row['COLUMN_TYPE']} {null_sql}"]
 
     if default is not None:
         # CURRENT_TIMESTAMP 等函数默认值不能再加引号；普通标量按字符串字面量写入
         upper = str(default).upper()
-        if upper in ("CURRENT_TIMESTAMP", "CURRENT_TIMESTAMP()", "NULL") or upper.startswith(
-            "CURRENT_TIMESTAMP"
-        ):
+        if upper in ("CURRENT_TIMESTAMP", "CURRENT_TIMESTAMP()", "NULL") or upper.startswith("CURRENT_TIMESTAMP"):
             parts.append(f"DEFAULT {default}")
         else:
             parts.append(f"DEFAULT '{_escape_sql_literal(str(default))}'")
-    if "auto_increment" in extra_l:
+    if needs_autoincrement or has_autoincrement:
         parts.append("AUTO_INCREMENT")
     if "on update current_timestamp" in extra_l:
         parts.append("ON UPDATE CURRENT_TIMESTAMP")
@@ -126,7 +146,13 @@ def upgrade() -> None:
                 _apply_dm_comment(table, name, comment)
             else:
                 # mysql / mariadb
-                _apply_mysql_comment(bind, table, name, comment)
+                _apply_mysql_comment(
+                    bind,
+                    table,
+                    name,
+                    comment,
+                    needs_autoincrement=_column_needs_autoincrement(column),
+                )
 
 
 def downgrade() -> None:

--- a/src/backend/bisheng/core/database/alembic/versions/v2_6_0_f088_points_restore_pk_autoincrement.py
+++ b/src/backend/bisheng/core/database/alembic/versions/v2_6_0_f088_points_restore_pk_autoincrement.py
@@ -1,0 +1,63 @@
+# ruff: noqa: RUF002, RUF003
+"""补回积分表主键 AUTO_INCREMENT（f084 中断重跑曾把自增剥掉）。
+
+Revision ID: f088_points_restore_pk_autoincrement
+Revises: f086_merge_points_qa_images
+
+f084 第一版用 ``op.alter_column`` 写 COMMENT，MySQL MODIFY 未带 AUTO_INCREMENT
+会剥掉主键自增；随后 tenant_id DEFAULT 二次转义报 1067 中断，只有已处理到的
+``user_point_account.id`` 中招。修复版又因 COMMENT 已是「主键」而跳过，自增
+再也没补回。本迁移对全部积分主键做幂等补回。
+
+达梦走 COMMENT ON COLUMN，不会剥 IDENTITY，此处跳过。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+from sqlalchemy import inspect
+
+from bisheng.core.database.alembic.versions.v2_6_0_f084_points_column_comments import (
+    _POINT_MODELS,
+    _apply_mysql_comment,
+    _column_needs_autoincrement,
+)
+
+revision: str = "f088_points_restore_pk_autoincrement"
+down_revision: str | Sequence[str] | None = "f086_merge_points_qa_images"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """MySQL：主键缺 AUTO_INCREMENT 时 MODIFY 补回；已有则跳过。"""
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+    if dialect not in ("mysql", "mariadb"):
+        # 达梦 COMMENT ON COLUMN 不改变 IDENTITY；SQLite INTEGER PK 自增语义不同。
+        return
+
+    inspector = inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+    for model in _POINT_MODELS:
+        table = model.__tablename__
+        if table not in existing_tables:
+            continue
+        for column in model.__table__.columns:
+            if not _column_needs_autoincrement(column):
+                continue
+            comment = column.comment or "主键"
+            _apply_mysql_comment(
+                bind,
+                table,
+                column.name,
+                comment,
+                needs_autoincrement=True,
+            )
+
+
+def downgrade() -> None:
+    """自增是主键不变量，downgrade 不剥 AUTO_INCREMENT。"""
+    return

--- a/src/backend/test/points/test_points_restore_pk_autoincrement.py
+++ b/src/backend/test/points/test_points_restore_pk_autoincrement.py
@@ -1,0 +1,95 @@
+# ruff: noqa: RUF002
+"""f084 COMMENT 迁移不得剥主键自增；f088 幂等补回缺失的 AUTO_INCREMENT。"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from bisheng.core.database.alembic.versions import (
+    v2_6_0_f084_points_column_comments as f084,
+)
+from bisheng.core.database.alembic.versions import (
+    v2_6_0_f088_points_restore_pk_autoincrement as f088,
+)
+from bisheng.points.domain.models.points import UserPointAccount
+
+
+class _Result:
+    """模拟 SQLAlchemy execute().mappings().first()。"""
+
+    def __init__(self, row: dict | None):
+        self._row = row
+
+    def mappings(self):
+        return self
+
+    def first(self):
+        return self._row
+
+
+def _row(*, comment: str = "主键", extra: str = "", column_type: str = "bigint") -> dict:
+    return {
+        "COLUMN_TYPE": column_type,
+        "IS_NULLABLE": "NO",
+        "COLUMN_DEFAULT": None,
+        "EXTRA": extra,
+        "COLUMN_COMMENT": comment,
+    }
+
+
+def test_f088_metadata_follows_points_merge_head() -> None:
+    assert f088.revision == "f088_points_restore_pk_autoincrement"
+    assert f088.down_revision == "f086_merge_points_qa_images"
+
+
+def test_account_id_needs_autoincrement() -> None:
+    column = UserPointAccount.__table__.c.id
+    assert f084._column_needs_autoincrement(column) is True
+
+
+def test_f084_skips_when_comment_and_autoincrement_already_ok() -> None:
+    """COMMENT 已匹配且 EXTRA 含 auto_increment 时不再 MODIFY。"""
+    bind = SimpleNamespace(execute=lambda *_a, **_k: _Result(_row(extra="auto_increment")))
+    with patch.object(f084.op, "execute") as execute:
+        f084._apply_mysql_comment(bind, "user_point_account", "id", "主键", needs_autoincrement=True)
+    execute.assert_not_called()
+
+
+def test_f084_restores_autoincrement_when_comment_already_set() -> None:
+    """COMMENT 已是「主键」但缺自增时仍要 MODIFY 补回 AUTO_INCREMENT。"""
+    bind = SimpleNamespace(execute=lambda *_a, **_k: _Result(_row(extra="")))
+    with patch.object(f084.op, "execute") as execute:
+        f084._apply_mysql_comment(bind, "user_point_account", "id", "主键", needs_autoincrement=True)
+    execute.assert_called_once()
+    sql = str(execute.call_args.args[0])
+    assert "AUTO_INCREMENT" in sql
+    assert "user_point_account" in sql
+    assert "COMMENT '主键'" in sql
+
+
+def test_f088_upgrade_skips_non_mysql() -> None:
+    bind = SimpleNamespace(dialect=SimpleNamespace(name="dm"))
+    with (
+        patch.object(f088.op, "get_bind", return_value=bind),
+        patch.object(f088, "_apply_mysql_comment") as apply_comment,
+    ):
+        f088.upgrade()
+    apply_comment.assert_not_called()
+
+
+def test_f088_upgrade_repairs_mysql_pk() -> None:
+    """MySQL 路径会对积分主键调用 COMMENT/自增补回 helper。"""
+    bind = SimpleNamespace(dialect=SimpleNamespace(name="mysql"))
+    tables = {model.__tablename__ for model in f088._POINT_MODELS}
+    inspector = SimpleNamespace(get_table_names=lambda: list(tables))
+    with (
+        patch.object(f088.op, "get_bind", return_value=bind),
+        patch.object(f088, "inspect", return_value=inspector),
+        patch.object(f088, "_apply_mysql_comment") as apply_comment,
+    ):
+        f088.upgrade()
+    targets = {(c.args[1], c.args[2]) for c in apply_comment.call_args_list}
+    assert ("user_point_account", "id") in targets
+    assert ("user_point_log", "id") in targets
+    assert all(c.kwargs.get("needs_autoincrement") is True for c in apply_comment.call_args_list)


### PR DESCRIPTION
## Summary
- MySQL `MODIFY COLUMN` 写 COMMENT 时若省略 `AUTO_INCREMENT` 会剥掉主键自增；f084 中断重跑后因 COMMENT 已写入而跳过，`user_point_account.id` 无法再建账户，上传发分全部失败。
- f084 改为：主键缺自增时仍补回 `AUTO_INCREMENT`，不因 COMMENT 已匹配而跳过。
- 新增幂等迁移 `f088_points_restore_pk_autoincrement`，修复已 stamp 过 f084 的环境。

## Test plan
- [x] `pytest test/points/test_points_restore_pk_autoincrement.py`（6 passed）
- [ ] `alembic upgrade head` 后确认 `user_point_account.id` 带 `AUTO_INCREMENT`
- [ ] 普通用户上传到部门库/团队库后能写入 `user_point_log`（日上限需 ≥ 单次分值）


Made with [Cursor](https://cursor.com)