### PR TITLE
feat(points): mom delta, rule display names, admin dept fixes

### DIFF
--- a/src/backend/bisheng/core/database/alembic/versions/v2_6_0_f090_points_rule_display_names.py
+++ b/src/backend/bisheng/core/database/alembic/versions/v2_6_0_f090_points_rule_display_names.py
@@ -1,0 +1,75 @@
+# ruff: noqa: RUF002, RUF003
+"""按产品文案更新积分规则展示名（G1–G7、R1–R3）。
+
+Revision ID: f090_points_rule_display_names
+Revises: f089_points_last_earned_at
+
+仅改 point_rule.name；不改 rule_code / 分值 / 启停。
+按 rule_code 全租户覆盖写入（含运营改过的同编码名称）。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f090_points_rule_display_names"
+down_revision: str | Sequence[str] | None = "f089_points_last_earned_at"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# 产品给定展示名；G3/G5/G6 与旧种子相同，一并幂等写回。
+_RULE_NAMES: dict[str, str] = {
+    "G1": "发布/上传到公共库",
+    "G2": "发布/上传到部门库",
+    "G3": "文档被收藏",
+    "G4": "问答被采纳",
+    "G5": "上传团队库文档",
+    "G6": "上传科室库文档",
+    "G7": "知识分享",
+    "R1": "色情低俗/暴力违法",
+    "R2": "不当言论",
+    "R3": "其他违反规范",
+}
+
+_OLD_RULE_NAMES: dict[str, str] = {
+    "G1": "上传公共库文档",
+    "G2": "上传部门库文档",
+    "G3": "文档被收藏",
+    "G4": "回答被采纳",
+    "G5": "上传团队库文档",
+    "G6": "上传科室库文档",
+    "G7": "文档库间分享",
+    "R1": "违规扣减 R1",
+    "R2": "违规扣减 R2",
+    "R3": "违规扣减 R3",
+}
+
+
+def _table_exists(bind, name: str) -> bool:
+    """跨库检查表是否存在。"""
+    return name in sa.inspect(bind).get_table_names()
+
+
+def _apply_names(names: dict[str, str]) -> None:
+    """按编码更新已有规则名称；缺表则跳过。"""
+    bind = op.get_bind()
+    if not _table_exists(bind, "point_rule"):
+        return
+    for code, name in names.items():
+        bind.execute(
+            sa.text("UPDATE point_rule SET name = :name WHERE rule_code = :code"),
+            {"name": name, "code": code},
+        )
+
+
+def upgrade() -> None:
+    """把 G1–G7、R1–R3 的展示名写成产品文案。"""
+    _apply_names(_RULE_NAMES)
+
+
+def downgrade() -> None:
+    """恢复本迁移前的种子展示名。"""
+    _apply_names(_OLD_RULE_NAMES)

--- a/src/backend/bisheng/points/domain/constants/seed_rules.py
+++ b/src/backend/bisheng/points/domain/constants/seed_rules.py
@@ -14,7 +14,7 @@ SEED_RULES = [
     {
         "rule_code": "G1",
         "rule_type": "earn",
-        "name": "上传公共库文档",
+        "name": "发布/上传到公共库",
         "score_expr": {"mode": "fixed", "score": 3},
         "daily_cap": 15,
         "beneficiary": "uploader",
@@ -24,7 +24,7 @@ SEED_RULES = [
     {
         "rule_code": "G2",
         "rule_type": "earn",
-        "name": "上传部门库文档",
+        "name": "发布/上传到部门库",
         "score_expr": {"mode": "fixed", "score": 2},
         "daily_cap": 10,
         "beneficiary": "uploader",
@@ -53,7 +53,7 @@ SEED_RULES = [
     {
         "rule_code": "G4",
         "rule_type": "earn",
-        "name": "回答被采纳",
+        "name": "问答被采纳",
         "score_expr": {"mode": "fixed", "score": 3},
         "daily_cap": 15,
         "beneficiary": "answerer",
@@ -83,7 +83,7 @@ SEED_RULES = [
     {
         "rule_code": "G7",
         "rule_type": "earn",
-        "name": "文档库间分享",
+        "name": "知识分享",
         "score_expr": {"mode": "fixed", "score": 2},
         "daily_cap": 10,
         "beneficiary": "uploader",
@@ -91,19 +91,36 @@ SEED_RULES = [
         "sort_order": 7,
     },
     # --- 扣减 R*（系统默认）---
-    *[
-        {
-            "rule_code": f"R{i}",
-            "rule_type": "deduct",
-            "name": f"违规扣减 R{i}",
-            "score_expr": {"mode": "fixed", "score": 100},
-            "daily_cap": None,
-            "beneficiary": None,
-            "status": "enabled",
-            "sort_order": 20 + i,
-        }
-        for i in range(1, 4)
-    ],
+    {
+        "rule_code": "R1",
+        "rule_type": "deduct",
+        "name": "色情低俗/暴力违法",
+        "score_expr": {"mode": "fixed", "score": 100},
+        "daily_cap": None,
+        "beneficiary": None,
+        "status": "enabled",
+        "sort_order": 21,
+    },
+    {
+        "rule_code": "R2",
+        "rule_type": "deduct",
+        "name": "不当言论",
+        "score_expr": {"mode": "fixed", "score": 100},
+        "daily_cap": None,
+        "beneficiary": None,
+        "status": "enabled",
+        "sort_order": 22,
+    },
+    {
+        "rule_code": "R3",
+        "rule_type": "deduct",
+        "name": "其他违反规范",
+        "score_expr": {"mode": "fixed", "score": 100},
+        "daily_cap": None,
+        "beneficiary": None,
+        "status": "enabled",
+        "sort_order": 23,
+    },
     # --- 月奖 M*：仅 M1/M4/M6 默认启用 ---
     {
         "rule_code": "M1",

--- a/src/backend/bisheng/points/domain/repositories/points_repository.py
+++ b/src/backend/bisheng/points/domain/repositories/points_repository.py
@@ -264,6 +264,20 @@ class PointsRepository:
         ).one()
         return int(value[0] if isinstance(value, tuple) else value or 0)
 
+    async def sum_tenant_earn(self, tenant_id: int, start: datetime, end: datetime) -> int:
+        """汇总租户在时间窗内的 earn 发放合计。"""
+        value = (
+            await self.session.exec(
+                select(func.coalesce(func.sum(UserPointLog.delta), 0)).where(
+                    UserPointLog.tenant_id == tenant_id,
+                    UserPointLog.direction == "earn",
+                    UserPointLog.occurred_at >= start,
+                    UserPointLog.occurred_at < end,
+                )
+            )
+        ).one()
+        return int(value[0] if isinstance(value, tuple) else value or 0)
+
     async def sum_total_balance(self, tenant_id: int) -> int:
         """租户当前余额合计。"""
         value = (

--- a/src/backend/bisheng/points/domain/schemas/points_schema.py
+++ b/src/backend/bisheng/points/domain/schemas/points_schema.py
@@ -83,6 +83,7 @@ class PointOverviewResponse(BaseModel):
     total_issued: int
     total_balance: int
     total_violation_deducted: int
+    total_issued_mom: int = 0
 
 
 class PointAdminUserItem(BaseModel):

--- a/src/backend/bisheng/points/domain/services/points_query_service.py
+++ b/src/backend/bisheng/points/domain/services/points_query_service.py
@@ -221,11 +221,12 @@ class PointsQueryService:
         """批量解析用户名与积分部门名称。
 
         部门名取主部门沿 path 向上最近的 ``org_level=dept`` 节点，与部门榜桶一致；
-        找不到该标签时不回退叶子部门，调用方按 ``—`` 展示。
+        展示名优先 ``short_name``。找不到该标签时不回退叶子/主部门，调用方按 ``—`` 展示（AC-22）。
         """
         if not user_ids:
             return {}, {}
         from bisheng.database.models.department import DepartmentDao, UserDepartmentDao
+        from bisheng.department.domain.services.department_display_service import get_department_display_name
         from bisheng.points.domain.services.points_rank_service import resolve_dept_bucket_id
         from bisheng.user.domain.models.user import UserDao
 
@@ -248,9 +249,14 @@ class PointsQueryService:
         for uid, primary in primary_map.items():
             bucket_id = resolve_dept_bucket_id(primary, dept_by_id)
             node = dept_by_id.get(bucket_id) if bucket_id is not None else None
-            name = getattr(node, "name", None) if node is not None else None
-            if name:
-                dept_by_user[int(uid)] = str(name)
+            if node is None:
+                continue
+            display = get_department_display_name(
+                str(getattr(node, "name", "") or ""),
+                getattr(node, "short_name", None),
+            ).strip()
+            if display:
+                dept_by_user[int(uid)] = display
         return name_by_user, dept_by_user
 
     async def overview(self, tenant_id: int, user: UserPayload) -> PointOverviewResponse:
@@ -264,10 +270,12 @@ class PointsQueryService:
         cached = await self._overview_cache_get(cache_key)
         if cached is not None:
             return PointOverviewResponse(**cached)
+        month_start, month_end = self._month_bounds()
         payload = {
             "total_issued": await self.repository.sum_total_issued(tenant_id),
             "total_balance": await self.repository.sum_total_balance(tenant_id),
             "total_violation_deducted": await self.repository.sum_violation_deducted(tenant_id),
+            "total_issued_mom": await self.repository.sum_tenant_earn(tenant_id, month_start, month_end),
         }
         await self._overview_cache_set(cache_key, payload)
         return PointOverviewResponse(**payload)
@@ -408,7 +416,11 @@ class PointsQueryService:
         month_deducted = abs(
             await self.repository.sum_user_delta(tenant_id, uid, direction="deduct", start=month_start, end=month_end)
         )
-        role_label = await self._resolve_user_role_label(uid)
+        from bisheng.points.domain.constants.admin_user_type import resolve_user_types_for_admin_list
+
+        # 与列表「角色」列同源：积分用户类型（空间管理角色），不用 RBAC 角色名。
+        user_type_by_user = await resolve_user_types_for_admin_list([uid])
+        role_label = user_type_by_user.get(uid, "普通用户")
 
         logs, logs_total = await self.my_logs(
             tenant_id,
@@ -432,7 +444,10 @@ class PointsQueryService:
 
     @staticmethod
     async def _resolve_user_role_label(user_id: int) -> str:
-        """解析用户角色展示名；无角色时默认「普通用户」。"""
+        """解析用户角色展示名；无角色时默认「普通用户」。
+
+        管理端详情已改用 ``resolve_user_types_for_admin_list``；本方法保留给其他调用方。
+        """
         try:
             from bisheng.database.models.role import RoleDao
             from bisheng.user.domain.models.user_role import UserRoleDao

--- a/src/backend/test/points/test_points_admin_lists.py
+++ b/src/backend/test/points/test_points_admin_lists.py
@@ -165,10 +165,9 @@ async def test_admin_user_detail_returns_summary_and_filtered_logs():
             "_leaderboard_display_maps",
             AsyncMock(return_value=({7: "张三"}, {7: "技术研发部"})),
         ),
-        patch.object(
-            PointsQueryService,
-            "_resolve_user_role_label",
-            AsyncMock(return_value="普通用户"),
+        patch(
+            "bisheng.points.domain.constants.admin_user_type.resolve_user_types_for_admin_list",
+            AsyncMock(return_value={7: "普通用户"}),
         ),
     ):
         out = await service.admin_user_detail(

--- a/src/backend/test/points/test_points_leaderboard.py
+++ b/src/backend/test/points/test_points_leaderboard.py
@@ -62,11 +62,11 @@ async def test_leaderboard_empty_when_user_has_no_company():
 @pytest.mark.asyncio
 async def test_display_maps_uses_org_level_dept_not_leaf():
     """挂在班组叶子上时，展示名取向上最近的 org_level=dept，不回退叶子名。"""
-    leaf = SimpleNamespace(id=94, path="/1/54/55/58/67/94/", name="五级积分部门1-1", org_level="squad")
-    dept = SimpleNamespace(id=55, path="/1/54/55/", name="二级积分部门1", org_level="dept")
-    company = SimpleNamespace(id=54, path="/1/54/", name="测试积分部门", org_level="company")
-    office = SimpleNamespace(id=58, path="/1/54/55/58/", name="三级积分部门1", org_level="office")
-    squad = SimpleNamespace(id=67, path="/1/54/55/58/67/", name="四级积分部门1", org_level="squad")
+    leaf = SimpleNamespace(id=94, path="/1/54/55/58/67/94/", name="五级积分部门1-1", org_level="squad", short_name=None)
+    dept = SimpleNamespace(id=55, path="/1/54/55/", name="二级积分部门1", org_level="dept", short_name=None)
+    company = SimpleNamespace(id=54, path="/1/54/", name="测试积分部门", org_level="company", short_name=None)
+    office = SimpleNamespace(id=58, path="/1/54/55/58/", name="三级积分部门1", org_level="office", short_name=None)
+    squad = SimpleNamespace(id=67, path="/1/54/55/58/67/", name="四级积分部门1", org_level="squad", short_name=None)
 
     with (
         patch(
@@ -91,8 +91,8 @@ async def test_display_maps_uses_org_level_dept_not_leaf():
 @pytest.mark.asyncio
 async def test_display_maps_omits_dept_when_no_org_level_dept():
     """path 上没有 dept 标签时不回退叶子名，交给调用方展示 —。"""
-    leaf = SimpleNamespace(id=9, path="/1/9/", name="未打标叶子", org_level=None)
-    root = SimpleNamespace(id=1, path="/1/", name="默认组织", org_level=None)
+    leaf = SimpleNamespace(id=9, path="/1/9/", name="未打标叶子", org_level=None, short_name=None)
+    root = SimpleNamespace(id=1, path="/1/", name="默认组织", org_level=None, short_name=None)
 
     with (
         patch(
@@ -112,6 +112,32 @@ async def test_display_maps_omits_dept_when_no_org_level_dept():
 
     assert names[7] == "nobody"
     assert 7 not in depts
+
+
+@pytest.mark.asyncio
+async def test_display_maps_prefers_short_name_for_dept_bucket():
+    """有 dept 桶时展示名优先 short_name。"""
+    leaf = SimpleNamespace(id=94, path="/1/54/55/94/", name="叶子", org_level="squad", short_name=None)
+    dept = SimpleNamespace(id=55, path="/1/54/55/", name="二级积分部门1", org_level="dept", short_name="质量部")
+    company = SimpleNamespace(id=54, path="/1/54/", name="公司", org_level="company", short_name=None)
+
+    with (
+        patch(
+            "bisheng.user.domain.models.user.UserDao.aget_user_by_ids",
+            AsyncMock(return_value=[SimpleNamespace(user_id=423, user_name="gzx")]),
+        ),
+        patch(
+            "bisheng.database.models.department.UserDepartmentDao.get_primary_department_map_by_user_ids",
+            return_value={423: leaf},
+        ),
+        patch(
+            "bisheng.database.models.department.DepartmentDao.aget_by_ids",
+            AsyncMock(return_value=[company, dept]),
+        ),
+    ):
+        _, depts = await PointsQueryService._leaderboard_display_maps([423])
+
+    assert depts[423] == "质量部"
 
 
 @pytest.mark.asyncio

--- a/src/backend/test/points/test_points_overview_cache.py
+++ b/src/backend/test/points/test_points_overview_cache.py
@@ -21,6 +21,7 @@ def _repo() -> SimpleNamespace:
         sum_total_issued=AsyncMock(return_value=100),
         sum_total_balance=AsyncMock(return_value=70),
         sum_violation_deducted=AsyncMock(return_value=-30),
+        sum_tenant_earn=AsyncMock(return_value=42),
     )
 
 
@@ -47,12 +48,15 @@ async def test_overview_caches_and_serves_second_call_from_cache():
     assert first.total_issued == 100
     assert first.total_balance == 70
     assert first.total_violation_deducted == -30
+    assert first.total_issued_mom == 42
     assert second == first
-    # 第二次必须来自缓存：三个聚合各自只被调用一次。
+    # 第二次必须来自缓存：四个聚合各自只被调用一次。
     assert repo.sum_total_issued.await_count == 1
     assert repo.sum_total_balance.await_count == 1
     assert repo.sum_violation_deducted.await_count == 1
+    assert repo.sum_tenant_earn.await_count == 1
     assert store[f"{mod.OVERVIEW_CACHE_PREFIX}1"]["total_issued"] == 100
+    assert store[f"{mod.OVERVIEW_CACHE_PREFIX}1"]["total_issued_mom"] == 42
 
 
 @pytest.mark.asyncio
@@ -77,6 +81,7 @@ async def test_overview_cache_is_scoped_per_tenant():
 
     assert set(store) == {f"{mod.OVERVIEW_CACHE_PREFIX}1", f"{mod.OVERVIEW_CACHE_PREFIX}2"}
     assert repo.sum_total_issued.await_count == 2
+    assert repo.sum_tenant_earn.await_count == 2
 
 
 @pytest.mark.asyncio
@@ -91,7 +96,9 @@ async def test_overview_falls_back_to_db_when_redis_unavailable(caplog):
             out = await service.overview(1, ADMIN)
 
     assert out.total_issued == 100
+    assert out.total_issued_mom == 42
     assert repo.sum_total_issued.await_count == 1
+    assert repo.sum_tenant_earn.await_count == 1
     # 读、写各降级一次，确认真的进了异常分支而非碰巧命中。
     assert client.await_count == 2
     assert sum("cache" in r.message for r in caplog.records) == 2


### PR DESCRIPTION
## Summary
- Align G1–G7 / R1–R3 `point_rule.name` with product copy (Alembic f090).
- Add `total_issued_mom` to admin overview (tenant month-to-date earn sum) with Redis cache.
- Tighten admin list/detail dept display: dept-bucket `short_name`, no primary-dept fallback (AC-22); detail `role_label` matches list `user_type`.

## Test plan
- [x] `pytest test/points/test_points_overview_cache.py`
- [x] `pytest test/points/test_points_leaderboard.py test/points/test_points_admin_lists.py`
- [ ] Admin → 积分管理：平台总发放卡展示「较上月+N」
- [ ] Admin 用户详情：部门/角色与列表一致


Made with [Cursor](https://cursor.com)