### PR TITLE
feat(points): 首页榜同分按最后获得时间，前十含并列

### DIFF
--- a/src/backend/bisheng/core/database/alembic/versions/v2_6_0_f089_points_last_earned_at.py
+++ b/src/backend/bisheng/core/database/alembic/versions/v2_6_0_f089_points_last_earned_at.py
@@ -1,0 +1,96 @@
+# ruff: noqa: RUF002, RUF003
+"""积分账户与排行快照增加最近获得时间，供首页榜同分排序。
+
+Revision ID: f089_points_last_earned_at
+Revises: f088_points_restore_pk_autoincrement
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f089_points_last_earned_at"
+down_revision: str | Sequence[str] | None = "f088_points_restore_pk_autoincrement"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _has_column(bind, table: str, column: str) -> bool:
+    return any(item["name"] == column for item in sa.inspect(bind).get_columns(table))
+
+
+def upgrade() -> None:
+    """账户/快照加 last_earned_at；有流水时从 earn 回填账户字段。"""
+    bind = op.get_bind()
+    if _has_column(bind, "user_point_account", "last_earned_at") is False:
+        op.add_column(
+            "user_point_account",
+            sa.Column(
+                "last_earned_at",
+                sa.DateTime(),
+                nullable=True,
+                comment="最近一次获得积分时间（仅 earn 更新；榜单同分排序用）",
+            ),
+        )
+    if _has_column(bind, "point_rank_snapshot", "last_earned_at") is False:
+        op.add_column(
+            "point_rank_snapshot",
+            sa.Column(
+                "last_earned_at",
+                sa.DateTime(),
+                nullable=True,
+                comment="刷榜时账户最近一次获得积分时间（同分排序；空则排后）",
+            ),
+        )
+    if not (
+        _has_column(bind, "user_point_account", "last_earned_at") and _has_column(bind, "user_point_log", "occurred_at")
+    ):
+        return
+    dialect = bind.dialect.name
+    if dialect in ("mysql", "mariadb"):
+        # 回填：每用户最近一笔获得流水时间（direction=earn）。
+        bind.execute(
+            sa.text(
+                """
+                UPDATE user_point_account AS a
+                INNER JOIN (
+                    SELECT tenant_id, user_id, MAX(occurred_at) AS earned_at
+                    FROM user_point_log
+                    WHERE direction = 'earn'
+                    GROUP BY tenant_id, user_id
+                ) AS src
+                    ON a.tenant_id = src.tenant_id AND a.user_id = src.user_id
+                SET a.last_earned_at = src.earned_at
+                WHERE a.last_earned_at IS NULL
+                """
+            )
+        )
+        return
+    # 达梦等：相关子查询回填（无 MySQL JOIN UPDATE 语法）。
+    bind.execute(
+        sa.text(
+            """
+            UPDATE user_point_account
+            SET last_earned_at = (
+                SELECT MAX(occurred_at)
+                FROM user_point_log
+                WHERE user_point_log.tenant_id = user_point_account.tenant_id
+                  AND user_point_log.user_id = user_point_account.user_id
+                  AND user_point_log.direction = 'earn'
+            )
+            WHERE last_earned_at IS NULL
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    """去掉最近获得时间列（榜单同分将回退为仅 user_id）。"""
+    bind = op.get_bind()
+    if _has_column(bind, "point_rank_snapshot", "last_earned_at"):
+        op.drop_column("point_rank_snapshot", "last_earned_at")
+    if _has_column(bind, "user_point_account", "last_earned_at"):
+        op.drop_column("user_point_account", "last_earned_at")

--- a/src/backend/bisheng/points/domain/models/points.py
+++ b/src/backend/bisheng/points/domain/models/points.py
@@ -71,6 +71,14 @@ class UserPointAccount(SQLModelSerializable, table=True):
             comment="更新时间",
         ),
     )
+    last_earned_at: datetime | None = Field(
+        default=None,
+        sa_column=Column(
+            DateTime,
+            nullable=True,
+            comment="最近一次获得积分时间（仅 earn 更新；榜单同分排序用）",
+        ),
+    )
     __table_args__ = (
         UniqueConstraint("tenant_id", "user_id", name="uk_upa_tenant_user"),
         Index("ix_upa_tenant_balance", "tenant_id", "balance"),
@@ -350,6 +358,14 @@ class PointRankSnapshot(SQLModelSerializable, table=True):
     dept_id: int | None = Field(
         default=None,
         sa_column=Column(Integer, comment="用户所属部门桶ID（展示用）"),
+    )
+    last_earned_at: datetime | None = Field(
+        default=None,
+        sa_column=Column(
+            DateTime,
+            nullable=True,
+            comment="刷榜时账户最近一次获得积分时间（同分排序；空则排后）",
+        ),
     )
     refreshed_at: datetime | None = Field(
         default=None,

--- a/src/backend/bisheng/points/domain/repositories/points_repository.py
+++ b/src/backend/bisheng/points/domain/repositories/points_repository.py
@@ -325,7 +325,11 @@ class PointsRepository:
         *,
         limit: int = 10,
     ) -> list[PointRankSnapshot]:
-        """读取 TOP N 排名快照。"""
+        """读取公司/部门桶快照，按首页榜排序键返回。
+
+        排序：分降序 → 最近获得时间升序（空在后）→ user_id。
+        ``limit`` 保留兼容；截断（算法甲）由查询服务按名次深度处理。
+        """
         stmt = select(PointRankSnapshot).where(
             PointRankSnapshot.tenant_id == tenant_id,
             PointRankSnapshot.period == period,
@@ -336,15 +340,18 @@ class PointsRepository:
             stmt = stmt.where(PointRankSnapshot.scope_id.is_(None))
         else:
             stmt = stmt.where(PointRankSnapshot.scope_id == scope_id)
-        # TOP N 按人数截断：同分同名次时仍按分值降序、user_id 升序取前 N 人。
+        # MySQL/DM8：用 IS NULL 分组把空获得时间排到同分末尾，避免 nulls_last 方言差异。
         rows = (
             await self.session.exec(
                 stmt.order_by(
                     PointRankSnapshot.period_score.desc(),
+                    PointRankSnapshot.last_earned_at.is_(None),
+                    PointRankSnapshot.last_earned_at.asc(),
                     PointRankSnapshot.user_id.asc(),
-                ).limit(limit)
+                )
             )
         ).all()
+        _ = limit
         return list(rows)
 
     async def latest_rank_refreshed_at(self, tenant_id: int, period: str, period_key: str) -> datetime | None:
@@ -615,6 +622,7 @@ class PointsRepository:
                 "period_score": row.period_score,
                 "balance": row.balance,
                 "dept_id": row.dept_id,
+                "last_earned_at": row.last_earned_at,
                 "refreshed_at": row.refreshed_at,
             }
             for row in rows

--- a/src/backend/bisheng/points/domain/services/points_ledger_service.py
+++ b/src/backend/bisheng/points/domain/services/points_ledger_service.py
@@ -146,12 +146,14 @@ class PointsLedgerService:
         balance = account.balance + delta
         account.balance = balance
         account.version += 1
-        if delta > 0:
-            account.lifetime_earned += delta
-        else:
-            account.lifetime_deducted += -delta
         # MySQL 严格模式下 ORM 传 None 不会回落到 server_default，需显式写入业务时间。
         occurred_at = datetime.now(SHANGHAI).replace(tzinfo=None)
+        if delta > 0:
+            account.lifetime_earned += delta
+            # 仅获得刷新；扣分不改，供首页榜同分「最后一次获得更早优先」。
+            account.last_earned_at = occurred_at
+        else:
+            account.lifetime_deducted += -delta
         log = await self.repository.append_log(
             UserPointLog(
                 tenant_id=tenant_id,

--- a/src/backend/bisheng/points/domain/services/points_query_service.py
+++ b/src/backend/bisheng/points/domain/services/points_query_service.py
@@ -170,7 +170,7 @@ class PointsQueryService:
         return [self._log_response(r) for r in rows], total
 
     async def leaderboard(self, tenant_id: int, period: str, user_id: int) -> PointLeaderboardResponse:
-        """读取当前用户所属公司的小时快照 TOP10；无公司则空榜（AC-15）。"""
+        """读取当前用户所属公司的小时快照前十（算法甲含并列）；无公司则空榜（AC-15）。"""
         now = datetime.now(SHANGHAI)
         if period == "year":
             period_key = now.strftime("%Y")
@@ -183,7 +183,13 @@ class PointsQueryService:
         refreshed = await self.repository.latest_rank_refreshed_at(tenant_id, period, period_key)
         if company_id is None:
             return PointLeaderboardResponse(period=period, refreshed_at=refreshed, items=[])
-        rows = await self.repository.list_top_ranks(tenant_id, period, "global", company_id, period_key, limit=10)
+        from bisheng.points.domain.services.points_rank_service import select_top_n_with_score_ties
+
+        # 先取整桶排序结果，再按第 10 名分值阈值纳入全部并列（人数可 >10）。
+        bucket_rows = await self.repository.list_top_ranks(
+            tenant_id, period, "global", company_id, period_key, limit=10
+        )
+        rows = select_top_n_with_score_ties(bucket_rows, top_n=10)
         user_ids = [int(r.user_id) for r in rows]
         name_by_user, dept_by_user = await self._leaderboard_display_maps(user_ids)
         items = [

--- a/src/backend/bisheng/points/domain/services/points_rank_service.py
+++ b/src/backend/bisheng/points/domain/services/points_rank_service.py
@@ -36,9 +36,7 @@ def year_bounds(now: datetime | None = None) -> tuple[datetime, datetime]:
     if current.tzinfo is not None:
         current = current.astimezone(SHANGHAI)
     start = current.replace(month=1, day=1, hour=0, minute=0, second=0, microsecond=0, tzinfo=None)
-    end = current.replace(
-        year=current.year + 1, month=1, day=1, hour=0, minute=0, second=0, microsecond=0, tzinfo=None
-    )
+    end = current.replace(year=current.year + 1, month=1, day=1, hour=0, minute=0, second=0, microsecond=0, tzinfo=None)
     return start, end
 
 
@@ -90,18 +88,28 @@ def build_ranked_rows(
     dept_ids: dict[int, int | None],
     exclude_user_ids: set[int],
     refreshed_at: datetime,
+    last_earned_at: dict[int, datetime | None] | None = None,
 ) -> list[PointRankSnapshot]:
-    """按 period_score 降序生成快照行；同分稠密同名次，列表序按 user_id 稳定。"""
+    """按分降序生成快照；同分看 last_earned_at 升序再 user_id；名次仍按分稠密并列。"""
+    earned_map = last_earned_at or {}
     candidates = [
-        (user_id, score)
+        (user_id, score, earned_map.get(user_id))
         for user_id, score in scores.items()
         if user_id not in exclude_user_ids
     ]
-    candidates.sort(key=lambda item: (-item[1], item[0]))
+    # 无获得时间的排在同分末尾，再比 user_id。
+    candidates.sort(
+        key=lambda item: (
+            -int(item[1]),
+            item[2] is None,
+            item[2] or datetime.min,
+            int(item[0]),
+        )
+    )
     rows: list[PointRankSnapshot] = []
     prev_score: int | None = None
     rank_no = 0
-    for user_id, score in candidates:
+    for user_id, score, earned_at in candidates:
         score_i = int(score)
         # 稠密名次：分不同才 +1；同分共用上一名次（100,100,90 → 1,1,2）。
         if prev_score is None or score_i != prev_score:
@@ -119,10 +127,24 @@ def build_ranked_rows(
                 period_score=score_i,
                 balance=int(balances.get(user_id, 0)),
                 dept_id=dept_ids.get(user_id),
+                last_earned_at=earned_at,
                 refreshed_at=refreshed_at,
             )
         )
     return rows
+
+
+def select_top_n_with_score_ties(rows: list, *, top_n: int = 10) -> list:
+    """算法甲：按已排序列表取第 N 人的分作阈值，纳入所有 ≥ 该分的行。
+
+    ``rows`` 须已按 period_score 降序（同分 last_earned_at / user_id 已排好）。
+    """
+    if top_n <= 0 or not rows:
+        return []
+    if len(rows) <= top_n:
+        return list(rows)
+    threshold = int(rows[top_n - 1].period_score)
+    return [row for row in rows if int(row.period_score) >= threshold]
 
 
 class PointsRankService:
@@ -165,6 +187,7 @@ class PointsRankService:
         accounts = await repo.list_accounts(tenant_id)
         balances = {int(a.user_id): int(a.balance) for a in accounts}
         lifetime_earned = {int(a.user_id): int(a.lifetime_earned) for a in accounts}
+        last_earned_at = {int(a.user_id): getattr(a, "last_earned_at", None) for a in accounts}
         if not balances:
             return {"tenant_id": tenant_id, "rows": 0}
 
@@ -174,14 +197,10 @@ class PointsRankService:
         year_start, year_end = year_bounds(now)
         month_scores = await repo.sum_deltas_by_user(tenant_id, start=month_start, end=month_end)
         year_scores = await repo.sum_deltas_by_user(tenant_id, start=year_start, end=year_end)
-        all_scores = {
-            user_id: earned for user_id, earned in lifetime_earned.items() if earned > 0
-        }
+        all_scores = {user_id: earned for user_id, earned in lifetime_earned.items() if earned > 0}
 
         exclude = await self._load_super_admin_ids()
-        company_by_user, bucket_by_user = await self._load_company_and_dept_buckets(
-            list(balances.keys())
-        )
+        company_by_user, bucket_by_user = await self._load_company_and_dept_buckets(list(balances.keys()))
         company_ids = sorted({cid for cid in company_by_user.values() if cid is not None})
 
         written = 0
@@ -214,6 +233,7 @@ class PointsRankService:
                         dept_ids=bucket_by_user,
                         exclude_user_ids=set(),
                         refreshed_at=refreshed_at,
+                        last_earned_at=last_earned_at,
                     )
                 )
 
@@ -236,6 +256,7 @@ class PointsRankService:
                             dept_ids=bucket_by_user,
                             exclude_user_ids=set(),
                             refreshed_at=refreshed_at,
+                            last_earned_at=last_earned_at,
                         )
                     )
 
@@ -261,9 +282,7 @@ class PointsRankService:
         from sqlmodel import select
 
         async with get_async_db_session() as session:
-            rows = (
-                await session.exec(select(UserRole.user_id).where(UserRole.role_id == AdminRole))
-            ).all()
+            rows = (await session.exec(select(UserRole.user_id).where(UserRole.role_id == AdminRole))).all()
         return {int(r[0] if isinstance(r, tuple) else r) for r in rows}
 
     @staticmethod

--- a/src/backend/test/points/test_points_leaderboard.py
+++ b/src/backend/test/points/test_points_leaderboard.py
@@ -12,11 +12,7 @@ from bisheng.points.domain.services.points_query_service import PointsQueryServi
 async def test_leaderboard_enriches_user_and_dept_names():
     repo = SimpleNamespace(
         list_top_ranks=AsyncMock(
-            return_value=[
-                SimpleNamespace(
-                    rank_no=1, user_id=10, balance=100, period_score=40, dept_id=2
-                )
-            ]
+            return_value=[SimpleNamespace(rank_no=1, user_id=10, balance=100, period_score=40, dept_id=2)]
         ),
         latest_rank_refreshed_at=AsyncMock(return_value=None),
     )
@@ -61,3 +57,36 @@ async def test_leaderboard_empty_when_user_has_no_company():
 
     assert out.items == []
     repo.list_top_ranks.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_leaderboard_keeps_all_ties_at_tenth_score():
+    """第 10 名分值并列时返回超过 10 人，顺序与仓储一致。"""
+    bucket = [
+        SimpleNamespace(rank_no=i, user_id=i, balance=i, period_score=score, dept_id=1)
+        for i, score in enumerate(
+            [100, 90, 80, 70, 60, 50, 40, 30, 20, 10, 10, 10],
+            start=1,
+        )
+    ]
+    repo = SimpleNamespace(
+        list_top_ranks=AsyncMock(return_value=bucket),
+        latest_rank_refreshed_at=AsyncMock(return_value=None),
+    )
+    service = PointsQueryService(session=None, repository=repo, ledger=None)
+    with (
+        patch.object(
+            PointsQueryService,
+            "_resolve_user_company_id",
+            AsyncMock(return_value=100),
+        ),
+        patch.object(
+            PointsQueryService,
+            "_leaderboard_display_maps",
+            AsyncMock(return_value=({i: str(i) for i in range(1, 13)}, dict.fromkeys(range(1, 13), "部"))),
+        ),
+    ):
+        out = await service.leaderboard(1, "month", user_id=1)
+
+    assert len(out.items) == 12
+    assert [item.user_id for item in out.items] == list(range(1, 13))

--- a/src/backend/test/points/test_points_ledger_service.py
+++ b/src/backend/test/points/test_points_ledger_service.py
@@ -73,3 +73,18 @@ async def test_deduct_allows_negative_balance():
         tenant_id=1, user_id=1, delta=-100, title="违规", rule_code="R1", idempotency_key="d", operator_id=2
     )
     assert result.balance == -100
+
+
+async def test_award_sets_last_earned_at_deduct_does_not():
+    """获得刷新 last_earned_at；扣分保持原值。"""
+    repo = FakeRepository()
+    service = PointsLedgerService(repo)
+    await service.award(tenant_id=1, user_id=1, delta=10, title="赚", rule_code="G1", idempotency_key="e1")
+    earned_at = repo.account.last_earned_at
+    assert earned_at is not None
+    await service.deduct(
+        tenant_id=1, user_id=1, delta=-3, title="扣", rule_code="R1", idempotency_key="d1", operator_id=2
+    )
+    assert repo.account.last_earned_at == earned_at
+    await service.award(tenant_id=1, user_id=1, delta=5, title="再赚", rule_code="G1", idempotency_key="e2")
+    assert repo.account.last_earned_at >= earned_at

--- a/src/backend/test/points/test_points_rank_service.py
+++ b/src/backend/test/points/test_points_rank_service.py
@@ -13,6 +13,7 @@ from bisheng.points.domain.services.points_rank_service import (
     period_keys,
     resolve_company_id,
     resolve_dept_bucket_id,
+    select_top_n_with_score_ties,
 )
 
 SHANGHAI = ZoneInfo("Asia/Shanghai")
@@ -60,8 +61,10 @@ def test_resolve_dept_bucket_none_when_unlabeled():
 
 
 def test_build_ranked_rows_dense_ties_and_excludes_admins():
-    """同分稠密同名次：100,100,50 → rank 1,1,2；列表序按 user_id。"""
+    """同分稠密同名次：100,100,50 → rank 1,1,2；同分按 last_earned_at 再 user_id。"""
     refreshed = datetime(2026, 8, 7, 5, 0)
+    earlier = datetime(2026, 8, 1, 10, 0)
+    later = datetime(2026, 8, 2, 10, 0)
     rows = build_ranked_rows(
         tenant_id=1,
         period="month",
@@ -73,12 +76,29 @@ def test_build_ranked_rows_dense_ties_and_excludes_admins():
         dept_ids={10: 2, 11: 2, 12: None, 99: 2},
         exclude_user_ids={99},
         refreshed_at=refreshed,
+        last_earned_at={10: later, 11: earlier, 12: earlier},
     )
-    assert [r.user_id for r in rows] == [10, 11, 12]
+    # 同分 100：先获得的 user 11 排在 user 10 前。
+    assert [r.user_id for r in rows] == [11, 10, 12]
     assert [r.rank_no for r in rows] == [1, 1, 2]
     assert rows[0].period_score == 100
     assert rows[0].scope_id == 100
+    assert rows[0].last_earned_at == earlier
     assert rows[2].dept_id is None
+
+
+def test_select_top_n_with_score_ties_includes_boundary_ties():
+    """算法甲：第 10 名分值并列者全部纳入，人数可超过 10。"""
+    rows = [
+        SimpleNamespace(user_id=i, period_score=score)
+        for i, score in enumerate(
+            [100, 90, 80, 70, 60, 50, 40, 30, 20, 10, 10, 10, 5],
+            start=1,
+        )
+    ]
+    selected = select_top_n_with_score_ties(rows, top_n=10)
+    assert [r.user_id for r in selected] == list(range(1, 13))
+    assert all(int(r.period_score) >= 10 for r in selected)
 
 
 @pytest.mark.asyncio
@@ -100,12 +120,8 @@ async def test_refresh_scopes_by_company_and_trims_inactive():
     repo = SimpleNamespace(
         list_accounts=AsyncMock(return_value=accounts),
         sum_deltas_by_user=AsyncMock(side_effect=[month_scores, year_scores]),
-        clear_period_rank_snapshots=AsyncMock(
-            side_effect=lambda *a, **_k: cleared.append(a) or None
-        ),
-        bulk_insert_rank_snapshots=AsyncMock(
-            side_effect=lambda rows: inserted.append(list(rows)) or len(rows)
-        ),
+        clear_period_rank_snapshots=AsyncMock(side_effect=lambda *a, **_k: cleared.append(a) or None),
+        bulk_insert_rank_snapshots=AsyncMock(side_effect=lambda rows: inserted.append(list(rows)) or len(rows)),
     )
 
     with (
@@ -151,9 +167,7 @@ async def test_refresh_no_company_writes_empty_period_batches():
         list_accounts=AsyncMock(return_value=accounts),
         sum_deltas_by_user=AsyncMock(side_effect=[{1: 10}, {1: 20}]),
         clear_period_rank_snapshots=AsyncMock(),
-        bulk_insert_rank_snapshots=AsyncMock(
-            side_effect=lambda rows: inserted.append(list(rows)) or len(rows)
-        ),
+        bulk_insert_rank_snapshots=AsyncMock(side_effect=lambda rows: inserted.append(list(rows)) or len(rows)),
     )
     with (
         patch.object(PointsRankService, "_load_super_admin_ids", AsyncMock(return_value=set())),


### PR DESCRIPTION
## Summary
- 账户/快照增加 `last_earned_at`（仅获得积分时更新），同分排序：分降序 → 最后获得越早越前 → `user_id`。
- 首页 leaderboard：奖牌取排序前 3 人；列表按算法甲（第 10 名分值阈值）返回完整前十（人数可 >10）。
- 迁移 `f089_points_last_earned_at` 含 earn 流水回填；上线后需刷一次排行快照。

## Test plan
- [ ] `alembic upgrade` 到 `f089`（或等价加列）
- [ ] `POST /api/v1/points/admin/jobs/refresh-rank-snapshots?tenant_id=1`
- [ ] 本月/本年/总榜：同分时最后获得更早者靠前；领奖台始终 3 人
- [ ] 第 10 名分值并列时接口返回人数 >10
- [ ] 相关单测：`test_points_rank_service` / `test_points_leaderboard` / `test_points_ledger_service`


Made with [Cursor](https://cursor.com)