### PR TITLE
fix(points): 日上限当前读串行入账，直传人等于发布人

### DIFF
--- a/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
+++ b/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
@@ -15909,7 +15909,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 )
         await self.update_folder_update_time(file_level_path)
         await KnowledgeDao.async_update_knowledge_update_time_by_id(knowledge_id)
-        # 积分旁路：上传成功记分，失败不影响返回。
+        # 积分旁路：直传人即发布人，上传成功记分，失败不影响返回。
         try:
             from bisheng.points.domain.services.points_award_hooks import notify_space_files_ready
 
@@ -15918,6 +15918,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 space_id=int(knowledge_id),
                 files=process_files,
                 uploader_id=int(self.login_user.user_id),
+                publisher_id=int(self.login_user.user_id),
                 is_favorite_space=bool(getattr(db_knowledge, "is_favorite", False)),
             )
         except Exception:

--- a/src/backend/bisheng/points/domain/repositories/points_repository.py
+++ b/src/backend/bisheng/points/domain/repositories/points_repository.py
@@ -80,19 +80,28 @@ class PointsRepository:
         return (await self.session.exec(select(UserPointLog).where(UserPointLog.id == log_id))).first()
 
     async def sum_earn_today(self, tenant_id: int, user_id: int, rule_code: str, start: datetime) -> int:
-        """汇总上海业务日内同规则已获得分数。"""
-        value = (
+        """汇总上海业务日内同规则已获得分数。
+
+        必须在账户行锁之后调用。``FOR UPDATE`` 走当前读，避免 REPEATABLE READ
+        下 Facade 先读规则定下的快照看不见排队事务刚提交的流水。
+        """
+        rows = (
             await self.session.exec(
-                select(func.coalesce(func.sum(UserPointLog.delta), 0)).where(
+                select(UserPointLog.delta)
+                .where(
                     UserPointLog.tenant_id == tenant_id,
                     UserPointLog.user_id == user_id,
                     UserPointLog.rule_code == rule_code,
                     UserPointLog.direction == "earn",
                     UserPointLog.occurred_at >= start,
                 )
+                .with_for_update()
             )
-        ).one()
-        return int(value[0] if isinstance(value, tuple) else value or 0)
+        ).all()
+        total = 0
+        for row in rows:
+            total += int(row[0] if isinstance(row, tuple) else row or 0)
+        return total
 
     async def sum_user_delta(
         self,
@@ -353,16 +362,24 @@ class PointsRepository:
             return None
         return value[0] if isinstance(value, tuple) else value
 
-    async def get_favorite_tier_award(self, tenant_id: int, file_id: int) -> PointFavoriteTierAward | None:
-        """读取文档已发放的 G3 最高档记录。"""
-        return (
-            await self.session.exec(
-                select(PointFavoriteTierAward).where(
-                    PointFavoriteTierAward.tenant_id == tenant_id,
-                    PointFavoriteTierAward.file_id == file_id,
-                )
-            )
-        ).first()
+    async def get_favorite_tier_award(
+        self,
+        tenant_id: int,
+        file_id: int,
+        *,
+        for_update: bool = False,
+    ) -> PointFavoriteTierAward | None:
+        """读取文档已发放的 G3 最高档记录。
+
+        :param for_update: 发分路径在账户行锁之后应加行锁，读取最新已提交进度。
+        """
+        stmt = select(PointFavoriteTierAward).where(
+            PointFavoriteTierAward.tenant_id == tenant_id,
+            PointFavoriteTierAward.file_id == file_id,
+        )
+        if for_update:
+            stmt = stmt.with_for_update()
+        return (await self.session.exec(stmt)).first()
 
     async def upsert_favorite_tier_award(
         self,

--- a/src/backend/bisheng/points/domain/services/points_award_facade.py
+++ b/src/backend/bisheng/points/domain/services/points_award_facade.py
@@ -259,7 +259,9 @@ class PointsAwardFacade:
         if skip:
             return AwardOutcome(skipped=True, reason=skip)
         s_target, highest_tier = _tier_target(rule.score_expr, event.unique_favoriter_count)
-        prior = await self.repository.get_favorite_tier_award(event.tenant_id, event.file_id)
+        # 先锁账户再读档位，避免并发收藏按过期进度各自补差价而超发。
+        await self.repository.lock_or_create_account(event.tenant_id, payee)
+        prior = await self.repository.get_favorite_tier_award(event.tenant_id, event.file_id, for_update=True)
         s_done = int(prior.points_granted_total) if prior else 0
         if s_target <= s_done:
             return AwardOutcome(skipped=True, reason="tier_already_granted")
@@ -346,11 +348,14 @@ class PointsAwardFacade:
         sharer_id: int | None = None,
         answerer_id: int | None = None,
     ) -> tuple[int | None, str | None]:
-        """按规则 beneficiary 解析唯一入账用户。"""
+        """按规则 beneficiary 解析唯一入账用户。
+
+        发布人不得回退成上传人：缺 publisher_id 时由调用方按「直传人=发布人」显式传入。
+        """
         role = (beneficiary or "").strip()
         mapping = {
             "uploader": uploader_id,
-            "publisher": publisher_id if publisher_id is not None else uploader_id,
+            "publisher": publisher_id,
             "sharer": sharer_id,
             "answerer": answerer_id,
         }

--- a/src/backend/bisheng/points/domain/services/points_award_hooks.py
+++ b/src/backend/bisheng/points/domain/services/points_award_hooks.py
@@ -15,6 +15,7 @@ from bisheng.knowledge.domain.models.knowledge_space_scope import (
     KnowledgeSpaceScopeDao,
 )
 from bisheng.points.domain.constants.notify_templates import resolve_earn_notify
+from bisheng.points.domain.constants.space_level_rules import earn_rule_for_space_level
 from bisheng.points.domain.repositories.points_repository import PointsRepository
 from bisheng.points.domain.services.points_award_facade import (
     AnswerAdoptedEvent,
@@ -77,6 +78,44 @@ async def resolve_space_level(space_id: int) -> str:
     except Exception:
         logger.exception("points.award.hooks resolve_level_failed space_id=%s", space_id)
         return KnowledgeSpaceLevelEnum.PERSONAL.value
+
+
+def _space_file_ids_from_payload(payload: dict[str, Any]) -> list[int]:
+    """解析入库发分 payload 中的文件 ID。
+
+    新消息用 ``file_ids``；旧 Worker 升级窗口仍可能只有 ``file_id``。
+    去重且保持原顺序，避免同一文件在一批里入账两次。
+    """
+    raw = payload.get("file_ids")
+    ids: list[int] = []
+    if isinstance(raw, list) and raw:
+        ids = [int(item) for item in raw if item is not None]
+    elif payload.get("file_id") is not None:
+        ids = [int(payload["file_id"])]
+    seen: set[int] = set()
+    unique: list[int] = []
+    for file_id in ids:
+        if file_id <= 0 or file_id in seen:
+            continue
+        seen.add(file_id)
+        unique.append(file_id)
+    return unique
+
+
+def _resolve_space_file_publisher_id(publisher_id: int | None, uploader_id: int) -> int:
+    """直传没有单独发布人时，发布人等于本次上传操作人。审批发布应显式传入申请人。"""
+    if publisher_id is not None:
+        return int(publisher_id)
+    return int(uploader_id)
+
+
+def _should_skip_space_file_batch(*, is_favorite_space: bool, space_level: str) -> str | None:
+    """整批入库在入队前即可判定的免计分原因；个人库/收藏库整批不进 Worker。"""
+    if is_favorite_space:
+        return "favorite_space"
+    if earn_rule_for_space_level(space_level) is None:
+        return "personal_or_unmapped_level"
+    return None
 
 
 def _award_async_enabled() -> bool:
@@ -194,21 +233,35 @@ async def _dispatch(event_type: str, payload: dict[str, Any]) -> None:
 async def _run_payload_sync(payload: dict[str, Any]) -> None:
     """与 Celery worker 相同的事件分发，供同步路径与 enqueue fallback 复用。"""
 
-    async def _award(facade: PointsAwardFacade) -> AwardOutcome:
+    async def _award(facade: PointsAwardFacade) -> AwardOutcome | list[AwardOutcome]:
         event_type = str(payload.get("event_type") or "")
         if event_type == "space_file_ready":
-            return await facade.on_space_file_ready(
-                SpaceFileReadyEvent(
-                    tenant_id=int(payload["tenant_id"]),
-                    space_id=int(payload["space_id"]),
-                    space_level=str(payload["space_level"]),
-                    file_id=int(payload["file_id"]),
-                    uploader_id=int(payload["uploader_id"]),
-                    publisher_id=(int(payload["publisher_id"]) if payload.get("publisher_id") is not None else None),
-                    is_favorite_space=bool(payload.get("is_favorite_space")),
-                    space_manager_ids=frozenset(int(x) for x in (payload.get("space_manager_ids") or [])),
-                )
+            file_ids = _space_file_ids_from_payload(payload)
+            if not file_ids:
+                raise ValueError("space_file_ready payload missing file_ids")
+            managers = frozenset(int(x) for x in (payload.get("space_manager_ids") or []))
+            uploader_id = int(payload["uploader_id"])
+            publisher_id = _resolve_space_file_publisher_id(
+                int(payload["publisher_id"]) if payload.get("publisher_id") is not None else None,
+                uploader_id,
             )
+            outcomes: list[AwardOutcome] = []
+            for file_id in file_ids:
+                outcomes.append(
+                    await facade.on_space_file_ready(
+                        SpaceFileReadyEvent(
+                            tenant_id=int(payload["tenant_id"]),
+                            space_id=int(payload["space_id"]),
+                            space_level=str(payload["space_level"]),
+                            file_id=file_id,
+                            uploader_id=uploader_id,
+                            publisher_id=publisher_id,
+                            is_favorite_space=bool(payload.get("is_favorite_space")),
+                            space_manager_ids=managers,
+                        )
+                    )
+                )
+            return outcomes
         if event_type == "document_shared":
             return await facade.on_document_shared(
                 DocumentSharedEvent(
@@ -253,9 +306,19 @@ async def notify_space_files_ready(
     is_favorite_space: bool | None = None,
     space_level: str | None = None,
 ) -> None:
-    """上传/发布入库成功后发分；一文件一任务（或同步路径一批处理）。"""
+    """上传/发布入库成功后发分；一次动作一个任务，任务内按文件串行入账。"""
     try:
-        file_ids = [int(f.id) for f in files if getattr(f, "id", None)]
+        seen: set[int] = set()
+        file_ids: list[int] = []
+        for item in files:
+            file_id = getattr(item, "id", None)
+            if file_id is None:
+                continue
+            file_id = int(file_id)
+            if file_id <= 0 or file_id in seen:
+                continue
+            seen.add(file_id)
+            file_ids.append(file_id)
         if not file_ids:
             return
         favorite = is_favorite_space
@@ -263,47 +326,34 @@ async def notify_space_files_ready(
             space = await KnowledgeDao.aquery_by_id(int(space_id))
             favorite = bool(space and getattr(space, "is_favorite", False))
         level = space_level or await resolve_space_level(space_id)
+        skip_reason = _should_skip_space_file_batch(is_favorite_space=bool(favorite), space_level=str(level))
+        if skip_reason:
+            logger.info(
+                "points.award.skip_enqueue reason=%s space_id=%s files=%s",
+                skip_reason,
+                space_id,
+                len(file_ids),
+            )
+            return
         managers = await resolve_space_manager_ids(space_id)
         manager_list = sorted(int(x) for x in managers)
+        body = {
+            "tenant_id": int(tenant_id),
+            "space_id": int(space_id),
+            "space_level": level,
+            "file_ids": file_ids,
+            "uploader_id": int(uploader_id),
+            # 直传未传发布人时按「直传人=发布人」写入 payload，避免 Worker 侧规则配发布人却 skip。
+            "publisher_id": _resolve_space_file_publisher_id(publisher_id, int(uploader_id)),
+            "is_favorite_space": bool(favorite),
+            "space_manager_ids": manager_list,
+        }
 
         if not _award_async_enabled():
-            # 同步：同一会话批量处理，减少连接开销；仍按文件各发一条站内信。
-            async def _award(facade: PointsAwardFacade) -> list[AwardOutcome]:
-                outs: list[AwardOutcome] = []
-                for file_id in file_ids:
-                    outs.append(
-                        await facade.on_space_file_ready(
-                            SpaceFileReadyEvent(
-                                tenant_id=int(tenant_id),
-                                space_id=int(space_id),
-                                space_level=level,
-                                file_id=file_id,
-                                uploader_id=int(uploader_id),
-                                publisher_id=int(publisher_id) if publisher_id is not None else None,
-                                is_favorite_space=bool(favorite),
-                                space_manager_ids=managers,
-                            )
-                        )
-                    )
-                return outs
-
-            await _run_with_facade(_award)
+            await _run_payload_sync({"event_type": "space_file_ready", **body})
             return
 
-        for file_id in file_ids:
-            await _dispatch(
-                "space_file_ready",
-                {
-                    "tenant_id": int(tenant_id),
-                    "space_id": int(space_id),
-                    "space_level": level,
-                    "file_id": int(file_id),
-                    "uploader_id": int(uploader_id),
-                    "publisher_id": int(publisher_id) if publisher_id is not None else None,
-                    "is_favorite_space": bool(favorite),
-                    "space_manager_ids": manager_list,
-                },
-            )
+        await _dispatch("space_file_ready", body)
     except Exception:
         logger.exception(
             "points.award.hooks space_file_ready_failed space_id=%s uploader_id=%s",

--- a/src/backend/bisheng/points/domain/services/points_ledger_service.py
+++ b/src/backend/bisheng/points/domain/services/points_ledger_service.py
@@ -13,6 +13,7 @@ SHANGHAI = ZoneInfo("Asia/Shanghai")
 @dataclass
 class LedgerResult:
     """记账结果；跳过日上限时 log_id 为空。"""
+
     applied_delta: int
     balance: int
     log_id: int | None = None
@@ -27,26 +28,110 @@ class PointsLedgerService:
         self.repository = repository
         self.notify_service = notify_service
 
-    async def award(self, *, tenant_id: int, user_id: int, delta: int, title: str, rule_code: str, idempotency_key: str, daily_cap: int | None = None, source: str = "auto", **kwargs) -> LedgerResult:
+    async def award(
+        self,
+        *,
+        tenant_id: int,
+        user_id: int,
+        delta: int,
+        title: str,
+        rule_code: str,
+        idempotency_key: str,
+        daily_cap: int | None = None,
+        source: str = "auto",
+        **kwargs,
+    ) -> LedgerResult:
         """自动发分；剩余额度不足整笔时跳过，不做部分截断。"""
         if delta <= 0:
             raise PointsInvalidAdjustError(msg="发放积分必须为正数")
-        return await self._write(tenant_id=tenant_id, user_id=user_id, delta=delta, title=title, rule_code=rule_code, idempotency_key=idempotency_key, daily_cap=daily_cap, source=source, **kwargs)
+        return await self._write(
+            tenant_id=tenant_id,
+            user_id=user_id,
+            delta=delta,
+            title=title,
+            rule_code=rule_code,
+            idempotency_key=idempotency_key,
+            daily_cap=daily_cap,
+            source=source,
+            **kwargs,
+        )
 
-    async def adjust(self, *, tenant_id: int, user_id: int, delta: int, title: str = "管理员调整积分", idempotency_key: str, operator_id: int, remark: str, **kwargs) -> LedgerResult:
+    async def adjust(
+        self,
+        *,
+        tenant_id: int,
+        user_id: int,
+        delta: int,
+        title: str = "管理员调整积分",
+        idempotency_key: str,
+        operator_id: int,
+        remark: str,
+        **kwargs,
+    ) -> LedgerResult:
         """管理员自由调分；余额允许变为负数。"""
         if not isinstance(delta, int) or delta == 0 or abs(delta) > 10000 or not 5 <= len(remark.strip()) <= 100:
             raise PointsInvalidAdjustError()
-        return await self._write(tenant_id=tenant_id, user_id=user_id, delta=delta, title=title, rule_code="MANUAL", idempotency_key=idempotency_key, source="manual_adjust", operator_id=operator_id, remark=remark, **kwargs)
+        return await self._write(
+            tenant_id=tenant_id,
+            user_id=user_id,
+            delta=delta,
+            title=title,
+            rule_code="MANUAL",
+            idempotency_key=idempotency_key,
+            source="manual_adjust",
+            operator_id=operator_id,
+            remark=remark,
+            **kwargs,
+        )
 
-    async def deduct(self, *, tenant_id: int, user_id: int, delta: int, title: str, rule_code: str, idempotency_key: str, operator_id: int, remark: str | None = None, **kwargs) -> LedgerResult:
+    async def deduct(
+        self,
+        *,
+        tenant_id: int,
+        user_id: int,
+        delta: int,
+        title: str,
+        rule_code: str,
+        idempotency_key: str,
+        operator_id: int,
+        remark: str | None = None,
+        **kwargs,
+    ) -> LedgerResult:
         """按 R 规则扣分；负余额是合法业务状态。"""
         if delta >= 0:
             raise PointsInvalidAdjustError(msg="扣减积分必须为负数")
-        return await self._write(tenant_id=tenant_id, user_id=user_id, delta=delta, title=title, rule_code=rule_code, idempotency_key=idempotency_key, source="manual_deduct", operator_id=operator_id, remark=remark, **kwargs)
+        return await self._write(
+            tenant_id=tenant_id,
+            user_id=user_id,
+            delta=delta,
+            title=title,
+            rule_code=rule_code,
+            idempotency_key=idempotency_key,
+            source="manual_deduct",
+            operator_id=operator_id,
+            remark=remark,
+            **kwargs,
+        )
 
-    async def _write(self, *, tenant_id: int, user_id: int, delta: int, title: str, rule_code: str, idempotency_key: str, source: str, daily_cap: int | None = None, operator_id: int | None = None, remark: str | None = None, biz_type: str | None = None, biz_id: str | None = None, beneficiary_role: str | None = None) -> LedgerResult:
+    async def _write(
+        self,
+        *,
+        tenant_id: int,
+        user_id: int,
+        delta: int,
+        title: str,
+        rule_code: str,
+        idempotency_key: str,
+        source: str,
+        daily_cap: int | None = None,
+        operator_id: int | None = None,
+        remark: str | None = None,
+        biz_type: str | None = None,
+        biz_id: str | None = None,
+        beneficiary_role: str | None = None,
+    ) -> LedgerResult:
         """在调用方事务内写入一笔账本记录并建立 outbox。"""
+        # 先锁账户再读限额/流水：同用户并发任务在行锁上排队，后到者看到已提交的当日合计。
         account = await self.repository.lock_or_create_account(tenant_id, user_id)
         existing = await self.repository.get_log_by_idempotency(tenant_id, idempotency_key)
         if existing:

--- a/src/backend/bisheng/worker/points/tasks.py
+++ b/src/backend/bisheng/worker/points/tasks.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
     name="bisheng.worker.points.tasks.process_points_award_event",
 )
 def process_points_award_event(payload: dict[str, Any]):
-    """消费自动发分事件；由 hooks 投递，幂等键防双发。"""
+    """消费自动发分事件；一次上传的多个文件在同一任务内串行入账，幂等键防双发。"""
     return run_async_task(lambda: _process_award_async(payload))
 
 

--- a/src/backend/test/points/test_points_award_facade.py
+++ b/src/backend/test/points/test_points_award_facade.py
@@ -27,7 +27,7 @@ class FakeAwardRepository:
     async def get_rule(self, _tenant_id, rule_code):
         return self.rules.get(rule_code)
 
-    async def get_favorite_tier_award(self, _tenant_id, file_id):
+    async def get_favorite_tier_award(self, _tenant_id, file_id, *, for_update=False):
         return self.tier_awards.get(file_id)
 
     async def upsert_favorite_tier_award(self, _tenant_id, file_id, *, highest_tier, points_granted_total):
@@ -46,8 +46,14 @@ class FakeAwardRepository:
     async def get_log_by_idempotency(self, _, key):
         return self.logs.get(key)
 
-    async def sum_earn_today(self, *_):
-        return self.today
+    async def sum_earn_today(self, _tenant_id, _user_id, rule_code, _start):
+        if self.today:
+            return self.today
+        return sum(
+            int(log.delta)
+            for log in self.logs.values()
+            if getattr(log, "rule_code", None) == rule_code and getattr(log, "direction", "earn") == "earn"
+        )
 
     async def append_log(self, log):
         log.id = len(self.logs) + 1
@@ -122,9 +128,7 @@ async def test_skips_personal_and_favorite_space():
 async def test_p7b_skips_when_payee_is_space_manager_not_operator():
     """管理员上传、受益人为 uploader → skip；操作人身份不参与判断。"""
     repo = FakeAwardRepository({"G1": _rule(beneficiary="uploader")})
-    outcome = await _facade(repo).on_space_file_ready(
-        _file_event(uploader_id=9, space_manager_ids=frozenset({9}))
-    )
+    outcome = await _facade(repo).on_space_file_ready(_file_event(uploader_id=9, space_manager_ids=frozenset({9})))
     assert outcome.reason == "space_manager_payee"
     assert repo.account.balance == 0
 
@@ -159,14 +163,34 @@ async def test_skips_platform_super_admin_payee():
 @pytest.mark.asyncio
 async def test_beneficiary_publisher_resolves_payee():
     repo = FakeAwardRepository({"G1": _rule(beneficiary="publisher", score=2)})
-    outcome = await _facade(repo).on_space_file_ready(
-        _file_event(uploader_id=4, publisher_id=8)
-    )
+    outcome = await _facade(repo).on_space_file_ready(_file_event(uploader_id=4, publisher_id=8))
     assert not outcome.skipped
     log = next(iter(repo.logs.values()))
     assert log.user_id == 8
     assert log.beneficiary_role == "publisher"
     assert log.delta == 2
+
+
+@pytest.mark.asyncio
+async def test_beneficiary_publisher_skips_when_publisher_id_missing():
+    """规则配发布人但事件未带 publisher_id 时 skip，不得回退成上传人。"""
+    repo = FakeAwardRepository({"G1": _rule(beneficiary="publisher", score=2)})
+    outcome = await _facade(repo).on_space_file_ready(_file_event(uploader_id=4, publisher_id=None))
+    assert outcome.skipped
+    assert outcome.reason == "beneficiary_unresolved"
+    assert repo.account.balance == 0
+    assert not repo.logs
+
+
+@pytest.mark.asyncio
+async def test_beneficiary_publisher_awards_direct_uploader_when_ids_equal():
+    """直传人等于发布人时，配发布人也给当前操作人。"""
+    repo = FakeAwardRepository({"G1": _rule(beneficiary="publisher", score=2)})
+    outcome = await _facade(repo).on_space_file_ready(_file_event(uploader_id=4, publisher_id=4))
+    assert not outcome.skipped
+    log = next(iter(repo.logs.values()))
+    assert log.user_id == 4
+    assert log.beneficiary_role == "publisher"
 
 
 @pytest.mark.asyncio
@@ -186,6 +210,20 @@ async def test_daily_cap_skips_entire_delta():
     assert outcome.result.skipped_cap
     assert repo.account.balance == 0
     assert not repo.logs
+
+
+@pytest.mark.asyncio
+async def test_same_session_serial_awards_respect_daily_cap():
+    """一批文件串行入账时，后一笔能看见本会话已写入流水，不会超过日上限。"""
+    repo = FakeAwardRepository({"G1": _rule(score=30, daily_cap=60)})
+    facade = _facade(repo)
+    first = await facade.on_space_file_ready(_file_event(file_id=1))
+    second = await facade.on_space_file_ready(_file_event(file_id=2))
+    third = await facade.on_space_file_ready(_file_event(file_id=3))
+    assert not first.skipped and not second.skipped
+    assert third.reason == "daily_cap"
+    assert repo.account.balance == 60
+    assert len(repo.logs) == 2
 
 
 @pytest.mark.asyncio

--- a/src/backend/test/points/test_points_award_hooks.py
+++ b/src/backend/test/points/test_points_award_hooks.py
@@ -32,11 +32,13 @@ async def test_notify_space_files_ready_sync_when_async_disabled():
             is_favorite_space=False,
         )
     award.assert_awaited_once()
+    assert award.await_args.args[0].publisher_id == 4
+    assert award.await_args.args[0].uploader_id == 4
 
 
 @pytest.mark.asyncio
-async def test_notify_space_files_ready_enqueues_one_task_per_file():
-    """异步开启时一文件一 Celery 任务。"""
+async def test_notify_space_files_ready_enqueues_one_task_per_upload():
+    """异步开启时一次上传只投一个 Celery 任务，携带全部 file_ids。"""
     enqueue = MagicMock()
     with (
         patch.object(hooks, "_award_async_enabled", return_value=True),
@@ -52,11 +54,54 @@ async def test_notify_space_files_ready_enqueues_one_task_per_file():
             is_favorite_space=False,
             space_level="public",
         )
-    assert enqueue.call_count == 2
-    first = enqueue.call_args_list[0].args[0]
-    assert first["event_type"] == "space_file_ready"
-    assert first["file_id"] == 100
-    assert first["space_manager_ids"] == [9]
+    enqueue.assert_called_once()
+    body = enqueue.call_args.args[0]
+    assert body["event_type"] == "space_file_ready"
+    assert body["file_ids"] == [100, 101]
+    assert body["space_manager_ids"] == [9]
+    assert body["publisher_id"] == 4
+
+
+@pytest.mark.asyncio
+async def test_notify_space_files_ready_keeps_explicit_publisher_id():
+    """审批发布显式传入的 publisher_id 不得被上传人覆盖。"""
+    enqueue = MagicMock()
+    with (
+        patch.object(hooks, "_award_async_enabled", return_value=True),
+        patch.object(hooks, "resolve_space_level", AsyncMock(return_value="public")),
+        patch.object(hooks, "resolve_space_manager_ids", AsyncMock(return_value=frozenset())),
+        patch.object(hooks, "_enqueue_award_event", enqueue),
+    ):
+        await hooks.notify_space_files_ready(
+            tenant_id=1,
+            space_id=10,
+            files=[SimpleNamespace(id=100)],
+            uploader_id=4,
+            publisher_id=8,
+            is_favorite_space=False,
+            space_level="public",
+        )
+    assert enqueue.call_args.args[0]["publisher_id"] == 8
+    assert enqueue.call_args.args[0]["uploader_id"] == 4
+
+
+@pytest.mark.asyncio
+async def test_notify_space_files_ready_skips_enqueue_for_personal_space():
+    """个人库整批不入队。"""
+    enqueue = MagicMock()
+    with (
+        patch.object(hooks, "_award_async_enabled", return_value=True),
+        patch.object(hooks, "_enqueue_award_event", enqueue),
+    ):
+        await hooks.notify_space_files_ready(
+            tenant_id=1,
+            space_id=10,
+            files=[SimpleNamespace(id=100), SimpleNamespace(id=101)],
+            uploader_id=4,
+            is_favorite_space=False,
+            space_level="personal",
+        )
+    enqueue.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -158,3 +203,35 @@ async def test_run_payload_sync_space_file_ready_maps_event():
     event = award.await_args.args[0]
     assert event.file_id == 100
     assert event.space_manager_ids == frozenset({9})
+    assert event.publisher_id == 4
+
+
+@pytest.mark.asyncio
+async def test_run_payload_sync_space_file_ready_processes_file_ids_in_order():
+    """新 payload 的 file_ids 在同一会话按顺序逐个入账。"""
+    award = AsyncMock()
+    facade = SimpleNamespace(on_space_file_ready=award)
+
+    async def fake_run(action):
+        await action(facade)
+
+    with patch.object(hooks, "_run_with_facade", side_effect=fake_run):
+        await hooks._run_payload_sync(
+            {
+                "event_type": "space_file_ready",
+                "tenant_id": 1,
+                "space_id": 10,
+                "space_level": "public",
+                "file_ids": [100, 101, 100],
+                "uploader_id": 4,
+                "is_favorite_space": False,
+                "space_manager_ids": [],
+            }
+        )
+    assert [call.args[0].file_id for call in award.await_args_list] == [100, 101]
+    assert all(call.args[0].publisher_id == 4 for call in award.await_args_list)
+
+
+def test_space_file_ids_from_payload_prefers_file_ids():
+    assert hooks._space_file_ids_from_payload({"file_ids": [2, 3], "file_id": 1}) == [2, 3]
+    assert hooks._space_file_ids_from_payload({"file_id": 9}) == [9]

--- a/src/backend/test/points/test_points_ledger_service.py
+++ b/src/backend/test/points/test_points_ledger_service.py
@@ -7,26 +7,56 @@ from bisheng.points.domain.services.points_ledger_service import PointsLedgerSer
 
 class FakeRepository:
     """以最小内存状态模拟账本仓储。"""
+
     def __init__(self):
         self.account = SimpleNamespace(balance=0, version=0, lifetime_earned=0, lifetime_deducted=0)
         self.logs = {}
         self.today = 0
 
-    async def lock_or_create_account(self, *_): return self.account
-    async def get_log_by_idempotency(self, _, key): return self.logs.get(key)
-    async def sum_earn_today(self, *_): return self.today
+    async def lock_or_create_account(self, *_):
+        return self.account
+
+    async def get_log_by_idempotency(self, _, key):
+        return self.logs.get(key)
+
+    async def sum_earn_today(self, *_):
+        if self.today:
+            return self.today
+        return sum(int(log.delta) for log in self.logs.values() if getattr(log, "direction", "earn") == "earn")
+
     async def append_log(self, log):
         log.id = len(self.logs) + 1
         self.logs[log.idempotency_key] = log
         return log
-    async def add_outbox(self, *_): pass
+
+    async def add_outbox(self, *_):
+        pass
 
 
 async def test_award_skips_entire_delta_when_cap_remaining_is_insufficient():
     repo = FakeRepository()
     repo.today = 8
-    result = await PointsLedgerService(repo).award(tenant_id=1, user_id=1, delta=3, title="测试", rule_code="G1", idempotency_key="a", daily_cap=10)
+    result = await PointsLedgerService(repo).award(
+        tenant_id=1, user_id=1, delta=3, title="测试", rule_code="G1", idempotency_key="a", daily_cap=10
+    )
     assert result.skipped_cap and result.applied_delta == 0 and repo.account.balance == 0
+
+
+async def test_serial_awards_in_same_session_stop_at_daily_cap():
+    """同一账户连续入账时按已写入流水累计，第三笔 30 分应被 60 上限挡住。"""
+    repo = FakeRepository()
+    service = PointsLedgerService(repo)
+    first = await service.award(
+        tenant_id=1, user_id=1, delta=30, title="G1", rule_code="G1", idempotency_key="a", daily_cap=60
+    )
+    second = await service.award(
+        tenant_id=1, user_id=1, delta=30, title="G1", rule_code="G1", idempotency_key="b", daily_cap=60
+    )
+    third = await service.award(
+        tenant_id=1, user_id=1, delta=30, title="G1", rule_code="G1", idempotency_key="c", daily_cap=60
+    )
+    assert first.applied_delta == 30 and second.applied_delta == 30
+    assert third.skipped_cap and repo.account.balance == 60
 
 
 async def test_award_is_idempotent():
@@ -39,5 +69,7 @@ async def test_award_is_idempotent():
 
 async def test_deduct_allows_negative_balance():
     repo = FakeRepository()
-    result = await PointsLedgerService(repo).deduct(tenant_id=1, user_id=1, delta=-100, title="违规", rule_code="R1", idempotency_key="d", operator_id=2)
+    result = await PointsLedgerService(repo).deduct(
+        tenant_id=1, user_id=1, delta=-100, title="违规", rule_code="R1", idempotency_key="d", operator_id=2
+    )
     assert result.balance == -100


### PR DESCRIPTION
## Summary
- 日上限 `sum_earn_today` / G3 档位在账户行锁后走 `FOR UPDATE` 当前读；一次上传改为单 Celery 任务内按文件串行入账，避免 RR 并发越过日上限。
- G1/G2/G5/G6：Facade 不再把「发布人」回退成上传人；直传 `add_file` 显式传 `publisher_id=login_user`，hooks/旧队列缺省按直传人=发布人补齐。
- 审批发布仍区分 uploader / publisher；配套单测已更新。

## Test plan
- [ ] `cd src/backend && .venv/bin/pytest test/points/test_points_award_facade.py test/points/test_points_award_hooks.py test/points/test_points_ledger_service.py -q`
- [ ] 直传公共/部门库：规则配上传人或发布人，均给当前操作人且只一笔
- [ ] 审批发布：配发布人给申请人，配上传人给源作者
- [ ] 同用户同规则多文件并发上传：当日合计不超过日上限
- [ ] 上线顺序：先 Worker 再 API（兼容旧 `file_id` payload）


Made with [Cursor](https://cursor.com)