### PR TITLE
fix(evaluation): 修复评估数据集上传的存储型 XSS

### DIFF
--- a/src/backend/bisheng/evaluation/domain/services/evaluation_service.py
+++ b/src/backend/bisheng/evaluation/domain/services/evaluation_service.py
@@ -139,7 +139,7 @@ class EvaluationService:
         file_ext = os.path.basename(file.filename).split(".")[-1]
         file_path = f"evaluation/dataset/{file_id}.{file_ext}"
         minio_client.put_object_sync(
-            bucket_name=minio_client.bucket, object_name=file_path, file=file.file, content_type=file.content_type
+            bucket_name=minio_client.bucket, object_name=file_path, file=file.file, content_type="text/csv"
         )
         return file_name, file_path
 


### PR DESCRIPTION
评估上传接口直接信任客户端传入的 Content-Type 并存入 MinIO，
攻击者可在合法 CSV 中伪造 Content-Type: text/html，
导致 presigned 下载 URL 被浏览器当作 HTML 渲染执行，
形成存储型 XSS（7 天匿名可访问）。

该接口已通过 pd.read_csv + 列名校验确保文件为 CSV，
强制硬编码 content_type="text/csv"。


比如可能通过类似如下链接控制弹窗或者其他行为： https://bisheng.dataelem.com/bisheng/evaluation/dataset/db8ff191e73b41348092bb0154c04ffa.csv?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=minioadmin%2F20260813%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20260813T102817Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=xxx 