### PR TITLE
feat(qa-expert): 转公开以业务表为准并加快问题列表

### DIFF
--- a/src/backend/bisheng/approval/domain/repositories/approval_instance_repository.py
+++ b/src/backend/bisheng/approval/domain/repositories/approval_instance_repository.py
@@ -34,7 +34,7 @@ class FixedOrNodeDecisionResult:
 
 
 class ApprovalInstanceRepository:
-    _DUPLICATE_ACTIVE_STATUSES = ('pending', 'exception', 'execute_failed')
+    _DUPLICATE_ACTIVE_STATUSES = ("pending", "exception", "execute_failed")
 
     @classmethod
     async def create_instance(
@@ -78,8 +78,8 @@ class ApprovalInstanceRepository:
         async with get_async_db_session() as session:
             saved = await session.get(ApprovalInstance, row.id)
             if saved is None:
-                raise ValueError(f'approval instance not found: {row.id}')
-            for key, value in row.model_dump(mode='python', exclude_unset=False).items():
+                raise ValueError(f"approval instance not found: {row.id}")
+            for key, value in row.model_dump(mode="python", exclude_unset=False).items():
                 setattr(saved, key, value)
             session.add(saved)
             await session.commit()
@@ -100,15 +100,40 @@ class ApprovalInstanceRepository:
         statuses = tuple(active_statuses) if active_statuses is not None else cls._DUPLICATE_ACTIVE_STATUSES
         if not statuses:
             return None
-        statement = select(ApprovalInstance).where(
-            ApprovalInstance.tenant_id == tenant_id,
-            ApprovalInstance.scenario_code == scenario_code,
-            ApprovalInstance.business_key == business_key,
-            ApprovalInstance.applicant_user_id == applicant_user_id,
-            ApprovalInstance.status.in_(statuses),
-        ).order_by(ApprovalInstance.id.desc())
+        statement = (
+            select(ApprovalInstance)
+            .where(
+                ApprovalInstance.tenant_id == tenant_id,
+                ApprovalInstance.scenario_code == scenario_code,
+                ApprovalInstance.business_key == business_key,
+                ApprovalInstance.applicant_user_id == applicant_user_id,
+                ApprovalInstance.status.in_(statuses),
+            )
+            .order_by(ApprovalInstance.id.desc())
+        )
         if session is not None:
             return (await session.exec(statement)).first()
+        async with get_async_db_session() as session:
+            return (await session.exec(statement)).first()
+
+    @classmethod
+    async def find_latest_by_business_key(
+        cls,
+        *,
+        tenant_id: int,
+        scenario_code: str,
+        business_key: str,
+    ) -> ApprovalInstance | None:
+        """按业务键取最新一条实例，不限状态。"""
+        statement = (
+            select(ApprovalInstance)
+            .where(
+                ApprovalInstance.tenant_id == tenant_id,
+                ApprovalInstance.scenario_code == scenario_code,
+                ApprovalInstance.business_key == business_key,
+            )
+            .order_by(ApprovalInstance.id.desc())
+        )
         async with get_async_db_session() as session:
             return (await session.exec(statement)).first()
 
@@ -186,8 +211,8 @@ class ApprovalInstanceRepository:
         async with get_async_db_session() as session:
             saved = await session.get(ApprovalTask, row.id)
             if saved is None:
-                raise ValueError(f'approval task not found: {row.id}')
-            for key, value in row.model_dump(mode='python', exclude_unset=False).items():
+                raise ValueError(f"approval task not found: {row.id}")
+            for key, value in row.model_dump(mode="python", exclude_unset=False).items():
                 setattr(saved, key, value)
             session.add(saved)
             await session.commit()
@@ -196,9 +221,13 @@ class ApprovalInstanceRepository:
 
     @classmethod
     async def list_tasks(cls, instance_id: int) -> list[ApprovalTask]:
-        statement = select(ApprovalTask).where(ApprovalTask.instance_id == instance_id).order_by(
-            ApprovalTask.node_order.asc(),
-            ApprovalTask.id.asc(),
+        statement = (
+            select(ApprovalTask)
+            .where(ApprovalTask.instance_id == instance_id)
+            .order_by(
+                ApprovalTask.node_order.asc(),
+                ApprovalTask.id.asc(),
+            )
         )
         async with get_async_db_session() as session:
             return list((await session.exec(statement)).all())
@@ -230,8 +259,8 @@ class ApprovalInstanceRepository:
         async with get_async_db_session() as session:
             saved = await session.get(ApprovalException, row.id)
             if saved is None:
-                raise ValueError(f'approval exception not found: {row.id}')
-            for key, value in row.model_dump(mode='python', exclude_unset=False).items():
+                raise ValueError(f"approval exception not found: {row.id}")
+            for key, value in row.model_dump(mode="python", exclude_unset=False).items():
                 setattr(saved, key, value)
             session.add(saved)
             await session.commit()
@@ -240,8 +269,12 @@ class ApprovalInstanceRepository:
 
     @classmethod
     async def list_exceptions(cls, instance_id: int) -> list[ApprovalException]:
-        statement = select(ApprovalException).where(ApprovalException.instance_id == instance_id).order_by(
-            ApprovalException.id.asc(),
+        statement = (
+            select(ApprovalException)
+            .where(ApprovalException.instance_id == instance_id)
+            .order_by(
+                ApprovalException.id.asc(),
+            )
         )
         async with get_async_db_session() as session:
             return list((await session.exec(statement)).all())
@@ -273,8 +306,8 @@ class ApprovalInstanceRepository:
         async with get_async_db_session() as session:
             saved = await session.get(ApprovalOutbox, row.id)
             if saved is None:
-                raise ValueError(f'approval outbox not found: {row.id}')
-            for key, value in row.model_dump(mode='python', exclude_unset=False).items():
+                raise ValueError(f"approval outbox not found: {row.id}")
+            for key, value in row.model_dump(mode="python", exclude_unset=False).items():
                 setattr(saved, key, value)
             session.add(saved)
             await session.commit()
@@ -283,8 +316,12 @@ class ApprovalInstanceRepository:
 
     @classmethod
     async def list_outbox(cls, instance_id: int) -> list[ApprovalOutbox]:
-        statement = select(ApprovalOutbox).where(ApprovalOutbox.instance_id == instance_id).order_by(
-            ApprovalOutbox.id.asc(),
+        statement = (
+            select(ApprovalOutbox)
+            .where(ApprovalOutbox.instance_id == instance_id)
+            .order_by(
+                ApprovalOutbox.id.asc(),
+            )
         )
         async with get_async_db_session() as session:
             return list((await session.exec(statement)).all())
@@ -308,8 +345,12 @@ class ApprovalInstanceRepository:
 
     @classmethod
     async def list_action_logs(cls, instance_id: int) -> list[ApprovalActionLog]:
-        statement = select(ApprovalActionLog).where(ApprovalActionLog.instance_id == instance_id).order_by(
-            ApprovalActionLog.id.asc(),
+        statement = (
+            select(ApprovalActionLog)
+            .where(ApprovalActionLog.instance_id == instance_id)
+            .order_by(
+                ApprovalActionLog.id.asc(),
+            )
         )
         async with get_async_db_session() as session:
             return list((await session.exec(statement)).all())
@@ -327,10 +368,7 @@ class ApprovalInstanceRepository:
             ApprovalActionLog.action == action,
         )
         async with get_async_db_session() as session:
-            return {
-                int(instance_id)
-                for instance_id in (await session.exec(statement)).all()
-            }
+            return {int(instance_id) for instance_id in (await session.exec(statement)).all()}
 
     @classmethod
     async def decide_fixed_or_node_atomic(
@@ -351,38 +389,25 @@ class ApprovalInstanceRepository:
         async with get_async_db_session() as session:
             try:
                 task_result = await session.execute(
-                    select(ApprovalTask)
-                    .where(ApprovalTask.id == task_id)
-                    .with_for_update()
+                    select(ApprovalTask).where(ApprovalTask.id == task_id).with_for_update()
                 )
                 task = task_result.scalars().first()
                 if task is None:
                     raise ApprovalRequestNotFoundError()
 
                 instance_result = await session.execute(
-                    select(ApprovalInstance)
-                    .where(ApprovalInstance.id == task.instance_id)
-                    .with_for_update()
+                    select(ApprovalInstance).where(ApprovalInstance.id == task.instance_id).with_for_update()
                 )
                 instance = instance_result.scalars().first()
                 if instance is None:
                     raise ApprovalRequestNotFoundError()
-                if (
-                    instance.scenario_code != "department_file_view_request"
-                    or task.node_mode != "or"
-                ):
+                if instance.scenario_code != "department_file_view_request" or task.node_mode != "or":
                     raise ValueError("task is not a fixed department-file OR-node task")
                 if instance.tenant_id != operator_tenant_id:
                     raise ApprovalRequestPermissionDeniedError()
-                if (
-                    not operator_is_admin
-                    and task.approver_user_id != operator_user_id
-                ):
+                if not operator_is_admin and task.approver_user_id != operator_user_id:
                     raise ApprovalRequestPermissionDeniedError()
-                if (
-                    instance.status != ApprovalInstanceStatus.PENDING
-                    or task.status != ApprovalTaskStatus.PENDING
-                ):
+                if instance.status != ApprovalInstanceStatus.PENDING or task.status != ApprovalTaskStatus.PENDING:
                     raise ApprovalRequestAlreadyProcessedError()
 
                 siblings_result = await session.execute(
@@ -396,26 +421,15 @@ class ApprovalInstanceRepository:
                 sibling_tasks = list(siblings_result.scalars().all())
                 acted_at = datetime.utcnow()
                 approved = action == "approve"
-                task.status = (
-                    ApprovalTaskStatus.APPROVED
-                    if approved
-                    else ApprovalTaskStatus.REJECTED
-                )
+                task.status = ApprovalTaskStatus.APPROVED if approved else ApprovalTaskStatus.REJECTED
                 task.comment = comment
                 task.acted_at = acted_at
                 for sibling in sibling_tasks:
-                    if (
-                        sibling.id != task.id
-                        and sibling.status == ApprovalTaskStatus.PENDING
-                    ):
+                    if sibling.id != task.id and sibling.status == ApprovalTaskStatus.PENDING:
                         sibling.status = ApprovalTaskStatus.SKIPPED
                         sibling.acted_at = acted_at
 
-                instance.status = (
-                    ApprovalInstanceStatus.APPROVED
-                    if approved
-                    else ApprovalInstanceStatus.REJECTED
-                )
+                instance.status = ApprovalInstanceStatus.APPROVED if approved else ApprovalInstanceStatus.REJECTED
                 instance.current_node_name = None
                 instance.latest_approver_user_id = operator_user_id
 
@@ -435,11 +449,7 @@ class ApprovalInstanceRepository:
                         operator_id=operator_user_id,
                         operator_name=operator_user_name,
                         operator_tenant_id=operator_tenant_id,
-                        action=(
-                            "approval.task.approve"
-                            if approved
-                            else "approval.task.reject"
-                        ),
+                        action=("approval.task.approve" if approved else "approval.task.reject"),
                         target_type="approval_task",
                         target_id=str(task.id),
                         reason=comment,

--- a/src/backend/bisheng/approval/domain/services/approval_center_service.py
+++ b/src/backend/bisheng/approval/domain/services/approval_center_service.py
@@ -38,7 +38,7 @@ from bisheng.user.domain.models.user import UserDao
 from bisheng.user.domain.services.auth import LoginUser
 
 # Comment recorded on a task auto-approved because its approver is the applicant.
-SELF_APPROVAL_COMMENT = '发起人与审批人为同一人，自动通过'
+SELF_APPROVAL_COMMENT = "发起人与审批人为同一人，自动通过"
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +68,7 @@ class ApprovalCenterService:
         return {
             int(department.id): build_department_name_projection(department)
             for department in departments
-            if getattr(department, 'id', None) is not None
+            if getattr(department, "id", None) is not None
         }
 
     @staticmethod
@@ -77,21 +77,19 @@ class ApprovalCenterService:
         department_map: dict[int, DepartmentNameProjection],
     ) -> dict:
         result = dict(snapshot or {})
-        department_id = int(result.get('department_id') or 0)
+        department_id = int(result.get("department_id") or 0)
         projection = department_map.get(department_id)
-        formal_name = str(result.get('department_name') or '')
-        result['department_display_name'] = (
-            projection.display_name if projection is not None else formal_name
-        )
+        formal_name = str(result.get("department_name") or "")
+        result["department_display_name"] = projection.display_name if projection is not None else formal_name
         if projection is not None:
-            result['department_short_name'] = projection.short_name
+            result["department_short_name"] = projection.short_name
         return result
 
     @classmethod
     async def list_my_tasks(cls, *, tenant_id: int, approver_user_id: int):
         tasks = await ApprovalQueryRepository.list_tasks_by_approver(tenant_id, approver_user_id)
         if not tasks:
-            return {'data': [], 'total': 0}
+            return {"data": [], "total": 0}
 
         instance_ids = list({t.instance_id for t in tasks})
         instances = await ApprovalInstanceRepository.get_instances_by_ids(instance_ids)
@@ -102,20 +100,18 @@ class ApprovalCenterService:
 
         # Batch-check which menu_access instances have had their grant revoked
         from bisheng.approval.domain.repositories.user_menu_access_repository import UserMenuAccessRepository
+
         menu_executed_ids = [
-            inst.id for inst in instances
-            if inst.scenario_code == 'menu_access_request' and inst.status == 'executed'
+            inst.id for inst in instances if inst.scenario_code == "menu_access_request" and inst.status == "executed"
         ]
         revoked_instance_ids = await UserMenuAccessRepository.get_revoked_instance_ids(menu_executed_ids)
         department_instance_ids = [
-            inst.id
-            for inst in instances
-            if inst.scenario_code == 'department_file_view_request'
+            inst.id for inst in instances if inst.scenario_code == "department_file_view_request"
         ]
         revoked_instance_ids.update(
             await ApprovalInstanceRepository.get_instance_ids_with_action(
                 department_instance_ids,
-                'revoke_grant',
+                "revoke_grant",
             )
         )
 
@@ -123,29 +119,29 @@ class ApprovalCenterService:
         for task in tasks:
             inst = instance_map.get(task.instance_id)
             projection = (
-                department_map.get(int(inst.applicant_department_id))
-                if inst and inst.applicant_department_id
-                else None
+                department_map.get(int(inst.applicant_department_id)) if inst and inst.applicant_department_id else None
             )
-            data.append({
-                'task_id': task.id,
-                'instance_id': task.instance_id,
-                'scenario_code': inst.scenario_code if inst else None,
-                'scenario_name': inst.scenario_name if inst else None,
-                'business_name': inst.business_name if inst else task.node_name,
-                'status': task.status,
-                'instance_status': inst.status if inst else None,
-                'grant_revoked': task.instance_id in revoked_instance_ids,
-                'current_node_name': task.node_name,
-                'applicant_user_name': inst.applicant_user_name if inst else None,
-                'applicant_department_id': inst.applicant_department_id if inst else None,
-                'applicant_department_name': projection.name if projection else None,
-                'applicant_department_short_name': projection.short_name if projection else None,
-                'applicant_department_display_name': projection.display_name if projection else None,
-                'create_time': task.create_time,
-                'update_time': task.update_time,
-            })
-        return {'data': data, 'total': len(data)}
+            data.append(
+                {
+                    "task_id": task.id,
+                    "instance_id": task.instance_id,
+                    "scenario_code": inst.scenario_code if inst else None,
+                    "scenario_name": inst.scenario_name if inst else None,
+                    "business_name": inst.business_name if inst else task.node_name,
+                    "status": task.status,
+                    "instance_status": inst.status if inst else None,
+                    "grant_revoked": task.instance_id in revoked_instance_ids,
+                    "current_node_name": task.node_name,
+                    "applicant_user_name": inst.applicant_user_name if inst else None,
+                    "applicant_department_id": inst.applicant_department_id if inst else None,
+                    "applicant_department_name": projection.name if projection else None,
+                    "applicant_department_short_name": projection.short_name if projection else None,
+                    "applicant_department_display_name": projection.display_name if projection else None,
+                    "create_time": task.create_time,
+                    "update_time": task.update_time,
+                }
+            )
+        return {"data": data, "total": len(data)}
 
     @classmethod
     async def _build_flow_nodes_with_approvers(
@@ -159,21 +155,20 @@ class ApprovalCenterService:
             return []
 
         from bisheng.approval.domain.repositories.approval_scenario_repository import ApprovalScenarioRepository
-        node_defs = await ApprovalScenarioRepository.list_node_definitions(
-            instance.tenant_id, instance.flow_version_id
-        )
+
+        node_defs = await ApprovalScenarioRepository.list_node_definitions(instance.tenant_id, instance.flow_version_id)
         if not node_defs:
             return []
 
         task_approvers_by_node: dict[str, list[int]] = {}
         for task in tasks:
-            node_key = task.node_code or f'order:{task.node_order}'
+            node_key = task.node_code or f"order:{task.node_order}"
             task_approvers_by_node.setdefault(node_key, []).append(task.approver_user_id)
 
         resolved_by_node: dict[str, list[int]] = {}
         future_nodes = []
         for node in node_defs:
-            node_key = node.node_code or f'order:{node.node_order}'
+            node_key = node.node_code or f"order:{node.node_order}"
             existing_approvers = task_approvers_by_node.get(node_key)
             if existing_approvers:
                 resolved_by_node[node_key] = list(dict.fromkeys(existing_approvers))
@@ -182,11 +177,12 @@ class ApprovalCenterService:
 
         if future_nodes:
             from bisheng.approval.domain.services.approval_runtime_handler_factory import build_runtime_handler
+
             try:
                 handler = await build_runtime_handler(instance.handler_key or instance.scenario_code)
             except KeyError:
                 logger.warning(
-                    'approval detail cannot resolve future approvers: unknown handler_key=%s',
+                    "approval detail cannot resolve future approvers: unknown handler_key=%s",
                     instance.handler_key or instance.scenario_code,
                 )
             else:
@@ -205,56 +201,43 @@ class ApprovalCenterService:
                 )
 
                 async def resolve_node_approvers(node) -> tuple[str, list[int]]:
-                    node_key = node.node_code or f'order:{node.node_order}'
+                    node_key = node.node_code or f"order:{node.node_order}"
                     try:
-                        approver_ids = await handler.resolve_approvers(
-                            node.approver_config or {}, request
-                        )
+                        approver_ids = await handler.resolve_approvers(node.approver_config or {}, request)
                     except Exception:
                         # Future-node enrichment must not make the approval detail unavailable.
                         logger.exception(
-                            'approval detail failed to resolve future approvers: '
-                            'instance_id=%s node_code=%s',
+                            "approval detail failed to resolve future approvers: instance_id=%s node_code=%s",
                             instance.id,
                             node.node_code,
                         )
                         return node_key, []
                     return node_key, list(dict.fromkeys(int(one) for one in approver_ids))
 
-                resolved_results = await asyncio.gather(
-                    *(resolve_node_approvers(node) for node in future_nodes)
-                )
+                resolved_results = await asyncio.gather(*(resolve_node_approvers(node) for node in future_nodes))
                 resolved_by_node.update(dict(resolved_results))
 
-        all_approver_ids = list({
-            approver_id
-            for approver_ids in resolved_by_node.values()
-            for approver_id in approver_ids
-        })
+        all_approver_ids = list(
+            {approver_id for approver_ids in resolved_by_node.values() for approver_id in approver_ids}
+        )
         approver_name_map = dict(task_user_name_map)
-        missing_user_ids = [
-            user_id for user_id in all_approver_ids if user_id not in approver_name_map
-        ]
+        missing_user_ids = [user_id for user_id in all_approver_ids if user_id not in approver_name_map]
         if missing_user_ids:
             users = await UserDao.aget_user_by_ids(missing_user_ids)
-            approver_name_map.update(
-                {user.user_id: user.user_name for user in (users or [])}
-            )
+            approver_name_map.update({user.user_id: user.user_name for user in (users or [])})
 
         return [
             {
-                'node_code': node.node_code,
-                'node_name': node.node_name,
-                'node_order': node.node_order,
-                'node_mode': node.node_mode,
-                'approvers': [
+                "node_code": node.node_code,
+                "node_name": node.node_name,
+                "node_order": node.node_order,
+                "node_mode": node.node_mode,
+                "approvers": [
                     {
-                        'user_id': user_id,
-                        'user_name': approver_name_map.get(user_id),
+                        "user_id": user_id,
+                        "user_name": approver_name_map.get(user_id),
                     }
-                    for user_id in resolved_by_node.get(
-                        node.node_code or f'order:{node.node_order}', []
-                    )
+                    for user_id in resolved_by_node.get(node.node_code or f"order:{node.node_order}", [])
                 ],
             }
             for node in node_defs
@@ -270,13 +253,17 @@ class ApprovalCenterService:
             raise ApprovalRequestNotFoundError()
         if instance.tenant_id != login_user.tenant_id:
             raise ApprovalRequestPermissionDeniedError()
-        if not login_user.is_admin() and task.approver_user_id != login_user.user_id and instance.applicant_user_id != login_user.user_id:
+        if (
+            not login_user.is_admin()
+            and task.approver_user_id != login_user.user_id
+            and instance.applicant_user_id != login_user.user_id
+        ):
             raise ApprovalRequestPermissionDeniedError()
 
         snapshot_department_ids = [
-            int(snapshot.get('department_id') or 0)
+            int(snapshot.get("department_id") or 0)
             for snapshot in (instance.payload_snapshot or {}, instance.detail_snapshot or {})
-            if snapshot.get('department_id')
+            if snapshot.get("department_id")
         ]
         department_map = await cls._load_department_projection_map(
             [instance.applicant_department_id, *snapshot_department_ids]
@@ -290,6 +277,7 @@ class ApprovalCenterService:
         task_user_name_map: dict[int, str] = {}
         if all_task_uids:
             from bisheng.user.domain.models.user import UserDao
+
             task_users = await UserDao.aget_user_by_ids(all_task_uids)
             task_user_name_map = {u.user_id: u.user_name for u in (task_users or [])}
 
@@ -300,66 +288,64 @@ class ApprovalCenterService:
         )
 
         grant_revoked = False
-        if instance.scenario_code == 'menu_access_request' and instance.status == 'executed':
+        if instance.scenario_code == "menu_access_request" and instance.status == "executed":
             from bisheng.approval.domain.repositories.user_menu_access_repository import UserMenuAccessRepository
+
             revoked_ids = await UserMenuAccessRepository.get_revoked_instance_ids([instance.id])
             grant_revoked = instance.id in revoked_ids
-        elif instance.scenario_code == 'department_file_view_request':
-            grant_revoked = any(
-                log.action == 'revoke_grant'
-                for log in action_logs
-            )
+        elif instance.scenario_code == "department_file_view_request":
+            grant_revoked = any(log.action == "revoke_grant" for log in action_logs)
 
         return {
-            'task_id': task.id,
-            'instance_id': task.instance_id,
-            'scenario_code': instance.scenario_code,
-            'scenario_name': instance.scenario_name,
-            'business_name': instance.business_name,
-            'status': task.status,
-            'instance_status': instance.status,
-            'grant_revoked': grant_revoked,
-            'current_node_name': task.node_name,
-            'comment': task.comment,
-            'detail_snapshot': cls._with_department_display_name(
+            "task_id": task.id,
+            "instance_id": task.instance_id,
+            "scenario_code": instance.scenario_code,
+            "scenario_name": instance.scenario_name,
+            "business_name": instance.business_name,
+            "status": task.status,
+            "instance_status": instance.status,
+            "grant_revoked": grant_revoked,
+            "current_node_name": task.node_name,
+            "comment": task.comment,
+            "detail_snapshot": cls._with_department_display_name(
                 instance.detail_snapshot,
                 department_map,
             ),
-            'payload_snapshot': cls._with_department_display_name(
+            "payload_snapshot": cls._with_department_display_name(
                 instance.payload_snapshot,
                 department_map,
             ),
-            'applicant_user_name': instance.applicant_user_name,
-            'applicant_department_id': instance.applicant_department_id,
-            'applicant_department_name': projection.name if projection else None,
-            'applicant_department_short_name': projection.short_name if projection else None,
-            'applicant_department_display_name': projection.display_name if projection else None,
-            'reason': instance.reason,
-            'create_time': instance.create_time,
-            'update_time': task.update_time,
-            'flow_nodes': flow_nodes,
-            'tasks': [
+            "applicant_user_name": instance.applicant_user_name,
+            "applicant_department_id": instance.applicant_department_id,
+            "applicant_department_name": projection.name if projection else None,
+            "applicant_department_short_name": projection.short_name if projection else None,
+            "applicant_department_display_name": projection.display_name if projection else None,
+            "reason": instance.reason,
+            "create_time": instance.create_time,
+            "update_time": task.update_time,
+            "flow_nodes": flow_nodes,
+            "tasks": [
                 {
-                    'task_id': t.id,
-                    'approver_user_id': t.approver_user_id,
-                    'approver_user_name': task_user_name_map.get(t.approver_user_id),
-                    'node_name': t.node_name,
-                    'node_order': t.node_order,
-                    'node_mode': t.node_mode,
-                    'status': t.status,
-                    'comment': t.comment,
-                    'update_time': t.update_time,
+                    "task_id": t.id,
+                    "approver_user_id": t.approver_user_id,
+                    "approver_user_name": task_user_name_map.get(t.approver_user_id),
+                    "node_name": t.node_name,
+                    "node_order": t.node_order,
+                    "node_mode": t.node_mode,
+                    "status": t.status,
+                    "comment": t.comment,
+                    "update_time": t.update_time,
                 }
                 for t in all_tasks
             ],
-            'action_logs': [
+            "action_logs": [
                 {
-                    'id': log.id,
-                    'action': log.action,
-                    'operator_user_id': log.operator_user_id,
-                    'operator_user_name': log.operator_user_name,
-                    'detail': log.detail,
-                    'create_time': log.create_time,
+                    "id": log.id,
+                    "action": log.action,
+                    "operator_user_id": log.operator_user_id,
+                    "operator_user_name": log.operator_user_name,
+                    "detail": log.detail,
+                    "create_time": log.create_time,
                 }
                 for log in action_logs
             ],
@@ -392,11 +378,11 @@ class ApprovalCenterService:
         task = await ApprovalInstanceRepository.get_task(task_id)
         instance = await ApprovalInstanceRepository.get_instance(task.instance_id) if task else None
         return {
-            'task_id': task.id if task else task_id,
-            'instance_id': task.instance_id if task else None,
-            'status': task.status if task else None,
-            'instance_status': instance.status if instance else None,
-            'comment': task.comment if task else comment,
+            "task_id": task.id if task else task_id,
+            "instance_id": task.instance_id if task else None,
+            "status": task.status if task else None,
+            "instance_status": instance.status if instance else None,
+            "comment": task.comment if task else comment,
         }
 
     @classmethod
@@ -427,7 +413,7 @@ class ApprovalCenterService:
         for inst_id, uids in inst_approver_map.items():
             names = [user_name_map[uid] for uid in uids if uid in user_name_map]
             if names:
-                approver_names_map[inst_id] = '、'.join(names)
+                approver_names_map[inst_id] = "、".join(names)
 
         department_map = await cls._load_department_projection_map(dept_ids)
         return approver_names_map, department_map
@@ -436,7 +422,7 @@ class ApprovalCenterService:
     async def list_my_requests(cls, *, tenant_id: int, applicant_user_id: int):
         rows = await ApprovalQueryRepository.list_instances_by_applicant(tenant_id, applicant_user_id)
         if not rows:
-            return {'data': [], 'total': 0}
+            return {"data": [], "total": 0}
 
         instance_ids = [r.id for r in rows]
         dept_ids = [r.applicant_department_id for r in rows if r.applicant_department_id]
@@ -444,44 +430,40 @@ class ApprovalCenterService:
 
         # Batch-check which menu_access instances have had their grant revoked
         from bisheng.approval.domain.repositories.user_menu_access_repository import UserMenuAccessRepository
-        menu_executed_ids = [
-            r.id for r in rows
-            if r.scenario_code == 'menu_access_request' and r.status == 'executed'
-        ]
+
+        menu_executed_ids = [r.id for r in rows if r.scenario_code == "menu_access_request" and r.status == "executed"]
         revoked_instance_ids = await UserMenuAccessRepository.get_revoked_instance_ids(menu_executed_ids)
-        department_instance_ids = [
-            row.id
-            for row in rows
-            if row.scenario_code == 'department_file_view_request'
-        ]
+        department_instance_ids = [row.id for row in rows if row.scenario_code == "department_file_view_request"]
         revoked_instance_ids.update(
             await ApprovalInstanceRepository.get_instance_ids_with_action(
                 department_instance_ids,
-                'revoke_grant',
+                "revoke_grant",
             )
         )
 
         data = []
         for row in rows:
             projection = department_map.get(int(row.applicant_department_id or 0))
-            data.append({
-                'instance_id': row.id,
-                'scenario_code': row.scenario_code,
-                'scenario_name': row.scenario_name,
-                'business_name': row.business_name,
-                'status': row.status,
-                'grant_revoked': row.id in revoked_instance_ids,
-                'applicant_user_name': row.applicant_user_name,
-                'applicant_department_id': row.applicant_department_id,
-                'applicant_department_name': projection.name if projection else None,
-                'applicant_department_short_name': projection.short_name if projection else None,
-                'applicant_department_display_name': projection.display_name if projection else None,
-                'current_node_name': row.current_node_name,
-                'current_approver_names': approver_names_map.get(row.id),
-                'create_time': row.create_time,
-                'update_time': row.update_time,
-            })
-        return {'data': data, 'total': len(data)}
+            data.append(
+                {
+                    "instance_id": row.id,
+                    "scenario_code": row.scenario_code,
+                    "scenario_name": row.scenario_name,
+                    "business_name": row.business_name,
+                    "status": row.status,
+                    "grant_revoked": row.id in revoked_instance_ids,
+                    "applicant_user_name": row.applicant_user_name,
+                    "applicant_department_id": row.applicant_department_id,
+                    "applicant_department_name": projection.name if projection else None,
+                    "applicant_department_short_name": projection.short_name if projection else None,
+                    "applicant_department_display_name": projection.display_name if projection else None,
+                    "current_node_name": row.current_node_name,
+                    "current_approver_names": approver_names_map.get(row.id),
+                    "create_time": row.create_time,
+                    "update_time": row.update_time,
+                }
+            )
+        return {"data": data, "total": len(data)}
 
     @classmethod
     async def get_instance_detail(cls, *, instance_id: int, login_user):
@@ -498,9 +480,9 @@ class ApprovalCenterService:
         action_logs = await ApprovalInstanceRepository.list_action_logs(instance.id)
         # Enrich with department name and current approver names
         snapshot_department_ids = [
-            int(snapshot.get('department_id') or 0)
+            int(snapshot.get("department_id") or 0)
             for snapshot in (instance.payload_snapshot or {}, instance.detail_snapshot or {})
-            if snapshot.get('department_id')
+            if snapshot.get("department_id")
         ]
         department_map = await cls._load_department_projection_map(
             [instance.applicant_department_id, *snapshot_department_ids]
@@ -512,12 +494,16 @@ class ApprovalCenterService:
         current_approver_names: str | None = None
         if all_task_uids:
             from bisheng.user.domain.models.user import UserDao
+
             task_users = await UserDao.aget_user_by_ids(all_task_uids)
             task_user_name_map = {u.user_id: u.user_name for u in (task_users or [])}
-            pending_names = [task_user_name_map[t.approver_user_id]
-                             for t in tasks if t.status == 'pending' and t.approver_user_id in task_user_name_map]
+            pending_names = [
+                task_user_name_map[t.approver_user_id]
+                for t in tasks
+                if t.status == "pending" and t.approver_user_id in task_user_name_map
+            ]
             if pending_names:
-                current_approver_names = '、'.join(pending_names)
+                current_approver_names = "、".join(pending_names)
 
         # Include all flow nodes and resolve future approvers before their tasks exist.
         flow_nodes = await cls._build_flow_nodes_with_approvers(
@@ -526,68 +512,63 @@ class ApprovalCenterService:
             task_user_name_map=task_user_name_map,
         )
 
-        grant_revoked = (
-            instance.scenario_code == 'department_file_view_request'
-            and any(log.action == 'revoke_grant' for log in action_logs)
+        grant_revoked = instance.scenario_code == "department_file_view_request" and any(
+            log.action == "revoke_grant" for log in action_logs
         )
-        if (
-            instance.scenario_code == 'menu_access_request'
-            and instance.status == 'executed'
-        ):
+        if instance.scenario_code == "menu_access_request" and instance.status == "executed":
             from bisheng.approval.domain.repositories.user_menu_access_repository import UserMenuAccessRepository
-            revoked_ids = await UserMenuAccessRepository.get_revoked_instance_ids(
-                [instance.id]
-            )
+
+            revoked_ids = await UserMenuAccessRepository.get_revoked_instance_ids([instance.id])
             grant_revoked = instance.id in revoked_ids
 
         return {
-            'instance_id': instance.id,
-            'scenario_code': instance.scenario_code,
-            'scenario_name': instance.scenario_name,
-            'business_name': instance.business_name,
-            'status': instance.status,
-            'grant_revoked': grant_revoked,
-            'reason': instance.reason,
-            'payload_snapshot': cls._with_department_display_name(
+            "instance_id": instance.id,
+            "scenario_code": instance.scenario_code,
+            "scenario_name": instance.scenario_name,
+            "business_name": instance.business_name,
+            "status": instance.status,
+            "grant_revoked": grant_revoked,
+            "reason": instance.reason,
+            "payload_snapshot": cls._with_department_display_name(
                 instance.payload_snapshot,
                 department_map,
             ),
-            'detail_snapshot': cls._with_department_display_name(
+            "detail_snapshot": cls._with_department_display_name(
                 instance.detail_snapshot,
                 department_map,
             ),
-            'applicant_user_name': instance.applicant_user_name,
-            'applicant_department_id': instance.applicant_department_id,
-            'applicant_department_name': projection.name if projection else None,
-            'applicant_department_short_name': projection.short_name if projection else None,
-            'applicant_department_display_name': projection.display_name if projection else None,
-            'current_node_name': instance.current_node_name,
-            'current_approver_names': current_approver_names,
-            'create_time': instance.create_time,
-            'update_time': instance.update_time,
-            'tasks': [
+            "applicant_user_name": instance.applicant_user_name,
+            "applicant_department_id": instance.applicant_department_id,
+            "applicant_department_name": projection.name if projection else None,
+            "applicant_department_short_name": projection.short_name if projection else None,
+            "applicant_department_display_name": projection.display_name if projection else None,
+            "current_node_name": instance.current_node_name,
+            "current_approver_names": current_approver_names,
+            "create_time": instance.create_time,
+            "update_time": instance.update_time,
+            "tasks": [
                 {
-                    'task_id': task.id,
-                    'approver_user_id': task.approver_user_id,
-                    'approver_user_name': task_user_name_map.get(task.approver_user_id),
-                    'node_name': task.node_name,
-                    'node_order': task.node_order,
-                    'node_mode': task.node_mode,
-                    'status': task.status,
-                    'comment': task.comment,
-                    'update_time': task.update_time,
+                    "task_id": task.id,
+                    "approver_user_id": task.approver_user_id,
+                    "approver_user_name": task_user_name_map.get(task.approver_user_id),
+                    "node_name": task.node_name,
+                    "node_order": task.node_order,
+                    "node_mode": task.node_mode,
+                    "status": task.status,
+                    "comment": task.comment,
+                    "update_time": task.update_time,
                 }
                 for task in tasks
             ],
-            'flow_nodes': flow_nodes,
-            'action_logs': [
+            "flow_nodes": flow_nodes,
+            "action_logs": [
                 {
-                    'id': log.id,
-                    'action': log.action,
-                    'operator_user_id': log.operator_user_id,
-                    'operator_user_name': log.operator_user_name,
-                    'detail': log.detail,
-                    'create_time': log.create_time,
+                    "id": log.id,
+                    "action": log.action,
+                    "operator_user_id": log.operator_user_id,
+                    "operator_user_name": log.operator_user_name,
+                    "detail": log.detail,
+                    "create_time": log.create_time,
                 }
                 for log in action_logs
             ],
@@ -605,9 +586,9 @@ class ApprovalCenterService:
     ):
         instance = await ApprovalInstanceRepository.get_instance(instance_id)
         if instance is None:
-            raise ValueError(f'instance not found: {instance_id}')
+            raise ValueError(f"instance not found: {instance_id}")
         if instance.applicant_user_id != operator_user_id:
-            raise PermissionError('only applicant can withdraw')
+            raise PermissionError("only applicant can withdraw")
         tasks = await ApprovalInstanceRepository.list_tasks(instance.id)
         for task in tasks:
             if task.status == ApprovalTaskStatus.PENDING:
@@ -620,23 +601,23 @@ class ApprovalCenterService:
             ApprovalActionLog(
                 tenant_id=instance.tenant_id,
                 instance_id=instance.id,
-                action='withdrawn',
+                action="withdrawn",
                 operator_user_id=operator_user_id,
                 operator_user_name=operator_user_name,
-                detail={'reason': reason},
+                detail={"reason": reason},
             )
         )
         await cls._write_audit_log(
             tenant_id=instance.tenant_id,
             operator_user_id=operator_user_id,
             operator_tenant_id=instance.tenant_id,
-            action='approval.request.withdraw',
+            action="approval.request.withdraw",
             target_id=str(instance.id),
             reason=reason,
             metadata={
-                'instance_id': instance.id,
-                'scenario_code': instance.scenario_code,
-                'handler': instance.handler_key or instance.scenario_code,
+                "instance_id": instance.id,
+                "scenario_code": instance.scenario_code,
+                "handler": instance.handler_key or instance.scenario_code,
             },
             operator_name=operator_user_name,
             object_name=instance.business_name,
@@ -648,19 +629,21 @@ class ApprovalCenterService:
             await cls._send_approval_notify(
                 sender=operator_user_id,
                 receiver_user_ids=task_approver_ids,
-                action_code='approval_instance_withdrawn',
+                action_code="approval_instance_withdrawn",
                 business_name=instance.business_name,
                 instance_id=instance.id,
                 reason=reason,
             )
         try:
             from bisheng.approval.domain.services.approval_runtime_handler_factory import build_runtime_handler
+
             handler = await build_runtime_handler(instance.handler_key or instance.scenario_code)
             await handler.on_withdrawn(instance.id, instance.payload_snapshot or {}, reason)
         except Exception:
             import logging
+
             logging.getLogger(__name__).exception(
-                'withdraw_instance: on_withdrawn hook failed for instance %s', instance.id
+                "withdraw_instance: on_withdrawn hook failed for instance %s", instance.id
             )
         return await cls.get_instance_detail(
             instance_id=instance.id,
@@ -689,16 +672,17 @@ class ApprovalCenterService:
             return
         from bisheng.core.database import get_async_db_session
         from bisheng.message.api.dependencies import get_message_service as _get_message_service
+
         async with get_async_db_session() as session:
             message_service = await _get_message_service(session)
             await message_service.send_generic_approval(
                 applicant_user_id=applicant_user_id,
                 applicant_user_name=applicant_user_name,
-                action_code='request_menu_access',
-                business_type='approval_instance_id',
+                action_code="request_menu_access",
+                business_type="approval_instance_id",
                 business_id=str(instance_id),
                 business_name=menu_name,
-                button_action_code='request_menu_access',
+                button_action_code="request_menu_access",
                 receiver_user_ids=approver_user_ids,
             )
 
@@ -725,14 +709,14 @@ class ApprovalCenterService:
         applicant_department_id = primary_dept.department_id if primary_dept else None
 
         registry = ApprovalRegistry.with_default_presets()
-        registry.register_handler('menu_access_request', MenuAccessApprovalHandler())
+        registry.register_handler("menu_access_request", MenuAccessApprovalHandler())
         gate = ApprovalGate(registry=registry)
         result = await gate.request_or_pass(
             ApprovalGateRequest(
                 tenant_id=login_user.tenant_id,
-                scenario_code='menu_access_request',
-                business_key=f'menu:{menu_key}:user:{login_user.user_id}',
-                business_resource_type='web_menu',
+                scenario_code="menu_access_request",
+                business_key=f"menu:{menu_key}:user:{login_user.user_id}",
+                business_resource_type="web_menu",
                 business_resource_id=menu_key,
                 business_name=menu_name,
                 applicant_user_id=login_user.user_id,
@@ -740,10 +724,10 @@ class ApprovalCenterService:
                 applicant_department_id=applicant_department_id,
                 reason=reason,
                 payload_snapshot={
-                    'menu_key': menu_key,
-                    'menu_name': menu_name,
-                    'tenant_id': login_user.tenant_id,
-                    'applicant_user_id': login_user.user_id,
+                    "menu_key": menu_key,
+                    "menu_name": menu_name,
+                    "tenant_id": login_user.tenant_id,
+                    "applicant_user_id": login_user.user_id,
                 },
                 ip_address=ip_address,
             )
@@ -774,12 +758,12 @@ class ApprovalCenterService:
         instance = await ApprovalInstanceRepository.get_instance(instance_id)
         if instance is None:
             raise ApprovalGrantNotRevokableError()
-        menu_key = (instance.payload_snapshot or {}).get('menu_key')
+        menu_key = (instance.payload_snapshot or {}).get("menu_key")
         rows = await UserMenuAccessService.revoke_menu_access(
             tenant_id=instance.tenant_id,
             user_id=instance.applicant_user_id,
             menu_key=menu_key,
-            grant_source='approval_instance',
+            grant_source="approval_instance",
             revoked_by_user_id=operator_user_id,
             revoked_reason=reason,
         )
@@ -789,23 +773,23 @@ class ApprovalCenterService:
             ApprovalActionLog(
                 tenant_id=instance.tenant_id,
                 instance_id=instance.id,
-                action='revoke_grant',
+                action="revoke_grant",
                 operator_user_id=operator_user_id,
                 operator_user_name=operator_user_name,
-                detail={'reason': reason, 'menu_key': menu_key},
+                detail={"reason": reason, "menu_key": menu_key},
             )
         )
         await cls._write_audit_log(
             tenant_id=instance.tenant_id,
             operator_user_id=operator_user_id,
             operator_tenant_id=instance.tenant_id,
-            action='approval.menu_access.revoke_grant',
+            action="approval.menu_access.revoke_grant",
             target_id=str(instance.id),
             reason=reason,
             metadata={
-                'scenario_code': instance.scenario_code,
-                'menu_key': menu_key,
-                'applicant_user_id': instance.applicant_user_id,
+                "scenario_code": instance.scenario_code,
+                "menu_key": menu_key,
+                "applicant_user_id": instance.applicant_user_id,
             },
             operator_name=operator_user_name,
             object_name=instance.business_name,
@@ -819,12 +803,12 @@ class ApprovalCenterService:
                 await cls._send_approval_notify(
                     sender=operator_user_id,
                     receiver_user_ids=[instance.applicant_user_id],
-                    action_code='menu_grant_revoked',
+                    action_code="menu_grant_revoked",
                     business_name=instance.business_name,
                     instance_id=instance.id,
                     reason=reason,
                 )
-        return {'revoked_keys': [row.menu_key for row in rows], 'instance_id': instance_id}
+        return {"revoked_keys": [row.menu_key for row in rows], "instance_id": instance_id}
 
     async def auto_approve_self_tasks(self, *, instance: ApprovalInstance, tasks: list[ApprovalTask]) -> bool:
         """Auto-approve a freshly created node's task when its approver is the applicant.
@@ -846,8 +830,7 @@ class ApprovalCenterService:
             (
                 task
                 for task in tasks
-                if task.approver_user_id == instance.applicant_user_id
-                and task.status == ApprovalTaskStatus.PENDING
+                if task.approver_user_id == instance.applicant_user_id and task.status == ApprovalTaskStatus.PENDING
             ),
             None,
         )
@@ -855,9 +838,9 @@ class ApprovalCenterService:
             return False
         await self.decide_task(
             task_id=self_task.id,
-            action='approve',
+            action="approve",
             operator_user_id=instance.applicant_user_id,
-            operator_user_name=instance.applicant_user_name or '',
+            operator_user_name=instance.applicant_user_name or "",
             operator_tenant_id=instance.tenant_id,
             comment=SELF_APPROVAL_COMMENT,
         )
@@ -887,10 +870,10 @@ class ApprovalCenterService:
             raise ApprovalRequestPermissionDeniedError()
         if task.status != ApprovalTaskStatus.PENDING:
             raise ApprovalRequestAlreadyProcessedError()
-        if action == 'reject' and not (comment or '').strip():
+        if action == "reject" and not (comment or "").strip():
             raise ApprovalRejectReasonRequiredError()
 
-        if instance.scenario_code == 'department_file_view_request':
+        if instance.scenario_code == "department_file_view_request":
             result = await self.instance_repository.decide_fixed_or_node_atomic(
                 task_id=task_id,
                 action=action,
@@ -907,9 +890,9 @@ class ApprovalCenterService:
                 sender=operator_user_id,
                 receiver_user_ids=[result.applicant_user_id],
                 action_code=(
-                    'approval_instance_approved'
+                    "approval_instance_approved"
                     if result.instance_status == ApprovalInstanceStatus.APPROVED
-                    else 'approval_task_rejected'
+                    else "approval_task_rejected"
                 ),
                 business_name=result.business_name,
                 instance_id=result.instance_id,
@@ -917,10 +900,34 @@ class ApprovalCenterService:
             )
             return
 
+        if instance.scenario_code == "qa_question_publish":
+            from bisheng.qa_expert.domain.publish_approval_bridge import request_id_from_payload
+            from bisheng.qa_expert.domain.publish_service import PublishService
+
+            request_id = request_id_from_payload(instance.payload_snapshot or {})
+            if request_id is None:
+                raise ApprovalRequestNotFoundError()
+            operator = SimpleNamespace(
+                user_id=operator_user_id,
+                user_name=operator_user_name,
+                tenant_id=operator_tenant_id,
+            )
+            svc = PublishService()
+            try:
+                await svc.decide_publish(
+                    request_id,
+                    operator,
+                    "approved" if action == "approve" else "rejected",
+                )
+            except Exception:
+                await svc._sync_approval_center(await svc.request_repo.get_by_id(request_id))
+                raise
+            return
+
         sibling_tasks = await self.instance_repository.list_tasks(instance.id)
         same_node_tasks = [one for one in sibling_tasks if one.node_code == task.node_code]
 
-        if action == 'reject':
+        if action == "reject":
             task.status = ApprovalTaskStatus.REJECTED
             task.comment = comment
             task.acted_at = datetime.utcnow()
@@ -936,25 +943,25 @@ class ApprovalCenterService:
                 ApprovalActionLog(
                     tenant_id=instance.tenant_id,
                     instance_id=instance.id,
-                    action='rejected',
+                    action="rejected",
                     operator_user_id=operator_user_id,
                     operator_user_name=operator_user_name,
-                    detail={'comment': comment},
+                    detail={"comment": comment},
                 )
             )
             await self.__class__._write_audit_log(
                 tenant_id=instance.tenant_id,
                 operator_user_id=operator_user_id,
                 operator_tenant_id=instance.tenant_id,
-                action='approval.task.reject',
-                target_type='approval_task',
+                action="approval.task.reject",
+                target_type="approval_task",
                 target_id=str(task.id),
                 reason=comment,
                 metadata={
-                    'instance_id': instance.id,
-                    'task_id': task.id,
-                    'scenario_code': instance.scenario_code,
-                    'handler': instance.handler_key or instance.scenario_code,
+                    "instance_id": instance.id,
+                    "task_id": task.id,
+                    "scenario_code": instance.scenario_code,
+                    "handler": instance.handler_key or instance.scenario_code,
                 },
                 operator_name=operator_user_name,
                 object_name=instance.business_name,
@@ -963,19 +970,21 @@ class ApprovalCenterService:
             await self.__class__._send_approval_notify(
                 sender=operator_user_id,
                 receiver_user_ids=[instance.applicant_user_id],
-                action_code='approval_task_rejected',
+                action_code="approval_task_rejected",
                 business_name=instance.business_name,
                 instance_id=instance.id,
                 reason=comment,
             )
             try:
                 from bisheng.approval.domain.services.approval_runtime_handler_factory import build_runtime_handler
+
                 handler = await build_runtime_handler(instance.handler_key or instance.scenario_code)
                 await handler.on_rejected(instance.id, instance.payload_snapshot or {}, comment)
             except Exception:
                 import logging
+
                 logging.getLogger(__name__).exception(
-                    'decide_task: on_rejected hook failed for instance %s', instance.id
+                    "decide_task: on_rejected hook failed for instance %s", instance.id
                 )
             return
 
@@ -987,49 +996,52 @@ class ApprovalCenterService:
             ApprovalActionLog(
                 tenant_id=instance.tenant_id,
                 instance_id=instance.id,
-                action='approved',
+                action="approved",
                 operator_user_id=operator_user_id,
                 operator_user_name=operator_user_name,
-                detail={'task_id': task.id, 'comment': comment},
+                detail={"task_id": task.id, "comment": comment},
             )
         )
         await self.__class__._write_audit_log(
             tenant_id=instance.tenant_id,
             operator_user_id=operator_user_id,
             operator_tenant_id=instance.tenant_id,
-            action='approval.task.approve',
-            target_type='approval_task',
+            action="approval.task.approve",
+            target_type="approval_task",
             target_id=str(task.id),
             reason=comment,
             metadata={
-                'instance_id': instance.id,
-                'task_id': task.id,
-                'scenario_code': instance.scenario_code,
-                'handler': instance.handler_key or instance.scenario_code,
+                "instance_id": instance.id,
+                "task_id": task.id,
+                "scenario_code": instance.scenario_code,
+                "handler": instance.handler_key or instance.scenario_code,
             },
             operator_name=operator_user_name,
             object_name=instance.business_name,
             ip_address=ip_address,
         )
 
-        if task.node_mode == 'or':
+        if task.node_mode == "or":
             for sibling in same_node_tasks:
                 if sibling.id != task.id and sibling.status == ApprovalTaskStatus.PENDING:
                     sibling.status = ApprovalTaskStatus.SKIPPED
                     sibling.acted_at = datetime.utcnow()
                     await self.instance_repository.update_task(sibling)
-            await self._advance_after_node_approved(instance=instance, current_node_order=task.node_order, operator_user_id=operator_user_id)
+            await self._advance_after_node_approved(
+                instance=instance, current_node_order=task.node_order, operator_user_id=operator_user_id
+            )
             return
 
         # same_node_tasks was fetched before the current task was updated, so the
         # current task's object still carries its old PENDING status. Treat it as
         # APPROVED by checking its id explicitly.
         all_same_node_approved = all(
-            t.id == task.id or t.status == ApprovalTaskStatus.APPROVED
-            for t in same_node_tasks
+            t.id == task.id or t.status == ApprovalTaskStatus.APPROVED for t in same_node_tasks
         )
         if all_same_node_approved:
-            await self._advance_after_node_approved(instance=instance, current_node_order=task.node_order, operator_user_id=operator_user_id)
+            await self._advance_after_node_approved(
+                instance=instance, current_node_order=task.node_order, operator_user_id=operator_user_id
+            )
 
     async def _advance_after_node_approved(
         self,
@@ -1042,6 +1054,7 @@ class ApprovalCenterService:
         next_node = None
         if instance.flow_version_id:
             from bisheng.approval.domain.repositories.approval_scenario_repository import ApprovalScenarioRepository
+
             node_defs = await ApprovalScenarioRepository.list_node_definitions(
                 instance.tenant_id, instance.flow_version_id
             )
@@ -1068,8 +1081,8 @@ class ApprovalCenterService:
             await self.__class__._send_approval_notify(
                 sender=operator_user_id,
                 receiver_user_ids=[instance.applicant_user_id],
-                action_code='approval_instance_approved',
-                business_name=instance.business_name or '',
+                action_code="approval_instance_approved",
+                business_name=instance.business_name or "",
                 instance_id=instance.id,
             )
             return
@@ -1078,13 +1091,16 @@ class ApprovalCenterService:
         from types import SimpleNamespace
 
         from bisheng.approval.domain.services.approval_runtime_handler_factory import build_runtime_handler
+
         try:
             handler = await build_runtime_handler(instance.handler_key or instance.scenario_code)
         except KeyError:
             import logging
+
             logging.getLogger(__name__).error(
-                'decide_task: unknown handler_key=%s, finalizing instance %s',
-                instance.handler_key, instance.id,
+                "decide_task: unknown handler_key=%s, finalizing instance %s",
+                instance.handler_key,
+                instance.id,
             )
             instance.status = ApprovalInstanceStatus.APPROVED
             instance.current_node_name = None
@@ -1102,8 +1118,8 @@ class ApprovalCenterService:
             await self.__class__._send_approval_notify(
                 sender=operator_user_id,
                 receiver_user_ids=[instance.applicant_user_id],
-                action_code='approval_instance_approved',
-                business_name=instance.business_name or '',
+                action_code="approval_instance_approved",
+                business_name=instance.business_name or "",
                 instance_id=instance.id,
             )
             return
@@ -1128,6 +1144,7 @@ class ApprovalCenterService:
                 ApprovalException,
                 ApprovalExceptionType,
             )
+
             instance.status = ApprovalInstanceStatus.EXCEPTION
             instance.current_node_name = next_node.node_name
             await self.instance_repository.update_instance(instance)
@@ -1137,12 +1154,12 @@ class ApprovalCenterService:
                     instance_id=instance.id,
                     exception_type=ApprovalExceptionType.APPROVER_EMPTY,
                     detail={
-                        'scenario_code': instance.scenario_code,
-                        'business_key': instance.business_key,
-                        'node_code': next_node.node_code,
-                        'node_name': next_node.node_name,
-                        'node_order': next_node.node_order,
-                        'node_mode': next_node.node_mode,
+                        "scenario_code": instance.scenario_code,
+                        "business_key": instance.business_key,
+                        "node_code": next_node.node_code,
+                        "node_name": next_node.node_name,
+                        "node_order": next_node.node_order,
+                        "node_mode": next_node.node_mode,
                     },
                 )
             )
@@ -1151,7 +1168,7 @@ class ApprovalCenterService:
             await ApprovalNotificationService.notify_admins(
                 tenant_id=instance.tenant_id,
                 applicant_user_id=instance.applicant_user_id,
-                action_code='approval_exception_approver_empty',
+                action_code="approval_exception_approver_empty",
                 business_name=instance.business_name,
                 instance_id=instance.id,
             )
@@ -1168,7 +1185,7 @@ class ApprovalCenterService:
                     node_name=next_node.node_name,
                     node_order=next_node.node_order,
                     approver_user_id=approver_user_id,
-                    approver_source_type='resolved',
+                    approver_source_type="resolved",
                     node_mode=next_node.node_mode,
                     status=ApprovalTaskStatus.PENDING,
                 )
@@ -1184,7 +1201,7 @@ class ApprovalCenterService:
             await self.__class__._send_approval_notify(
                 sender=instance.applicant_user_id,
                 receiver_user_ids=[task.approver_user_id],
-                action_code='approval_task_pending',
+                action_code="approval_task_pending",
                 business_name=instance.business_name,
                 instance_id=instance.id,
                 task_id=task.id,
@@ -1217,6 +1234,7 @@ class ApprovalCenterService:
     @staticmethod
     def _dispatch_outbox(outbox_id: int) -> None:
         from bisheng.worker.approval.tasks import execute_approval_outbox
+
         execute_approval_outbox.delay(outbox_id)
 
     @classmethod
@@ -1232,7 +1250,7 @@ class ApprovalCenterService:
         metadata: dict | None = None,
         operator_name: str | None = None,
         object_name: str | None = None,
-        target_type: str = 'approval_instance',
+        target_type: str = "approval_instance",
         ip_address: str | None = None,
     ) -> None:
         await AuditLogDao.ainsert_v2(

--- a/src/backend/bisheng/approval/domain/services/approval_registry.py
+++ b/src/backend/bisheng/approval/domain/services/approval_registry.py
@@ -283,6 +283,15 @@ class ApprovalRegistry:
                 ],
             )
         )
+        registry.register_preset(
+            ApprovalScenarioPreset(
+                scenario_code="qa_question_publish",
+                scenario_name="专家问答转公开",
+                handler_key="qa_question_publish",
+                condition_fields=["applicant_role"],
+                approver_source_types=["direct_user"],
+            )
+        )
         return registry
 
     def register_preset(self, preset: ApprovalScenarioPreset) -> None:

--- a/src/backend/bisheng/approval/domain/services/approval_runtime_handler_factory.py
+++ b/src/backend/bisheng/approval/domain/services/approval_runtime_handler_factory.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from typing import Any
 
 from bisheng.approval.domain.services.channel_subscribe_scenario_handler import ChannelSubscribeScenarioHandler
-from bisheng.approval.domain.services.knowledge_space_subscribe_scenario_handler import KnowledgeSpaceSubscribeScenarioHandler
+from bisheng.approval.domain.services.knowledge_space_subscribe_scenario_handler import (
+    KnowledgeSpaceSubscribeScenarioHandler,
+)
 from bisheng.approval.domain.services.menu_access_handler import MenuAccessApprovalHandler
 from bisheng.approval.domain.services.shougang_approval_handler import (
     FILE_PUBLISH_SCENARIO,
@@ -14,22 +16,24 @@ from bisheng.approval.domain.services.shougang_approval_handler import (
     KnowledgeSpaceFileShareApprovalHandler,
 )
 from bisheng.common.models.space_channel_member import BusinessTypeEnum, SpaceChannelMemberDao
-from bisheng.common.repositories.implementations.space_channel_member_repository_impl import SpaceChannelMemberRepositoryImpl
+from bisheng.common.repositories.implementations.space_channel_member_repository_impl import (
+    SpaceChannelMemberRepositoryImpl,
+)
 from bisheng.core.database import get_async_db_session
 
 
 async def build_runtime_handler(scenario_code: str) -> Any:
-    if scenario_code == 'department_file_view_request':
+    if scenario_code == "department_file_view_request":
         from bisheng.approval.domain.services.department_file_view_handler import (
             DepartmentFileViewApprovalHandler,
         )
 
         return DepartmentFileViewApprovalHandler()
-    if scenario_code == 'menu_access_request':
+    if scenario_code == "menu_access_request":
         return MenuAccessApprovalHandler()
-    if scenario_code == 'channel_subscribe_request':
+    if scenario_code == "channel_subscribe_request":
         return ChannelSubscribeScenarioHandler(_AsyncSpaceChannelMembershipAdapter())
-    if scenario_code == 'knowledge_space_subscribe_request':
+    if scenario_code == "knowledge_space_subscribe_request":
         from bisheng.knowledge.domain.services.knowledge_space_service import KnowledgeSpaceService
 
         return KnowledgeSpaceSubscribeScenarioHandler(
@@ -43,7 +47,11 @@ async def build_runtime_handler(scenario_code: str) -> Any:
         return KnowledgeSpaceFilePublishApprovalHandler()
     if scenario_code == FILE_SHARE_SCENARIO:
         return KnowledgeSpaceFileShareApprovalHandler()
-    raise KeyError(f'handler not registered for scenario_code={scenario_code}')
+    if scenario_code == "qa_question_publish":
+        from bisheng.qa_expert.domain.publish_handler import QaQuestionPublishHandler
+
+        return QaQuestionPublishHandler()
+    raise KeyError(f"handler not registered for scenario_code={scenario_code}")
 
 
 class _AsyncSpaceChannelMembershipAdapter:

--- a/src/backend/bisheng/common/errcode/qa_expert.py
+++ b/src/backend/bisheng/common/errcode/qa_expert.py
@@ -1,0 +1,70 @@
+# ruff: noqa: RUF001, RUF002
+"""专家问答模块业务错误码（183xx）。"""
+
+from bisheng.common.errcode.base import BaseErrorCode
+
+
+class QaExpertQuestionAccessDeniedError(BaseErrorCode):
+    """当前用户不可见该问题（定向隔离 / 未登录等）。"""
+
+    Code, Msg = 18301, "无权查看该问题"
+
+
+class QaExpertAnswerNotAllowedError(BaseErrorCode):
+    """当前用户不具备回答资格。"""
+
+    Code, Msg = 18302, "当前无权回答该问题"
+
+
+class QaExpertContentLockedError(BaseErrorCode):
+    """首答后正文/类型/邀请已锁定。"""
+
+    Code, Msg = 18303, "问题内容已锁定，不可编辑"
+
+
+class QaExpertAdoptLimitError(BaseErrorCode):
+    """同题采纳槽位已满（最多 3 条）。"""
+
+    Code, Msg = 18304, "每个问题最多采纳 3 个回答"
+
+
+class QaExpertPublishNotAllowedError(BaseErrorCode):
+    """不可发起或审批转公开。"""
+
+    Code, Msg = 18305, "当前无权发起或审批转公开"
+
+
+class QaExpertPublishConflictError(BaseErrorCode):
+    """已有进行中的转公开申请。"""
+
+    Code, Msg = 18306, "已有进行中的转公开申请"
+
+
+class QaExpertAdminRequiredError(BaseErrorCode):
+    """需要专家库管理员（Portal isPortalAdmin），不是平台超管门闸。"""
+
+    Code, Msg = 18307, "需要专家库管理员权限"
+
+
+class QaExpertDisabledError(BaseErrorCode):
+    """专家已停用，不可新回答。"""
+
+    Code, Msg = 18308, "专家已停用"
+
+
+class QaExpertCommentNotAllowedError(BaseErrorCode):
+    """定向题须先提交有效回答才能评论（追问除外）。"""
+
+    Code, Msg = 18309, "定向题须先提交有效回答后才能评论"
+
+
+class QaExpertPublishDurationInvalidError(BaseErrorCode):
+    """转公开有效期仅允许 1/3/7 天。"""
+
+    Code, Msg = 18310, "转公开有效期不合法"
+
+
+class QaExpertAnonymousRevealRequiredError(BaseErrorCode):
+    """定向且勾选匿名时，必须预选转公开后是否公开姓名。"""
+
+    Code, Msg = 18311, "定向匿名须选择转公开后是否公开姓名"

--- a/src/backend/bisheng/core/database/alembic/versions/v2_6_0_f090_merge_f083_f087_f089.py
+++ b/src/backend/bisheng/core/database/alembic/versions/v2_6_0_f090_merge_f083_f087_f089.py
@@ -1,0 +1,33 @@
+# ruff: noqa: RUF002
+"""合并 Alembic 三 head：F083 专家问答 + 全文 outbox + 积分 last_earned_at。
+
+Revision ID: f090_merge_f083_f087_f089
+Revises: f083_expert_qa_enhancement, f087_knowledge_fulltext_outbox, f089_points_last_earned_at
+Create Date: 2026-08-15
+
+三条链路均从 f086_merge_points_qa_images 分叉，本空合并 revision 收口为单 head。
+无 DDL、无回填、不改表。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+revision: str = "f090_merge_f083_f087_f089"
+down_revision: str | Sequence[str] | None = (
+    "f083_expert_qa_enhancement",
+    "f087_knowledge_fulltext_outbox",
+    "f089_points_last_earned_at",
+)
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """空合并：三侧 schema 已由各自 revision 完成。"""
+    pass
+
+
+def downgrade() -> None:
+    """空合并无反向 DDL。"""
+    pass

--- a/src/backend/bisheng/core/database/tenant_filter.py
+++ b/src/backend/bisheng/core/database/tenant_filter.py
@@ -47,6 +47,7 @@ _TENANT_AWARE_MODEL_MODULES = (
     "bisheng.database.models.audit_log",
     "bisheng.database.models.department",
     "bisheng.database.models.message",
+    "bisheng.database.models.qa_expert",
     "bisheng.database.models.session",
     "bisheng.knowledge.domain.models.knowledge",
     "bisheng.knowledge.domain.models.department_knowledge_space",

--- a/src/backend/bisheng/database/models/qa_expert.py
+++ b/src/backend/bisheng/database/models/qa_expert.py
@@ -1,3 +1,4 @@
+# ruff: noqa: RUF001, RUF002, RUF003
 """
 Expert QA Database Models - SQLModel ORM
 
@@ -5,83 +6,79 @@ Expert QA Database Models - SQLModel ORM
 """
 
 from datetime import datetime
-from typing import Optional, List, TYPE_CHECKING
-from sqlmodel import SQLModel, Field, Relationship, Column, String
-from bisheng.core.database.dialect_helpers import JsonType, LargeText
 
-if TYPE_CHECKING:
-    from bisheng.database.models.user_link import User
+from sqlalchemy import DateTime, UniqueConstraint
+from sqlmodel import Column, Field, SQLModel
 
+from bisheng.core.database.dialect_helpers import UPDATE_TIME_SERVER_DEFAULT, LargeText
 
 # ==================== 专家表 ====================
 
+
 class Expert(SQLModel, table=True):
     """专家表"""
+
     __tablename__ = "qa_expert"
-    
-    id: Optional[int] = Field(default=None, primary_key=True)
+
+    id: int | None = Field(default=None, primary_key=True)
+    tenant_id: int = Field(default=1, index=True, description="租户ID")
     user_id: int = Field(index=True)
     expert_name: str = Field(index=True)
-    introduction: Optional[str] = None
-    depart_ment: Optional[str] = Field(
-        default=None,
-        description="所属部门，JSON 格式"
-    )
-    major: Optional[str] = Field(
-        default=None,
-        description="所属专业"
-    )
-    position: Optional[str] = Field(
-        default=None,
-        description="所属岗位"
-    )
-    job_family: Optional[str] = Field(
-        default=None,
-        description="所属岗位族"
-    )
-    job_category: Optional[str] = Field(
-        default=None,
-        description="所属岗位分类"
-    )
-    
+    introduction: str | None = None
+    depart_ment: str | None = Field(default=None, description="所属部门，JSON 格式")
+    major: str | None = Field(default=None, description="所属专业")
+    position: str | None = Field(default=None, description="所属岗位")
+    job_family: str | None = Field(default=None, description="所属岗位族")
+    job_category: str | None = Field(default=None, description="所属岗位分类")
+
     # 统计字段
     answer_count: int = Field(default=0)
     adoption_count: int = Field(default=0)
     vote_count: int = Field(default=0)
-    
+    # 1 有效 / 0 停用；历史行迁移默认有效
+    status: int = Field(default=1, description="专家状态：1有效 0停用")
+
     # 时间戳
     created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
-    
-
 
 
 # ==================== 问题表 ====================
 
+
 class Question(SQLModel, table=True):
     """问题表"""
+
     __tablename__ = "qa_question"
-    
-    id: Optional[int] = Field(default=None, primary_key=True)
+
+    id: int | None = Field(default=None, primary_key=True)
+    tenant_id: int = Field(default=1, index=True, description="租户ID")
     user_id: int = Field(index=True)
     title: str = Field(index=True)
     description: str
     business_domain: str = Field(index=True)
     status: int = Field(default=0, index=True)  # 0: 未解决, 1: 已解决, 2: 已关闭 3.待采纳
-    attachments: Optional[str] = Field(
+    question_type: str = Field(default="public", max_length=16, description="问题类型：directed/public")
+    content_locked: int = Field(default=0, description="首个有效回答后内容锁定")
+    asker_anonymous: int = Field(default=0, description="提问者是否匿名（公开/定向均可）")
+    asker_reveal_on_public: int | None = Field(default=None, description="定向且匿名时：转公开后是否公开提问者姓名")
+    adopt_count: int = Field(default=0, description="有效采纳条数（0–3）")
+    resolved_at: datetime | None = Field(default=None, description="首次采纳成功时间")
+    active_publish_request_id: int | None = Field(default=None, description="当前有效转公开申请ID（无则空）")
+    attachments: str | None = Field(
         default=None,
         sa_column=Column(LargeText),
         description="分号分隔的持久化附件引用或业务 ID",
     )
-    related_docs: Optional[str] = Field(default=None, description="关联文档 ID 列表")
-    invited_experts: Optional[str] = Field(default=None, description="被邀请的专家 ID 列表")
-    
-    experts_names: Optional[str] = Field(default=None, description="邀请专家名称，多个用分号;分割")
-    image_url: Optional[str] = Field(default=None, max_length=1024, schema_extra={"comment": "持久化图片引用"})
-    file_url: Optional[str] = Field(default=None, max_length=1024, schema_extra={"comment": "持久化附件引用"})
-    file_name: Optional[str] = Field(default=None, max_length=512, schema_extra={"comment": "文件名"})
+    related_docs: str | None = Field(default=None, description="关联文档 ID 列表")
+    invited_experts: str | None = Field(default=None, description="被邀请的专家 ID 列表")
+
+    experts_names: str | None = Field(default=None, description="邀请专家名称，多个用分号;分割")
+    image_url: str | None = Field(default=None, max_length=1024, schema_extra={"comment": "持久化图片引用"})
+    file_url: str | None = Field(default=None, max_length=1024, schema_extra={"comment": "持久化附件引用"})
+    file_name: str | None = Field(default=None, max_length=512, schema_extra={"comment": "文件名"})
     # 采纳的最佳回答
-    adopted_answer_id: Optional[int] = None
+    adopted_answer_id: int | None = None
     # 统计字段
     vote_count: int = Field(default=0)
     answer_count: int = Field(default=0, index=True)
@@ -90,133 +87,243 @@ class Question(SQLModel, table=True):
     # 时间戳
     created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
-    created_by: Optional[str] = Field(default=None, description="创建人")
-    
- 
-
+    created_by: str | None = Field(default=None, description="创建人")
 
 
 # ==================== 回答表 ====================
 
+
 class Answer(SQLModel, table=True):
     """回答表"""
+
     __tablename__ = "qa_answer"
-    
-    id: Optional[int] = Field(default=None, primary_key=True)
+
+    id: int | None = Field(default=None, primary_key=True)
+    tenant_id: int = Field(default=1, index=True, description="租户ID")
     question_id: int = Field(index=True)
-    expert_id: Optional[int] = Field(default=None, index=True)
-    expert_name: Optional[str] = Field(default=None, description="回答者名称（专家可选）")
+    expert_id: int | None = Field(default=None, index=True)
+    user_id: int | None = Field(default=None, index=True, description="回答者用户ID")
+    expert_name: str | None = Field(default=None, description="回答者名称（专家可选）")
     content: str
     status: int = Field(default=1, index=True)  # 1: normal, 2: adopted, 3: deleted
+    anonymous: int = Field(default=0, description="本回答是否匿名（公开题）")
+    reveal_on_public: int | None = Field(default=None, description="定向题：转公开后是否公开姓名")
     # 附件和关联文档
-    attachments: Optional[str] = Field(
+    attachments: str | None = Field(
         default=None,
         sa_column=Column(LargeText),
         description="分号分隔的持久化附件引用或业务 ID",
     )
-    related_docs: Optional[str] = Field(
-        default=None,
-    
-        description="关联文档 ID 列表"
-    )
-    images_url: Optional[str] = Field(
-        default=None,
-        sa_column=Column(LargeText),
-        description="分号分隔的持久化图片引用"
-    )
+    related_docs: str | None = Field(default=None, description="关联文档 ID 列表")
+    images_url: str | None = Field(default=None, sa_column=Column(LargeText), description="分号分隔的持久化图片引用")
     # 统计字段
     vote_count: int = Field(default=0)
     comment_count: int = Field(default=0)
-    adopted: Optional[bool] = Field(default=False, index=True)  # 是否被采纳  
+    adopted: bool | None = Field(default=False, index=True)  # 是否被采纳
     # 时间戳
     created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
-    
-  
-
 
 
 # ==================== 评论/追问表 ====================
 
+
 class Comment(SQLModel, table=True):
     """评论/追问表"""
+
     __tablename__ = "qa_comment"
-    
-    id: Optional[int] = Field(default=None, primary_key=True)
+
+    id: int | None = Field(default=None, primary_key=True)
+    tenant_id: int = Field(default=1, index=True, description="租户ID")
     answer_id: int = Field(index=True)
     question_id: int = Field(index=True)
     user_id: int = Field(index=True)
-    user_name: Optional[str] = Field(default=None, description="评论者名称")
+    user_name: str | None = Field(default=None, description="评论者名称")
     content: str
     is_follow_up: bool = Field(default=False)  # True 为追问，False 为评论
+    anonymous: int = Field(default=0, description="评论是否匿名")
+    reveal_on_public: int | None = Field(default=None, description="定向阶段预存：转公开后是否公开姓名")
     # 统计字段
     vote_count: int = Field(default=0)
     # 时间戳
     created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
-    
+
+
+# ==================== F083 正规化表（邀请 / 采纳 / 匿名 / 资格 / 转公开） ====================
+
+QUESTION_TYPE_PUBLIC = "public"
+QUESTION_TYPE_DIRECTED = "directed"
+EXPERT_STATUS_ACTIVE = 1
+EXPERT_STATUS_DISABLED = 0
+ANSWER_STATUS_NORMAL = 1
+ANSWER_STATUS_DELETED = 3
+PUBLISH_STATUS_PENDING = "pending"
+PUBLISH_DECISION_PENDING = "pending"
+
+
+class QuestionInvite(SQLModel, table=True):
+    """问题邀请的专家；取代 invited_experts 分号串作为真相源。"""
+
+    __tablename__ = "qa_question_invite"
+    __table_args__ = (UniqueConstraint("question_id", "expert_id", name="uk_qa_invite_q_expert"),)
+
+    id: int | None = Field(default=None, primary_key=True)
+    tenant_id: int = Field(default=1, index=True, description="租户ID")
+    question_id: int = Field(index=True, description="问题ID")
+    expert_id: int = Field(description="专家档案ID（qa_expert.id）")
+    user_id: int = Field(index=True, description="专家对应用户ID")
+    created_at: datetime = Field(default_factory=datetime.utcnow, description="创建时间")
+
+
+class AnswerAdopt(SQLModel, table=True):
+    """问题采纳槽位（每题最多 3 条，每回答最多 1 次）。"""
+
+    __tablename__ = "qa_answer_adopt"
+    __table_args__ = (
+        UniqueConstraint("answer_id", name="uk_qa_adopt_answer"),
+        UniqueConstraint("question_id", "answer_id", name="uk_qa_adopt_q_answer"),
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    tenant_id: int = Field(default=1, index=True, description="租户ID")
+    question_id: int = Field(index=True, description="问题ID")
+    answer_id: int = Field(description="回答ID")
+    expert_user_id: int = Field(description="被采纳回答者用户ID")
+    adopted_by: int = Field(description="提问者用户ID")
+    created_at: datetime = Field(default_factory=datetime.utcnow, description="创建时间")
+
+
+class AnonymousAlias(SQLModel, table=True):
+    """题内稳定匿名别名；序号不因删内容回收。"""
+
+    __tablename__ = "qa_anonymous_alias"
+    __table_args__ = (
+        UniqueConstraint("question_id", "user_id", name="uk_qa_alias_q_user"),
+        UniqueConstraint("question_id", "alias_ord", name="uk_qa_alias_q_ord"),
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    tenant_id: int = Field(default=1, index=True, description="租户ID")
+    question_id: int = Field(index=True, description="问题ID")
+    user_id: int = Field(description="用户ID")
+    alias_ord: int = Field(description="分配序号（从1起，不回收）")
+    alias_label: str = Field(max_length=32, description="匿名展示名，如匿名同事A")
+    created_at: datetime = Field(default_factory=datetime.utcnow, description="创建时间")
+
+
+class AnswerEligibility(SQLModel, table=True):
+    """公开题首次采纳后的回答资格快照。"""
+
+    __tablename__ = "qa_answer_eligibility"
+    __table_args__ = (UniqueConstraint("question_id", "user_id", name="uk_qa_elig_q_user"),)
+
+    id: int | None = Field(default=None, primary_key=True)
+    tenant_id: int = Field(default=1, index=True, description="租户ID")
+    question_id: int = Field(index=True, description="问题ID")
+    user_id: int = Field(description="有资格专家用户ID")
+    source: str = Field(max_length=32, description="资格来源：invited / pre_adopt_answer")
+    created_at: datetime = Field(default_factory=datetime.utcnow, description="创建时间")
+
+
+class PublishRequest(SQLModel, table=True):
+    """定向题转公开申请头。"""
+
+    __tablename__ = "qa_publish_request"
+
+    id: int | None = Field(default=None, primary_key=True)
+    tenant_id: int = Field(default=1, index=True, description="租户ID")
+    question_id: int = Field(index=True, description="问题ID")
+    initiator_user_id: int = Field(description="发起人用户ID")
+    status: str = Field(max_length=16, description="pending/approved/rejected/expired/ended")
+    duration_days: int = Field(description="有效期天数：1/3/7")
+    expire_at: datetime = Field(description="到期时间")
+    extension_days: int = Field(default=0, description="已累计延期天数（≤3）")
+    version: int = Field(default=0, description="乐观锁版本")
+    created_at: datetime = Field(default_factory=datetime.utcnow, description="创建时间")
+    updated_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        sa_column=Column(DateTime, nullable=False, server_default=UPDATE_TIME_SERVER_DEFAULT),
+        description="更新时间",
+    )
+
+
+class PublishApprover(SQLModel, table=True):
+    """转公开申请的审批人及决策。"""
+
+    __tablename__ = "qa_publish_approver"
+    __table_args__ = (UniqueConstraint("request_id", "user_id", name="uk_qa_pub_appr"),)
+
+    id: int | None = Field(default=None, primary_key=True)
+    tenant_id: int = Field(default=1, index=True, description="租户ID")
+    request_id: int = Field(index=True, description="转公开申请ID")
+    user_id: int = Field(index=True, description="审批人用户ID")
+    role_in_request: str = Field(max_length=16, description="asker / answerer")
+    decision: str = Field(max_length=32, description="pending/approved/rejected/default_approved")
+    decided_at: datetime | None = Field(default=None, description="决策时间")
+    created_at: datetime = Field(default_factory=datetime.utcnow, description="创建时间")
+
 
 # ==================== 投票表 ====================
 
+
 class QuestionVote(SQLModel, table=True):
     """问题投票（赞）记录"""
+
     __tablename__ = "qa_question_vote"
-    
-    id: Optional[int] = Field(default=None, primary_key=True)
+
+    id: int | None = Field(default=None, primary_key=True)
     user_id: int = Field(index=True)
     question_id: int = Field(index=True)
-    
+
     # 时间戳
     created_at: datetime = Field(default_factory=datetime.utcnow)
-    
-
 
 
 class AnswerVote(SQLModel, table=True):
     """回答投票（赞/有用）记录"""
+
     __tablename__ = "qa_answer_vote"
-    
-    id: Optional[int] = Field(default=None, primary_key=True)
+
+    id: int | None = Field(default=None, primary_key=True)
     user_id: int = Field(index=True)
     answer_id: int = Field(index=True)
     vote_type: str = Field(default="helpful")  # helpful 有用，support 支持
     # 时间戳
     created_at: datetime = Field(default_factory=datetime.utcnow)
-    
-
 
 
 class CommentVote(SQLModel, table=True):
     """评论投票（赞）记录"""
+
     __tablename__ = "qa_comment_vote"
-    
-    id: Optional[int] = Field(default=None, primary_key=True)
+
+    id: int | None = Field(default=None, primary_key=True)
     user_id: int = Field(index=True)
     comment_id: int = Field(index=True)
-    
+
     # 时间戳
     created_at: datetime = Field(default_factory=datetime.utcnow)
-    
-
 
 
 # ==================== 通知表 ====================
 
+
 class QANotification(SQLModel, table=True):
     """专家问答站内消息"""
+
     __tablename__ = "qa_notification"
-    
-    id: Optional[int] = Field(default=None, primary_key=True)
+
+    id: int | None = Field(default=None, primary_key=True)
     recipient_id: int = Field(index=True)
     sender_id: int = Field(index=True)
     notification_type: str = Field(index=True)  # invited, answered, commented, adopted
     question_id: int = Field(index=True)
-    answer_id: Optional[int] = Field(default=None)
+    answer_id: int | None = Field(default=None)
     content: str
     read: bool = Field(default=False, index=True)
-    
+
     # 多租户字段
     tenant_id: int = Field(default=1, index=True)
-    
+
     # 时间戳
     created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
-    

--- a/src/backend/bisheng/qa_expert/api/endpoints.py
+++ b/src/backend/bisheng/qa_expert/api/endpoints.py
@@ -1,3 +1,4 @@
+# ruff: noqa: RUF002
 """
 Expert QA API Endpoints - HTTP 路由处理层
 """
@@ -31,6 +32,7 @@ from bisheng.qa_expert.domain.schemas import (
     ExpertUpdateRequest,
     GetCommentsRequest,
     ModerateDeleteRequest,
+    PublishCreateRequest,
     QAExpertStatsResponse,
     QANotificationResponse,
     QuestionCheckRequest,
@@ -141,13 +143,19 @@ async def list_expert_filter_options(
 
 
 @router.post("/experts", response_model=ExpertResponse)
-async def create_expert(request: ExpertCreateRequest, service: ExpertService = Depends(get_expert_service)):
-    """创建专家（管理员操作）"""
+async def create_expert(
+    request: ExpertCreateRequest,
+    user: UserPayload = Depends(UserPayload.get_login_user),
+    service: ExpertService = Depends(get_expert_service),
+):
+    """创建专家（专家库管理员）"""
     try:
-        expert = await service.create_expert(request)
+        expert = await service.create_expert(request, user=user)
         return resp_200(data=expert)
+    except BaseErrorCode as exc:
+        return exc.return_resp_instance()
     except Exception as e:
-        return resp_500(code=500, msg=str(e))
+        return resp_500(code=500, message=str(e))
 
 
 @router.put("/experts/{expert_id}", response_model=ExpertResponse)
@@ -159,26 +167,62 @@ async def update_expert(
 ):
     """更新专家信息"""
     try:
-        expert = await service.update_expert(expert_id, request)
+        expert = await service.update_expert(expert_id, request, user=user)
         return resp_200(data=expert)
+    except BaseErrorCode as exc:
+        return exc.return_resp_instance()
     except Exception as e:
-        return resp_500(code=500, msg=str(e))
+        return resp_500(code=500, message=str(e))
 
 
-@router.delete("/experts/{expert_id}")
+@router.delete("/experts/{expert_id}", deprecated=True)
 async def delete_expert(
     expert_id: int,
     user: UserPayload = Depends(UserPayload.get_login_user),
     service: ExpertService = Depends(get_expert_service),
 ):
-    """删除专家"""
+    """删除专家（兼容：映射为停用）"""
     try:
-        success = await service.delete_expert(expert_id)
+        success = await service.delete_expert(expert_id, user=user)
         if not success:
-            return resp_500(code=500, msg="Failed to delete expert")
-        return resp_200(data={"message": "Expert deleted successfully"})
+            return resp_500(code=500, message="Failed to disable expert")
+        return resp_200(data={"message": "Expert disabled successfully", "deprecated": True})
+    except BaseErrorCode as exc:
+        return exc.return_resp_instance()
     except Exception as e:
-        return resp_500(code=500, msg=str(e))
+        return resp_500(code=500, message=str(e))
+
+
+@router.post("/experts/{expert_id}/disable")
+async def disable_expert(
+    expert_id: int,
+    user: UserPayload = Depends(UserPayload.get_login_user),
+    service: ExpertService = Depends(get_expert_service),
+):
+    """停用专家"""
+    try:
+        expert = await service.disable_expert(expert_id, user)
+        return resp_200(data=_jsonable(expert))
+    except BaseErrorCode as exc:
+        return exc.return_resp_instance()
+    except Exception as e:
+        return resp_500(code=500, message=str(e))
+
+
+@router.post("/experts/{expert_id}/enable")
+async def enable_expert(
+    expert_id: int,
+    user: UserPayload = Depends(UserPayload.get_login_user),
+    service: ExpertService = Depends(get_expert_service),
+):
+    """恢复专家"""
+    try:
+        expert = await service.enable_expert(expert_id, user)
+        return resp_200(data=_jsonable(expert))
+    except BaseErrorCode as exc:
+        return exc.return_resp_instance()
+    except Exception as e:
+        return resp_500(code=500, message=str(e))
 
 
 @router.get("/experts/name/{expert_name}")
@@ -263,20 +307,22 @@ async def list_questions(
 ):
     """问题列表"""
 
-    user_id = user.user_id if (query.status == 3 or query.status == 4) else None
-
     questions, total = await service.list_questions(
         business_domain=query.domain,
         status=query.status,
         sort_by=query.sort_by,
-        user_id=user_id,
+        user_id=user.user_id,
         skip=(query.page - 1) * query.page_size,
         limit=query.page_size,
+        user=user,
+        list_filter=query.filter,
+        display_status=query.display_status,
+        keyword=query.keyword,
     )
 
     return resp_200(
         data={
-            "questions": questions,
+            "questions": [question_detail_payload(item) for item in questions],
             "total": total,
         }
     )
@@ -310,6 +356,74 @@ async def update_question(
     return resp_200(data=question)
 
 
+def question_detail_payload(question) -> dict:
+    """把 ORM 上挂的响应态字段打进 JSON。
+
+    SQLModel.model_dump() 只含表列。无关联文档时旧逻辑直接返回 ORM，
+    capabilities / display_status / asker 会被丢掉，详情页就会没有回答框、采纳、转公开入口。
+    """
+    if isinstance(question, dict):
+        payload = dict(question)
+    elif hasattr(question, "model_dump"):
+        payload = question.model_dump()
+    else:
+        payload = {}
+    for key in (
+        "display_status",
+        "capabilities",
+        "related_doc_views",
+        "asker",
+        "latest_answer",
+        "active_publish_request",
+        "latest_publish_request",
+        "question_type",
+        "content_locked",
+    ):
+        value = getattr(question, key, payload.get(key))
+        if value is not None:
+            payload[key] = value
+    caps = payload.get("capabilities")
+    if caps is not None and not isinstance(caps, dict):
+        payload["capabilities"] = getattr(caps, "__dict__", caps)
+    views = payload.get("related_doc_views")
+    if views:
+        payload["related_docs"] = views
+        payload["related_doc_views"] = views
+    # 匿名题不得把 created_by 真名留给前端自己藏；非管理员 JSON 改成别名。
+    asker = payload.get("asker")
+    if isinstance(asker, dict) and asker.get("anonymous") and "real_name" not in asker:
+        payload["created_by"] = asker.get("display_name")
+    return payload
+
+
+def answer_payload(answer) -> dict:
+    """回答 JSON：SQLModel dump 不含 author；匿名时 expert_name 改成别名，不写回表列。"""
+    if isinstance(answer, dict):
+        payload = dict(answer)
+        author = payload.get("author")
+    elif hasattr(answer, "model_dump"):
+        try:
+            payload = answer.model_dump(mode="json")
+        except TypeError:
+            payload = answer.model_dump()
+        author = getattr(answer, "author", payload.get("author"))
+    else:
+        payload = {}
+        author = getattr(answer, "author", None)
+    if author is not None:
+        payload["author"] = author
+    if isinstance(author, dict) and author.get("anonymous") and "real_name" not in author:
+        payload["expert_name"] = author.get("display_name")
+    return payload
+
+
+def comment_payload(comment) -> dict:
+    """评论 JSON：走 CommentDetailResponse，匿名时 user_name 为别名。"""
+    if isinstance(comment, dict):
+        return dict(comment)
+    return CommentDetailResponse.from_comment(comment).model_dump(mode="json")
+
+
 @router.get("/questions/{question_id}", response_model=QuestionDetailResponse)
 async def get_question_detail(
     question_id: int,
@@ -317,8 +431,25 @@ async def get_question_detail(
     service: QuestionService = Depends(get_question_service),
 ):
     """获取问题详情"""
-    question = await service.get_question_detail(question_id, user.user_id)
-    return resp_200(data=question)
+    question = await service.get_question_detail(question_id, user.user_id, user=user)
+    return resp_200(data=question_detail_payload(question))
+
+
+@router.get("/questions/similar", response_model=QuestionPageData)
+async def list_similar_questions(
+    text: str = Query(default="", max_length=200),
+    limit: int = Query(default=5, ge=1, le=10),
+    user: UserPayload = Depends(UserPayload.get_login_user),
+    service: QuestionService = Depends(get_question_service),
+):
+    """类似问题：仅返回当前用户可见的题，不阻断发布。"""
+    questions = await service.find_similar_questions(user=user, text=text, limit=limit)
+    return resp_200(
+        data={
+            "questions": [question_detail_payload(item) for item in questions],
+            "total": len(questions),
+        }
+    )
 
 
 @router.post("/questions/{question_id}/adopt", response_model=QuestionDetailResponse)
@@ -349,7 +480,7 @@ async def delete_question(
 
         return resp_200(data={"success": success})
     except Exception as e:
-        return resp_500(code=500, msg=str(e))
+        return resp_500(code=500, message=str(e))
 
 
 # ==================== 回答管理 Endpoints ====================
@@ -370,8 +501,10 @@ async def create_answer(
     if not user.user_id:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
 
-    answer = await service.create_answer(user.user_id, request, tenant_id=user.tenant_id)
-    return resp_200(data=answer)
+    answer = await service.create_answer(user.user_id, request, tenant_id=user.tenant_id, user=user)
+    if not isinstance(answer, dict):
+        answer = await service.attach_author(answer, user)
+    return resp_200(data=answer_payload(answer))
 
 
 # 根据问题id获取回答数据
@@ -385,8 +518,8 @@ async def get_answers(
     service: AnswerService = Depends(get_answer_service),
 ):
     """获取问题的所有回答"""
-    answers, total = await service.get_answers(question_id, (page - 1) * page_size, page_size, sort_by)
-    return resp_200(data={"answers": answers, "total": total})
+    answers, total = await service.get_answers(question_id, (page - 1) * page_size, page_size, sort_by, user=user)
+    return resp_200(data={"answers": [answer_payload(item) for item in answers], "total": total})
 
 
 @router.get("/questions/{question_id}/answers")
@@ -397,8 +530,8 @@ async def get_answersbyname(
     service: AnswerService = Depends(get_answer_service),
 ):
     """获取问题的所有回答"""
-    answers = await service.get_by_expertname(expert_name, question_id)
-    return resp_200(data=answers)
+    answers = await service.get_by_expertname(expert_name, question_id, user=user)
+    return resp_200(data=answer_payload(answers) if answers is not None else answers)
 
 
 @router.put("/answers/{answer_id}", response_model=AnswerDetailResponse)
@@ -422,7 +555,7 @@ async def update_answer(
 
         return resp_200(data=answer)
     except Exception as e:
-        return resp_500(code=500, msg=str(e))
+        return resp_500(code=500, message=str(e))
 
 
 @router.delete("/answers/{answer_id}")
@@ -437,7 +570,7 @@ async def delete_answer(
 
         return resp_200(data={"success": success})
     except Exception as e:
-        return resp_500(code=500, msg=str(e))
+        return resp_500(code=500, message=str(e))
 
 
 # ==================== 评论管理 Endpoints ====================
@@ -459,8 +592,9 @@ async def create_comment(
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
 
     comment = await service.create_comment(user.user_id, user.user_name, request)
-
-    return resp_200(data=comment)
+    if not isinstance(comment, dict):
+        comment = await service.attach_author(comment, user)
+    return resp_200(data=comment_payload(comment))
 
 
 @router.post("/admin/moderate-delete")
@@ -492,7 +626,7 @@ async def moderate_delete(
         return exc.return_resp_instance()
     except Exception as e:
         logger.exception("qa.moderate_delete.failed")
-        return resp_500(code=500, msg=str(e))
+        return resp_500(code=500, message=str(e))
 
 
 @router.post(
@@ -500,7 +634,7 @@ async def moderate_delete(
 )
 async def get_allcomments(
     request: GetCommentsRequest,
-    _user: UserPayload = Depends(UserPayload.get_login_user),
+    user: UserPayload = Depends(UserPayload.get_login_user),
     service: CommentService = Depends(get_comment_service),
 ):
     """获取回答的评论"""
@@ -509,6 +643,7 @@ async def get_allcomments(
         request.question_id,
         (request.page - 1) * request.page_size,
         request.page_size,
+        user=user,
     )
     page_data = CommentPageData(
         comments=[CommentDetailResponse.from_comment(comment) for comment in comments],
@@ -623,3 +758,66 @@ async def upload_file(*, file: UploadFile = File(...)):
 
     finally:
         await file.close()
+
+
+async def get_publish_service():
+    """依赖注入：转公开服务"""
+    from bisheng.qa_expert.domain.publish_service import PublishService
+
+    return PublishService()
+
+
+def _jsonable(row):
+    """把 SQLModel/Pydantic 转成可进 UnifiedResponse 的 dict。"""
+    dump = getattr(row, "model_dump", None)
+    if callable(dump):
+        try:
+            return dump(mode="json")
+        except TypeError:
+            return dump()
+    return row
+
+
+@router.post("/questions/{question_id}/publish-requests")
+async def create_publish_request(
+    question_id: int,
+    request: PublishCreateRequest,
+    user: UserPayload = Depends(UserPayload.get_login_user),
+    service=Depends(get_publish_service),
+):
+    """发起转公开申请"""
+    row = await service.create_publish_request(question_id, user, request.duration_days)
+    return resp_200(data=_jsonable(row))
+
+
+@router.post("/publish-requests/{request_id}/approve")
+async def approve_publish_request(
+    request_id: int,
+    user: UserPayload = Depends(UserPayload.get_login_user),
+    service=Depends(get_publish_service),
+):
+    """同意转公开"""
+    row = await service.decide_publish(request_id, user, "approved")
+    return resp_200(data=_jsonable(row))
+
+
+@router.post("/publish-requests/{request_id}/reject")
+async def reject_publish_request(
+    request_id: int,
+    user: UserPayload = Depends(UserPayload.get_login_user),
+    service=Depends(get_publish_service),
+):
+    """拒绝转公开"""
+    row = await service.decide_publish(request_id, user, "rejected")
+    return resp_200(data=_jsonable(row))
+
+
+@router.get("/publish-requests/{request_id}")
+async def get_publish_request(
+    request_id: int,
+    user: UserPayload = Depends(UserPayload.get_login_user),
+    service=Depends(get_publish_service),
+):
+    """读取转公开申请（读时惰性过期）"""
+    row = await service.get_request(request_id, user)
+    return resp_200(data=_jsonable(row))

--- a/src/backend/bisheng/qa_expert/api/router.py
+++ b/src/backend/bisheng/qa_expert/api/router.py
@@ -7,6 +7,7 @@ router.include_router(qa_router)
 """
 
 from fastapi import APIRouter
+
 from bisheng.qa_expert.api import endpoints
 
 # 创建路由
@@ -25,6 +26,8 @@ router.add_api_route(
 )
 router.add_api_route("/experts", endpoints.create_expert, methods=["POST"])
 router.add_api_route("/experts/{expert_id}", endpoints.update_expert, methods=["PUT"])
+router.add_api_route("/experts/{expert_id}/disable", endpoints.disable_expert, methods=["POST"])
+router.add_api_route("/experts/{expert_id}/enable", endpoints.enable_expert, methods=["POST"])
 router.add_api_route("/experts/{expert_id}", endpoints.delete_expert, methods=["DELETE"])
 router.add_api_route("/experts/name/{expert_name}", endpoints.expertsinfo, methods=["GET"])
 router.add_api_route("/experts/userid/{user_id}", endpoints.expertsinfo_id, methods=["GET"])
@@ -37,10 +40,31 @@ router.add_api_route("/questions", endpoints.create_question, methods=["POST"])
 router.add_api_route("/questions", endpoints.list_questions, methods=["GET"])
 # 静态路由必须放在 /questions/{question_id} 动态路由之前
 router.add_api_route("/questions/answer_count/domain", endpoints.get_answer_count_by_domain, methods=["GET"])
+router.add_api_route("/questions/similar", endpoints.list_similar_questions, methods=["GET"])
 router.add_api_route("/questions/{question_id}", endpoints.update_question, methods=["PUT"])
 router.add_api_route("/questions/{question_id}", endpoints.get_question_detail, methods=["GET"])
 router.add_api_route("/questions/{question_id}/adopt", endpoints.adopt_answer, methods=["POST"])
 router.add_api_route("/questions/{question_id}", endpoints.delete_question, methods=["DELETE"])
+router.add_api_route(
+    "/questions/{question_id}/publish-requests",
+    endpoints.create_publish_request,
+    methods=["POST"],
+)
+router.add_api_route(
+    "/publish-requests/{request_id}/approve",
+    endpoints.approve_publish_request,
+    methods=["POST"],
+)
+router.add_api_route(
+    "/publish-requests/{request_id}/reject",
+    endpoints.reject_publish_request,
+    methods=["POST"],
+)
+router.add_api_route(
+    "/publish-requests/{request_id}",
+    endpoints.get_publish_request,
+    methods=["GET"],
+)
 
 
 # 回答管理

--- a/src/backend/bisheng/qa_expert/domain/capability.py
+++ b/src/backend/bisheng/qa_expert/domain/capability.py
@@ -1,0 +1,248 @@
+# ruff: noqa: RUF002, RUF003
+"""专家问答资格引擎：展示态与写操作 capabilities 的唯一入口。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from bisheng.database.models.qa_expert import (
+    EXPERT_STATUS_ACTIVE,
+    QUESTION_TYPE_DIRECTED,
+    QUESTION_TYPE_PUBLIC,
+)
+
+DISPLAY_UNANSWERED = "unanswered"
+DISPLAY_PENDING_ADOPT = "pending_adopt"
+DISPLAY_SOLVED = "solved"
+UNRESOLVED_DISPLAY_STATUSES = frozenset({DISPLAY_UNANSWERED, DISPLAY_PENDING_ADOPT})
+
+# 对齐 Portal isPortalAdmin：角色名 + admin 账号；同时承认 UserPayload.is_admin()
+_EXPERT_LIBRARY_ADMIN_ROLES = frozenset({"管理员", "系统管理员", "admin"})
+_EXPERT_LIBRARY_ADMIN_ACCOUNTS = frozenset({"admin"})
+
+
+@dataclass(frozen=True)
+class QuestionCapabilities:
+    """详情/写路径共用的可操作项；visible=False 时其余应为 False。"""
+
+    can_edit: bool
+    can_delete_question: bool
+    can_answer: bool
+    can_adopt: bool
+    can_comment: bool
+    can_start_publish: bool
+    can_decide_publish: bool
+    can_view_real_identity: bool
+    visible: bool = True
+
+
+@dataclass(frozen=True)
+class CapabilityResult:
+    """资格引擎输出：派生三态 + capabilities。"""
+
+    display_status: str
+    capabilities: QuestionCapabilities
+
+
+@dataclass(frozen=True)
+class CapabilitySnapshot:
+    """解析资格所需的仓储快照；单测可直接构造，不查库。"""
+
+    expert: Any | None = None
+    invited_user_ids: frozenset[int] = field(default_factory=frozenset)
+    eligibility_user_ids: frozenset[int] = field(default_factory=frozenset)
+    effective_answer_count: int = 0
+    user_has_effective_answer: bool = False
+    has_pending_publish: bool = False
+    latest_publish_status: str | None = None
+    approver_user_ids: frozenset[int] = field(default_factory=frozenset)
+
+
+def derive_display_status(*, effective_answer_count: int, adopt_count: int) -> str:
+    """由有效回答数与采纳数派生三态；不引入「已关闭」。"""
+    if adopt_count > 0:
+        return DISPLAY_SOLVED
+    if effective_answer_count > 0:
+        return DISPLAY_PENDING_ADOPT
+    return DISPLAY_UNANSWERED
+
+
+def is_unresolved(display_status: str) -> bool:
+    """「未解决」筛选 = 未回答 ∪ 待采纳。"""
+    return display_status in UNRESOLVED_DISPLAY_STATUSES
+
+
+def _normalize_identity(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip().lower()
+
+
+def is_expert_library_admin(user: Any | None) -> bool:
+    """专家库管理员：is_admin() 或 Portal 角色名/admin 账号；不查 role_access。"""
+    if user is None:
+        return False
+    is_admin = getattr(user, "is_admin", None)
+    if callable(is_admin) and bool(is_admin()):
+        return True
+    account = _normalize_identity(getattr(user, "user_name", None) or getattr(user, "account", None))
+    if account in _EXPERT_LIBRARY_ADMIN_ACCOUNTS:
+        return True
+    role = getattr(user, "role", None)
+    role_names = getattr(user, "role_names", None)
+    candidates: list[Any] = []
+    if role:
+        candidates.append(role)
+    if isinstance(role_names, (list, tuple, set, frozenset)):
+        candidates.extend(role_names)
+    for name in candidates:
+        if _normalize_identity(name) in {item.lower() for item in _EXPERT_LIBRARY_ADMIN_ROLES}:
+            return True
+        # 中文角色名大小写不变，再按原字面匹配
+        if str(name).strip() in _EXPERT_LIBRARY_ADMIN_ROLES:
+            return True
+    return False
+
+
+def _user_id(user: Any | None) -> int | None:
+    if user is None:
+        return None
+    value = getattr(user, "user_id", None)
+    return int(value) if value is not None else None
+
+
+def _expert_active(snapshot: CapabilitySnapshot) -> bool:
+    expert = snapshot.expert
+    if expert is None:
+        return False
+    status = getattr(expert, "status", EXPERT_STATUS_ACTIVE)
+    return int(status) == EXPERT_STATUS_ACTIVE
+
+
+class CapabilityResolver:
+    """单入口资格引擎；写接口与详情必须复用，避免列表/详情/写路径不一致。"""
+
+    def resolve(self, user: Any | None, question: Any, snapshot: CapabilitySnapshot) -> CapabilityResult:
+        """根据用户、问题与仓储快照计算 display_status 与 capabilities。"""
+        display_status = derive_display_status(
+            effective_answer_count=snapshot.effective_answer_count,
+            adopt_count=int(getattr(question, "adopt_count", 0) or 0),
+        )
+        admin = is_expert_library_admin(user)
+        uid = _user_id(user)
+        asker_id = int(question.user_id)
+        is_asker = uid is not None and uid == asker_id
+        question_type = str(getattr(question, "question_type", QUESTION_TYPE_PUBLIC) or QUESTION_TYPE_PUBLIC)
+        locked = bool(getattr(question, "content_locked", 0))
+        visible = self._is_visible(
+            user=user,
+            question_type=question_type,
+            is_asker=is_asker,
+            uid=uid,
+            snapshot=snapshot,
+            admin=admin,
+        )
+        if not visible:
+            return CapabilityResult(
+                display_status=display_status,
+                capabilities=self._denied(can_view_real_identity=admin),
+            )
+
+        can_mutate_question = is_asker and not locked
+        can_answer = self._can_answer(
+            uid=uid,
+            is_asker=is_asker,
+            question_type=question_type,
+            snapshot=snapshot,
+            adopt_count=int(getattr(question, "adopt_count", 0) or 0),
+        )
+        can_comment = self._can_comment(
+            uid=uid,
+            is_asker=is_asker,
+            question_type=question_type,
+            snapshot=snapshot,
+        )
+        can_start_publish = (
+            question_type == QUESTION_TYPE_DIRECTED
+            and display_status == DISPLAY_SOLVED
+            and not snapshot.has_pending_publish
+            and snapshot.latest_publish_status != "ended"
+            and (is_asker or snapshot.user_has_effective_answer)
+        )
+        can_decide_publish = snapshot.has_pending_publish and uid is not None and uid in snapshot.approver_user_ids
+        return CapabilityResult(
+            display_status=display_status,
+            capabilities=QuestionCapabilities(
+                can_edit=can_mutate_question,
+                can_delete_question=can_mutate_question,
+                can_answer=can_answer,
+                can_adopt=is_asker and int(getattr(question, "adopt_count", 0) or 0) < 3,
+                can_comment=can_comment,
+                can_start_publish=can_start_publish,
+                can_decide_publish=can_decide_publish,
+                can_view_real_identity=admin,
+                visible=True,
+            ),
+        )
+
+    @staticmethod
+    def _denied(*, can_view_real_identity: bool) -> QuestionCapabilities:
+        return QuestionCapabilities(
+            can_edit=False,
+            can_delete_question=False,
+            can_answer=False,
+            can_adopt=False,
+            can_comment=False,
+            can_start_publish=False,
+            can_decide_publish=False,
+            can_view_real_identity=can_view_real_identity,
+            visible=False,
+        )
+
+    @staticmethod
+    def _is_visible(
+        *,
+        user: Any | None,
+        question_type: str,
+        is_asker: bool,
+        uid: int | None,
+        snapshot: CapabilitySnapshot,
+        admin: bool,
+    ) -> bool:
+        if user is None or uid is None:
+            return False
+        if question_type != QUESTION_TYPE_DIRECTED:
+            return True
+        return is_asker or admin or uid in snapshot.invited_user_ids
+
+    @staticmethod
+    def _can_answer(
+        *,
+        uid: int | None,
+        is_asker: bool,
+        question_type: str,
+        snapshot: CapabilitySnapshot,
+        adopt_count: int,
+    ) -> bool:
+        if uid is None or is_asker or not _expert_active(snapshot):
+            return False
+        if question_type == QUESTION_TYPE_DIRECTED:
+            return uid in snapshot.invited_user_ids
+        if adopt_count <= 0:
+            return True
+        return uid in snapshot.eligibility_user_ids
+
+    @staticmethod
+    def _can_comment(
+        *,
+        uid: int | None,
+        is_asker: bool,
+        question_type: str,
+        snapshot: CapabilitySnapshot,
+    ) -> bool:
+        if uid is None:
+            return False
+        if question_type != QUESTION_TYPE_DIRECTED:
+            return True
+        return is_asker or snapshot.user_has_effective_answer

--- a/src/backend/bisheng/qa_expert/domain/capability.py
+++ b/src/backend/bisheng/qa_expert/domain/capability.py
@@ -56,7 +56,9 @@ class CapabilitySnapshot:
     user_has_effective_answer: bool = False
     has_pending_publish: bool = False
     latest_publish_status: str | None = None
+    # 仅仍 pending 的审批人；发起人默认同意后不在此集合，can_decide_publish 为 False。
     approver_user_ids: frozenset[int] = field(default_factory=frozenset)
+    viewer_publish_decision: str | None = None
 
 
 def derive_display_status(*, effective_answer_count: int, adopt_count: int) -> str:
@@ -170,6 +172,7 @@ class CapabilityResolver:
             and snapshot.latest_publish_status != "ended"
             and (is_asker or snapshot.user_has_effective_answer)
         )
+        # 只给尚未决策的审批人；发起人创建时已写入 approved，不能再点同意/拒绝。
         can_decide_publish = snapshot.has_pending_publish and uid is not None and uid in snapshot.approver_user_ids
         return CapabilityResult(
             display_status=display_status,

--- a/src/backend/bisheng/qa_expert/domain/identity.py
+++ b/src/backend/bisheng/qa_expert/domain/identity.py
@@ -1,0 +1,192 @@
+# ruff: noqa: RUF002
+"""题内匿名别名与身份脱敏：序号按首次出现时间递增，删内容不回收。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from bisheng.database.models.qa_expert import QUESTION_TYPE_DIRECTED, QUESTION_TYPE_PUBLIC, AnonymousAlias
+from bisheng.qa_expert.domain.capability import is_expert_library_admin
+from bisheng.qa_expert.domain.repositories import AnonymousAliasRepository
+
+ALIAS_PREFIX = "匿名同事"
+
+
+def alias_label_for_ord(alias_ord: int) -> str:
+    """序号 1→A、2→B；超过 26 用 AA、AB…，永不复用已分配序号。"""
+    if alias_ord <= 0:
+        alias_ord = 1
+    n = alias_ord
+    letters: list[str] = []
+    while n > 0:
+        n, rem = divmod(n - 1, 26)
+        letters.append(chr(ord("A") + rem))
+    return f"{ALIAS_PREFIX}{''.join(reversed(letters))}"
+
+
+@dataclass
+class IdentityView:
+    """服务端已脱敏的身份；真名字段仅管理员可读。"""
+
+    display_name: str
+    avatar_url: str | None
+    anonymous: bool
+    real_user_id: int | None = None
+    real_name: str | None = None
+    department: str | None = None
+    title: str | None = None
+
+    def to_dict(self, *, can_view_real_identity: bool) -> dict[str, Any]:
+        """非管理员不下发真名/真 user_id。"""
+        payload: dict[str, Any] = {
+            "display_name": self.display_name,
+            "avatar_url": self.avatar_url,
+            "anonymous": self.anonymous,
+        }
+        if can_view_real_identity:
+            payload["real_user_id"] = self.real_user_id
+            payload["real_name"] = self.real_name
+            payload["department"] = self.department
+            payload["title"] = self.title
+        return payload
+
+
+def should_reveal_name(
+    *,
+    anonymous: bool,
+    question_type: str,
+    reveal_on_public: bool | int | None,
+) -> bool:
+    """转公开后按预存 reveal_on_public 展示，不再询问。"""
+    if not anonymous:
+        return True
+    if str(question_type or "") != QUESTION_TYPE_PUBLIC:
+        return False
+    return bool(int(reveal_on_public or 0))
+
+
+def persist_anonymous_choice(
+    *,
+    anonymous: bool,
+    reveal_on_public: bool | int | None,
+    question_type: str,
+) -> tuple[int, int | None]:
+    """把客户端匿名选项落成表字段；未匿名不存 reveal。定向匿名必须先选转公开姓名。"""
+    if not anonymous:
+        return 0, None
+    if str(question_type or "") == QUESTION_TYPE_DIRECTED and reveal_on_public is None:
+        from bisheng.common.errcode.qa_expert import QaExpertAnonymousRevealRequiredError
+
+        raise QaExpertAnonymousRevealRequiredError()
+    if reveal_on_public is None:
+        return 1, None
+    return 1, 1 if int(reveal_on_public) else 0
+
+
+def copy_stored_anonymous_flags(
+    anonymous: bool | int | None,
+    reveal_on_public: bool | int | None,
+) -> tuple[int, int | None]:
+    """继承已落库的匿名/转公开姓名，不读客户端覆盖。"""
+    if not int(anonymous or 0):
+        return 0, None
+    if reveal_on_public is None:
+        return 1, None
+    return 1, 1 if int(reveal_on_public) else 0
+
+
+class IdentityService:
+    """读写 qa_anonymous_alias，并把展示身份做成 IdentityView。"""
+
+    def __init__(self, alias_repo: AnonymousAliasRepository | None = None):
+        self.alias_repo = alias_repo or AnonymousAliasRepository()
+        # 列表一次预加载后复用；(question_id, user_id) → 别名。None 表示未预加载。
+        self._alias_cache: dict[tuple[int, int], AnonymousAlias] | None = None
+
+    async def preload_for_questions(self, question_ids: list[int]) -> None:
+        """把本页别名一次载入缓存，后续 mask_identity 不再按人打库。"""
+        rows = await self.alias_repo.list_by_question_ids(question_ids)
+        self._alias_cache = {
+            (int(row.question_id), int(row.user_id)): row
+            for row in rows
+            if getattr(row, "question_id", None) is not None and getattr(row, "user_id", None) is not None
+        }
+
+    async def get_or_assign_alias(
+        self,
+        *,
+        question_id: int,
+        user_id: int,
+        tenant_id: int = 1,
+    ) -> AnonymousAlias:
+        """同题同用户返回已有别名；否则按 max(alias_ord)+1 分配，不回收已删内容序号。"""
+        cache_key = (int(question_id), int(user_id))
+        if self._alias_cache is not None:
+            cached = self._alias_cache.get(cache_key)
+            if cached is not None:
+                return cached
+        else:
+            existing = await self.alias_repo.get_by_question_user(question_id, user_id)
+            if existing is not None:
+                return existing
+        next_ord = await self.alias_repo.next_alias_ord(question_id)
+        row = AnonymousAlias(
+            tenant_id=tenant_id,
+            question_id=question_id,
+            user_id=user_id,
+            alias_ord=next_ord,
+            alias_label=alias_label_for_ord(next_ord),
+        )
+        created = await self.alias_repo.create(row)
+        if self._alias_cache is not None:
+            self._alias_cache[cache_key] = created
+        return created
+
+    async def mask_identity(
+        self,
+        viewer: Any,
+        *,
+        question_id: int,
+        user_id: int,
+        real_name: str,
+        anonymous: bool,
+        question_type: str,
+        reveal_on_public: bool | int | None = None,
+        tenant_id: int = 1,
+        department: str | None = None,
+        title: str | None = None,
+        avatar_url: str | None = None,
+    ) -> IdentityView:
+        """按匿名预选项与问题当前类型生成展示身份；管理员可读真名。"""
+        can_view_real = is_expert_library_admin(viewer)
+        revealed = should_reveal_name(
+            anonymous=anonymous,
+            question_type=question_type,
+            reveal_on_public=reveal_on_public,
+        )
+        display_name = real_name
+        shown_anonymous = False
+        if anonymous and not revealed:
+            alias = await self.get_or_assign_alias(
+                question_id=question_id,
+                user_id=user_id,
+                tenant_id=tenant_id,
+            )
+            display_name = alias.alias_label
+            shown_anonymous = True
+        view = IdentityView(
+            display_name=display_name,
+            avatar_url=None if shown_anonymous else avatar_url,
+            anonymous=shown_anonymous,
+            real_user_id=user_id,
+            real_name=real_name,
+            department=department,
+            title=title,
+        )
+        if not can_view_real:
+            view.real_user_id = None
+            view.real_name = None
+            view.department = None
+            view.title = None
+        return view

--- a/src/backend/bisheng/qa_expert/domain/inbox_notice.py
+++ b/src/backend/bisheng/qa_expert/domain/inbox_notice.py
@@ -1,0 +1,126 @@
+# ruff: noqa: RUF002
+"""专家问答站内信：统一用用户 ID 收件，匿名触发人只写同题别名。"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from loguru import logger
+
+from bisheng.qa_expert.domain.identity import IdentityService
+
+_ANON_VIEWER = SimpleNamespace(user_id=0, is_admin=lambda: False, role=None)
+_SYSTEM_SENDER = 0
+
+
+def _public_user_metadata(*, anonymous: bool, user_id: int) -> dict[str, Any]:
+    """匿名不写 user_id，避免列表接口回填真名和部门。"""
+    if anonymous:
+        return {}
+    return {"user_id": int(user_id)}
+
+
+async def display_name_for_trigger(
+    question,
+    *,
+    user_id: int,
+    real_name: str,
+    anonymous: bool,
+    reveal_on_public: bool | int | None = None,
+) -> tuple[str, bool]:
+    """返回通知展示名；非管理员视角下匿名为同题稳定别名。"""
+    view = await IdentityService().mask_identity(
+        _ANON_VIEWER,
+        question_id=int(question.id),
+        user_id=int(user_id),
+        real_name=real_name or "",
+        anonymous=bool(anonymous),
+        question_type=str(getattr(question, "question_type", "") or ""),
+        reveal_on_public=reveal_on_public,
+        tenant_id=int(getattr(question, "tenant_id", 1) or 1),
+    )
+    return view.display_name, bool(view.anonymous)
+
+
+async def send_qa_inbox(
+    *,
+    action_code: str,
+    system_text: str,
+    question,
+    receivers: list[int],
+    sender_user_id: int,
+    sender_display: str,
+    sender_anonymous: bool,
+    answer_id: int | None = None,
+    comment_id: int | None = None,
+    request_id: int | None = None,
+    instance_id: int | None = None,
+    task_id: int | None = None,
+    tooltip: str | None = None,
+    business_type: str = "qa_question",
+) -> None:
+    """写入 inbox_message；失败只打日志，不回滚业务。"""
+    receivers = list(dict.fromkeys(int(uid) for uid in receivers if uid and int(uid) != int(sender_user_id)))
+    if not receivers:
+        return
+
+    from bisheng.core.database import get_async_db_session
+    from bisheng.message.domain.models.inbox_message import MessageStatusEnum, MessageTypeEnum
+    from bisheng.message.domain.repositories.implementations.inbox_message_read_repository_impl import (
+        InboxMessageReadRepositoryImpl,
+    )
+    from bisheng.message.domain.repositories.implementations.inbox_message_repository_impl import (
+        InboxMessageRepositoryImpl,
+    )
+    from bisheng.message.domain.services.message_service import MessageService
+
+    data: dict[str, Any] = {"question_id": str(question.id)}
+    if answer_id:
+        data["answer_id"] = str(answer_id)
+    if comment_id:
+        data["comment_id"] = str(comment_id)
+    if request_id:
+        data["request_id"] = str(request_id)
+    if instance_id:
+        data["approval_instance_id"] = str(instance_id)
+        data["instance_id"] = str(instance_id)
+    if task_id:
+        data["approval_task_id"] = str(task_id)
+        data["task_id"] = str(task_id)
+    if business_type == "approval_instance_id" and instance_id:
+        data["approval_instance_id"] = str(instance_id)
+        data["business_id"] = str(instance_id)
+
+    content: list[dict[str, Any]] = [
+        {
+            "type": "user",
+            "content": f"@{sender_display}",
+            "metadata": _public_user_metadata(anonymous=sender_anonymous, user_id=sender_user_id),
+        },
+        {"type": "system_text", "content": system_text},
+        {
+            "type": "business_url",
+            "content": f"--{question.title}",
+            "metadata": {"business_type": business_type, "data": data},
+        },
+    ]
+    if tooltip:
+        content.append({"type": "tooltip_text", "content": tooltip[:50]})
+
+    try:
+        async with get_async_db_session() as session:
+            service = MessageService(
+                message_repository=InboxMessageRepositoryImpl(session),
+                message_read_repository=InboxMessageReadRepositoryImpl(session),
+            )
+            await service.send_message(
+                content=content,
+                sender=_SYSTEM_SENDER if sender_anonymous else int(sender_user_id),
+                message_type=MessageTypeEnum.NOTIFY,
+                receiver=receivers,
+                status=MessageStatusEnum.APPROVED,
+                action_code=action_code,
+            )
+    except Exception:
+        logger.exception("qa.inbox.send_failed action_code={}", action_code)

--- a/src/backend/bisheng/qa_expert/domain/publish_approval_bridge.py
+++ b/src/backend/bisheng/qa_expert/domain/publish_approval_bridge.py
@@ -1,0 +1,347 @@
+# ruff: noqa: RUF002, RUF003
+"""转公开适配审批中心：qa_publish_* 为准，instance/task 只做待我处理看板。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from types import SimpleNamespace
+from typing import Any
+
+from loguru import logger
+
+from bisheng.approval.domain.models.approval_instance import (
+    ApprovalActionLog,
+    ApprovalInstance,
+    ApprovalInstanceStatus,
+    ApprovalTask,
+    ApprovalTaskStatus,
+)
+from bisheng.approval.domain.models.approval_scenario import (
+    ApprovalFlowDefinition,
+    ApprovalFlowVersion,
+    ApprovalNodeDefinition,
+    ApprovalRouteRule,
+    ApprovalScenario,
+)
+from bisheng.approval.domain.repositories.approval_instance_repository import ApprovalInstanceRepository
+from bisheng.approval.domain.repositories.approval_scenario_repository import ApprovalScenarioRepository
+
+# 与 publish_service 状态字面量对齐；本模块不反向 import，避免循环。
+DECISION_APPROVED = "approved"
+DECISION_DEFAULT_APPROVED = "default_approved"
+DECISION_PENDING = "pending"
+DECISION_REJECTED = "rejected"
+PUBLISH_APPROVED = "approved"
+PUBLISH_ENDED = "ended"
+PUBLISH_EXPIRED = "expired"
+PUBLISH_PENDING = "pending"
+PUBLISH_REJECTED = "rejected"
+
+QA_PUBLISH_SCENARIO = "qa_question_publish"
+QA_PUBLISH_SCENARIO_NAME = "专家问答转公开"
+QA_PUBLISH_FLOW_CODE = "qa_question_publish_default"
+QA_PUBLISH_NODE_CODE = "qa_publish_and"
+QA_PUBLISH_NODE_NAME = "回答专家会签"
+QA_PUBLISH_BUSINESS_TYPE = "qa_question"
+
+
+@dataclass(frozen=True)
+class QaPublishFlowContract:
+    """租户内转公开待办所需的流程版本与会签节点。"""
+
+    flow_version_id: int
+    node_code: str
+    node_name: str
+    node_order: int
+    route_rule_id: int | None
+    scenario_name: str
+
+
+def business_key_for(request_id: int) -> str:
+    """instance.business_key，用来反查 qa_publish_request。"""
+    return f"qa_publish:{int(request_id)}"
+
+
+def request_id_from_payload(payload: dict[str, Any] | None) -> int | None:
+    """从审批实例快照取出转公开申请 ID。"""
+    if not payload:
+        return None
+    raw = payload.get("request_id") or payload.get("qa_publish_request_id")
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+async def ensure_flow_contract(tenant_id: int) -> QaPublishFlowContract:
+    """幂等预置场景/流程/会签节点，给 approval_task.flow_version_id 用。"""
+    tenant_id = int(tenant_id or 1)
+    scenario = await ApprovalScenarioRepository.get_scenario_by_code(tenant_id, QA_PUBLISH_SCENARIO)
+    if scenario is None:
+        scenario = await ApprovalScenarioRepository.create_scenario(
+            ApprovalScenario(
+                tenant_id=tenant_id,
+                scenario_code=QA_PUBLISH_SCENARIO,
+                scenario_name=QA_PUBLISH_SCENARIO_NAME,
+                enabled=True,
+                display_name=QA_PUBLISH_SCENARIO_NAME,
+            )
+        )
+    elif not scenario.enabled:
+        scenario.enabled = True
+        scenario = await ApprovalScenarioRepository.update_scenario(scenario)
+
+    flows = await ApprovalScenarioRepository.list_flow_definitions(tenant_id, int(scenario.id))
+    flow = next((row for row in flows if row.flow_code == QA_PUBLISH_FLOW_CODE), None)
+    if flow is None:
+        flow = await ApprovalScenarioRepository.create_flow_definition(
+            ApprovalFlowDefinition(
+                tenant_id=tenant_id,
+                scenario_id=int(scenario.id),
+                flow_code=QA_PUBLISH_FLOW_CODE,
+                flow_name=QA_PUBLISH_SCENARIO_NAME,
+                is_active=True,
+            )
+        )
+    version = await ApprovalScenarioRepository.get_active_flow_version(tenant_id, int(flow.id))
+    if version is None:
+        version = await ApprovalScenarioRepository.create_flow_version(
+            ApprovalFlowVersion(
+                tenant_id=tenant_id,
+                flow_definition_id=int(flow.id),
+                version_no=1,
+                is_active=True,
+                definition_snapshot={"nodes": [QA_PUBLISH_NODE_CODE]},
+            )
+        )
+    nodes = await ApprovalScenarioRepository.list_node_definitions(tenant_id, int(version.id))
+    node = next((row for row in nodes if row.node_code == QA_PUBLISH_NODE_CODE), None)
+    if node is None:
+        node = await ApprovalScenarioRepository.create_node_definition(
+            ApprovalNodeDefinition(
+                tenant_id=tenant_id,
+                flow_version_id=int(version.id),
+                node_code=QA_PUBLISH_NODE_CODE,
+                node_name=QA_PUBLISH_NODE_NAME,
+                node_order=1,
+                node_mode="and",
+                approver_config={"sources": [{"type": "direct_user", "user_ids": []}]},
+                extra_config={},
+            )
+        )
+    routes = await ApprovalScenarioRepository.list_route_rules(tenant_id, int(scenario.id))
+    route = next((row for row in routes if int(row.flow_definition_id or 0) == int(flow.id)), None)
+    if route is None:
+        route = await ApprovalScenarioRepository.create_route_rule(
+            ApprovalRouteRule(
+                tenant_id=tenant_id,
+                scenario_id=int(scenario.id),
+                route_name="默认会签",
+                route_type="flow",
+                sort_order=0,
+                flow_definition_id=int(flow.id),
+                match_config={},
+                enabled=True,
+            )
+        )
+    return QaPublishFlowContract(
+        flow_version_id=int(version.id),
+        node_code=str(node.node_code),
+        node_name=str(node.node_name),
+        node_order=int(node.node_order or 1),
+        route_rule_id=int(route.id) if route and route.id else None,
+        scenario_name=str(scenario.scenario_name or QA_PUBLISH_SCENARIO_NAME),
+    )
+
+
+def _instance_status_for(publish_status: str) -> str:
+    mapping = {
+        PUBLISH_PENDING: ApprovalInstanceStatus.PENDING,
+        PUBLISH_APPROVED: ApprovalInstanceStatus.EXECUTED,
+        PUBLISH_REJECTED: ApprovalInstanceStatus.REJECTED,
+        PUBLISH_EXPIRED: ApprovalInstanceStatus.CANCELLED,
+        PUBLISH_ENDED: ApprovalInstanceStatus.CANCELLED,
+    }
+    return mapping.get(str(publish_status), ApprovalInstanceStatus.PENDING)
+
+
+def _task_status_for(decision: str) -> str:
+    if decision in {DECISION_APPROVED, DECISION_DEFAULT_APPROVED}:
+        return ApprovalTaskStatus.APPROVED
+    if decision == DECISION_REJECTED:
+        return ApprovalTaskStatus.REJECTED
+    if decision == DECISION_PENDING:
+        return ApprovalTaskStatus.PENDING
+    return ApprovalTaskStatus.CANCELLED
+
+
+async def _get_instance(request) -> ApprovalInstance | None:
+    tenant_id = int(getattr(request, "tenant_id", 1) or 1)
+    return await ApprovalInstanceRepository.find_latest_by_business_key(
+        tenant_id=tenant_id,
+        scenario_code=QA_PUBLISH_SCENARIO,
+        business_key=business_key_for(int(request.id)),
+    )
+
+
+async def sync_after_create(request, question, initiator, approvers: list[Any]) -> ApprovalInstance | None:
+    """发完转公开通知后，为仍 pending 的审批人建 instance + task。"""
+    try:
+        return await _sync_after_create(request, question, initiator, approvers)
+    except Exception:
+        logger.exception("qa.publish.bridge.create_failed request_id={}", getattr(request, "id", None))
+        return None
+
+
+async def _sync_after_create(request, question, initiator, approvers: list[Any]) -> ApprovalInstance | None:
+    pending_ids = [int(row.user_id) for row in approvers if str(row.decision) == DECISION_PENDING]
+    tenant_id = int(getattr(question, "tenant_id", 1) or 1)
+    contract = await ensure_flow_contract(tenant_id)
+    expire_at = getattr(request, "expire_at", None)
+    payload = {
+        "request_id": int(request.id),
+        "question_id": int(question.id),
+        "expire_at": expire_at.isoformat() if expire_at else None,
+        "duration_days": int(getattr(request, "duration_days", 0) or 0),
+    }
+    instance = await _get_instance(request)
+    if instance is None:
+        instance = await ApprovalInstanceRepository.create_instance(
+            ApprovalInstance(
+                tenant_id=tenant_id,
+                scenario_code=QA_PUBLISH_SCENARIO,
+                scenario_name=contract.scenario_name,
+                handler_key=QA_PUBLISH_SCENARIO,
+                business_key=business_key_for(int(request.id)),
+                business_resource_type=QA_PUBLISH_BUSINESS_TYPE,
+                business_resource_id=str(question.id),
+                business_name=str(question.title or ""),
+                applicant_user_id=int(initiator.user_id),
+                applicant_user_name=str(getattr(initiator, "user_name", "") or ""),
+                flow_version_id=contract.flow_version_id,
+                route_rule_id=contract.route_rule_id,
+                status=ApprovalInstanceStatus.PENDING,
+                payload_snapshot=payload,
+                detail_snapshot={
+                    "question_title": str(question.title or ""),
+                    "expire_at": payload["expire_at"],
+                    "duration_days": payload["duration_days"],
+                },
+                current_node_name=contract.node_name,
+            )
+        )
+        await ApprovalInstanceRepository.create_action_log(
+            ApprovalActionLog(
+                tenant_id=tenant_id,
+                instance_id=int(instance.id),
+                action="submitted",
+                operator_user_id=int(initiator.user_id),
+                operator_user_name=str(getattr(initiator, "user_name", "") or ""),
+                detail={"request_id": int(request.id)},
+            )
+        )
+    if not pending_ids:
+        await sync_from_publish_request(request, approvers)
+        return instance
+    existing = await ApprovalInstanceRepository.list_tasks(int(instance.id))
+    have = {int(row.approver_user_id) for row in existing}
+    new_rows = [
+        ApprovalTask(
+            tenant_id=tenant_id,
+            instance_id=int(instance.id),
+            flow_version_id=contract.flow_version_id,
+            node_code=contract.node_code,
+            node_name=contract.node_name,
+            node_order=contract.node_order,
+            approver_user_id=uid,
+            approver_source_type="resolved",
+            node_mode="and",
+            status=ApprovalTaskStatus.PENDING,
+        )
+        for uid in pending_ids
+        if uid not in have
+    ]
+    if new_rows:
+        await ApprovalInstanceRepository.create_tasks(new_rows)
+    return instance
+
+
+async def add_pending_task(request, question, user_id: int) -> ApprovalTask | None:
+    """中途新增回答专家：补一条 pending 待办。"""
+    try:
+        instance = await _get_instance(request)
+        if instance is None or str(instance.status) != ApprovalInstanceStatus.PENDING:
+            initiator = SimpleNamespace(
+                user_id=int(getattr(request, "initiator_user_id", 0) or 0),
+                user_name="",
+            )
+            instance = await sync_after_create(request, question, initiator, [])
+        if instance is None:
+            return None
+        tasks = await ApprovalInstanceRepository.list_tasks(int(instance.id))
+        for row in tasks:
+            if int(row.approver_user_id) == int(user_id):
+                return row
+        tenant_id = int(getattr(question, "tenant_id", 1) or 1)
+        contract = await ensure_flow_contract(tenant_id)
+        created = await ApprovalInstanceRepository.create_task(
+            ApprovalTask(
+                tenant_id=tenant_id,
+                instance_id=int(instance.id),
+                flow_version_id=contract.flow_version_id,
+                node_code=contract.node_code,
+                node_name=contract.node_name,
+                node_order=contract.node_order,
+                approver_user_id=int(user_id),
+                approver_source_type="resolved",
+                node_mode="and",
+                status=ApprovalTaskStatus.PENDING,
+            )
+        )
+        return created
+    except Exception:
+        logger.exception(
+            "qa.publish.bridge.add_task_failed request_id={} user_id={}",
+            getattr(request, "id", None),
+            user_id,
+        )
+        return None
+
+
+async def sync_from_publish_request(request, approvers: list[Any] | None = None) -> None:
+    """按 qa_publish_approver 回写 task / instance 状态。"""
+    try:
+        await _sync_from_publish_request(request, approvers)
+    except Exception:
+        logger.exception("qa.publish.bridge.sync_failed request_id={}", getattr(request, "id", None))
+
+
+async def _sync_from_publish_request(request, approvers: list[Any] | None) -> None:
+    instance = await _get_instance(request)
+    if instance is None:
+        return
+    if approvers is None:
+        from bisheng.qa_expert.domain.repositories import PublishApproverRepository
+
+        approvers = await PublishApproverRepository().list_by_request(int(request.id))
+    decision_by_user = {int(row.user_id): str(row.decision) for row in approvers}
+    tasks = await ApprovalInstanceRepository.list_tasks(int(instance.id))
+    now = datetime.utcnow()
+    publish_status = str(request.status)
+    for task in tasks:
+        wanted = _task_status_for(decision_by_user.get(int(task.approver_user_id), DECISION_PENDING))
+        if publish_status != PUBLISH_PENDING and wanted == ApprovalTaskStatus.PENDING:
+            wanted = ApprovalTaskStatus.CANCELLED
+        if str(task.status) == wanted:
+            continue
+        task.status = wanted
+        if wanted != ApprovalTaskStatus.PENDING:
+            task.acted_at = now
+        await ApprovalInstanceRepository.update_task(task)
+    target = _instance_status_for(publish_status)
+    if str(instance.status) != target:
+        instance.status = target
+        await ApprovalInstanceRepository.update_instance(instance)

--- a/src/backend/bisheng/qa_expert/domain/publish_handler.py
+++ b/src/backend/bisheng/qa_expert/domain/publish_handler.py
@@ -1,0 +1,42 @@
+# ruff: noqa: RUF002
+"""审批中心运行时 handler：转公开业务仍由 PublishService 执行，这里只满足注册契约。"""
+
+from __future__ import annotations
+
+from bisheng.qa_expert.domain.publish_approval_bridge import QA_PUBLISH_SCENARIO
+
+
+class QaQuestionPublishHandler:
+    """待办决策已在 decide_task 里转调 PublishService，本 handler 不改问题状态。"""
+
+    scenario_code = QA_PUBLISH_SCENARIO
+
+    async def validate(self, req, login_user) -> None:
+        return None
+
+    async def build_title(self, req) -> str:
+        return req.business_name
+
+    async def build_detail(self, req) -> dict:
+        payload = req.payload_snapshot or {}
+        return {
+            "question_title": req.business_name,
+            "expire_at": payload.get("expire_at"),
+            "duration_days": payload.get("duration_days"),
+        }
+
+    async def build_business_link(self, req) -> dict:
+        return {"question_id": (req.payload_snapshot or {}).get("question_id")}
+
+    async def resolve_approvers(self, node_config: dict, req) -> list[int]:
+        ids = (req.payload_snapshot or {}).get("approver_user_ids") or []
+        return [int(uid) for uid in ids]
+
+    async def on_approved(self, instance_id: int, payload_snapshot: dict) -> dict:
+        return {"status": "delegated"}
+
+    async def on_rejected(self, instance_id: int, payload_snapshot: dict, reason: str | None) -> None:
+        return None
+
+    async def on_withdrawn(self, instance_id: int, payload_snapshot: dict, reason: str | None) -> None:
+        return None

--- a/src/backend/bisheng/qa_expert/domain/publish_service.py
+++ b/src/backend/bisheng/qa_expert/domain/publish_service.py
@@ -1,0 +1,535 @@
+# ruff: noqa: RUF002, RUF003
+"""定向题转公开：申请、审批、专家停用默认同意、到期过期。"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any
+
+from loguru import logger
+
+from bisheng.common.errcode.qa_expert import (
+    QaExpertPublishConflictError,
+    QaExpertPublishDurationInvalidError,
+    QaExpertPublishNotAllowedError,
+    QaExpertQuestionAccessDeniedError,
+)
+from bisheng.database.models.qa_expert import (
+    QUESTION_TYPE_PUBLIC,
+    AnswerEligibility,
+    PublishApprover,
+    PublishRequest,
+)
+from bisheng.qa_expert.domain.capability import (
+    CapabilityResolver,
+    CapabilitySnapshot,
+)
+from bisheng.qa_expert.domain.repositories import (
+    AnswerEligibilityRepository,
+    AnswerRepository,
+    ExpertRepository,
+    PublishApproverRepository,
+    PublishRequestRepository,
+    QuestionInviteRepository,
+    QuestionRepository,
+)
+
+ALLOWED_DURATION_DAYS = frozenset({1, 3, 7})
+MAX_EXTENSION_DAYS = 3
+PUBLISH_PENDING = "pending"
+PUBLISH_APPROVED = "approved"
+PUBLISH_REJECTED = "rejected"
+PUBLISH_EXPIRED = "expired"
+PUBLISH_ENDED = "ended"
+DECISION_PENDING = "pending"
+DECISION_APPROVED = "approved"
+DECISION_REJECTED = "rejected"
+DECISION_DEFAULT_APPROVED = "default_approved"
+ROLE_ASKER = "asker"
+ROLE_ANSWERER = "answerer"
+ANSWER_STATUS_DELETED = 3
+ELIGIBILITY_INVITED = "invited"
+ELIGIBILITY_ANSWER = "pre_adopt_answer"
+
+
+def serialize_publish_request(row: PublishRequest) -> dict[str, Any]:
+    """详情挂载用的转公开申请摘要。"""
+    expire_at = getattr(row, "expire_at", None)
+    return {
+        "id": int(row.id),
+        "status": str(row.status),
+        "duration_days": int(getattr(row, "duration_days", 0) or 0),
+        "expire_at": expire_at.isoformat() if expire_at is not None else None,
+        "extension_days": int(getattr(row, "extension_days", 0) or 0),
+    }
+
+
+class PublishService:
+    """转公开申请编排；通过后 question_type=public，并补写回答资格快照。"""
+
+    def __init__(self):
+        self.question_repo = QuestionRepository()
+        self.answer_repo = AnswerRepository()
+        self.invite_repo = QuestionInviteRepository()
+        self.expert_repo = ExpertRepository()
+        self.request_repo = PublishRequestRepository()
+        self.approver_repo = PublishApproverRepository()
+        self.eligibility_repo = AnswerEligibilityRepository()
+        self.capability_resolver = CapabilityResolver()
+        self.notify = None  # 测试可注入 async (event, question, extra)
+
+    async def create_publish_request(
+        self,
+        question_id: int,
+        user,
+        duration_days: int,
+        *,
+        now: datetime | None = None,
+    ) -> PublishRequest:
+        """发起转公开；有效期仅 1/3/7；同题至多一条 pending。"""
+        if int(duration_days) not in ALLOWED_DURATION_DAYS:
+            raise QaExpertPublishDurationInvalidError()
+        if user is None or getattr(user, "user_id", None) is None:
+            raise QaExpertQuestionAccessDeniedError()
+        now = now or datetime.utcnow()
+        question = await self.question_repo.get_by_id_for_update(question_id)
+        if not question:
+            from bisheng.qa_expert.domain.services import QuestionNotFoundError
+
+            raise QuestionNotFoundError()
+        if await self.request_repo.get_pending_by_question(question_id):
+            raise QaExpertPublishConflictError()
+        snapshot = await self._snapshot(question, user, has_pending=False)
+        caps = self.capability_resolver.resolve(user, question, snapshot).capabilities
+        if not caps.can_start_publish:
+            raise QaExpertPublishNotAllowedError()
+
+        tenant_id = int(getattr(question, "tenant_id", 1) or 1)
+        request = PublishRequest(
+            tenant_id=tenant_id,
+            question_id=int(question.id),
+            initiator_user_id=int(user.user_id),
+            status=PUBLISH_PENDING,
+            duration_days=int(duration_days),
+            expire_at=now + timedelta(days=int(duration_days)),
+            extension_days=0,
+            version=0,
+        )
+        request = await self.request_repo.create(request)
+        approvers = await self._build_approvers(question, request, user, now)
+        await self.approver_repo.create_many(approvers)
+        await self.question_repo.update(int(question.id), active_publish_request_id=request.id)
+        from bisheng.qa_expert.domain.publish_approval_bridge import sync_after_create
+
+        await sync_after_create(request, question, user, approvers)
+        await self._notify("publish_started", question, extra={"request_id": request.id, "user": user})
+        finalized = await self._maybe_finalize(request, question, now=now)
+        await self._sync_approval_center(finalized)
+        refreshed = await self.request_repo.get_by_id(int(request.id))
+        return refreshed or request
+
+    async def decide_publish(
+        self,
+        request_id: int,
+        user,
+        decision: str,
+        *,
+        now: datetime | None = None,
+    ) -> PublishRequest:
+        """同意或拒绝；已决策不可改口。"""
+        now = now or datetime.utcnow()
+        if user is None or getattr(user, "user_id", None) is None:
+            raise QaExpertQuestionAccessDeniedError()
+        request = await self._get_live_request(request_id, now=now)
+        if request.status != PUBLISH_PENDING:
+            raise QaExpertPublishNotAllowedError()
+        row = await self.approver_repo.get_for_user(int(request.id), int(user.user_id))
+        if row is None:
+            raise QaExpertPublishNotAllowedError()
+        if str(row.decision) != DECISION_PENDING:
+            raise QaExpertPublishNotAllowedError()
+        normalized = str(decision or "").strip().lower()
+        if normalized not in {DECISION_APPROVED, DECISION_REJECTED}:
+            raise QaExpertPublishNotAllowedError()
+        await self.approver_repo.update(int(row.id), decision=normalized, decided_at=now)
+        question = await self.question_repo.get_by_id(int(request.question_id))
+        if not question:
+            from bisheng.qa_expert.domain.services import QuestionNotFoundError
+
+            raise QuestionNotFoundError()
+        if normalized == DECISION_REJECTED:
+            await self._close_request(request, PUBLISH_REJECTED, question)
+            await self._notify("publish_rejected", question, extra={"request_id": request.id, "user": user})
+            request.status = PUBLISH_REJECTED
+            await self._sync_approval_center(request)
+            return request
+        result = await self._maybe_finalize(request, question, now=now)
+        await self._sync_approval_center(result)
+        return result
+
+    async def on_expert_disabled(self, user_id: int, *, now: datetime | None = None) -> list[int]:
+        """停用专家：pending 审批改 default_approved，立即重判；不加入已结束申请。"""
+        now = now or datetime.utcnow()
+        passed: list[int] = []
+        # 通过仓储列出该用户仍 pending 的审批行：由调用方注入 list_pending_for_user
+        list_pending = getattr(self.approver_repo, "list_pending_for_user", None)
+        rows = await list_pending(int(user_id)) if callable(list_pending) else []
+        for row in rows:
+            request = await self.request_repo.get_by_id(int(row.request_id))
+            if request is None or request.status != PUBLISH_PENDING:
+                continue
+            await self.approver_repo.update(
+                int(row.id),
+                decision=DECISION_DEFAULT_APPROVED,
+                decided_at=now,
+            )
+            question = await self.question_repo.get_by_id(int(request.question_id))
+            if question is None:
+                continue
+            finalized = await self._maybe_finalize(request, question, now=now)
+            if finalized.status == PUBLISH_APPROVED:
+                passed.append(int(finalized.id))
+                await self._notify(
+                    "publish_default_approved",
+                    question,
+                    extra={"request_id": request.id, "disabled_user_id": user_id},
+                )
+            await self._sync_approval_center(finalized)
+        return passed
+
+    async def on_asker_disabled(self, question_id: int, *, now: datetime | None = None) -> PublishRequest | None:
+        """提问者账号停用：进行中的申请 ended。"""
+        now = now or datetime.utcnow()
+        request = await self.request_repo.get_pending_by_question(int(question_id))
+        if request is None:
+            return None
+        question = await self.question_repo.get_by_id(int(question_id))
+        if question is None:
+            return request
+        await self._close_request(request, PUBLISH_ENDED, question)
+        await self._notify("publish_ended", question, extra={"request_id": request.id})
+        request.status = PUBLISH_ENDED
+        await self._sync_approval_center(request)
+        return request
+
+    async def refresh_latest_for_question(
+        self, question_id: int, *, now: datetime | None = None
+    ) -> PublishRequest | None:
+        """读详情前惰性过期，再返回同题最近一条申请。"""
+        now = now or datetime.utcnow()
+        pending = await self.request_repo.get_pending_by_question(int(question_id))
+        if pending is not None and pending.expire_at is not None and pending.expire_at <= now:
+            await self._get_live_request(int(pending.id), now=now)
+        return await self.request_repo.get_latest_by_question(int(question_id))
+
+    async def extend_one_day(self, request_id: int, user, *, now: datetime | None = None) -> PublishRequest:
+        """+1 天延期，累计不超过 3 天。"""
+        now = now or datetime.utcnow()
+        request = await self._get_live_request(request_id, now=now)
+        if request.status != PUBLISH_PENDING:
+            raise QaExpertPublishNotAllowedError()
+        if int(request.extension_days or 0) >= MAX_EXTENSION_DAYS:
+            raise QaExpertPublishDurationInvalidError()
+        new_ext = int(request.extension_days or 0) + 1
+        new_expire = request.expire_at + timedelta(days=1)
+        updated = await self.request_repo.update(
+            int(request.id),
+            extension_days=new_ext,
+            expire_at=new_expire,
+            version=int(request.version or 0) + 1,
+        )
+        return updated or request
+
+    async def expire_pending(self, *, now: datetime | None = None, tenant_id: int | None = None) -> int:
+        """把到期 pending 标为 expired，并通知。tenant_id 仅记录上下文。"""
+        now = now or datetime.utcnow()
+        rows = await self.request_repo.list_expired_pending(now)
+        count = 0
+        for request in rows:
+            if tenant_id is not None and int(getattr(request, "tenant_id", 0) or 0) != int(tenant_id):
+                continue
+            question = await self.question_repo.get_by_id(int(request.question_id))
+            if question is None:
+                continue
+            await self._close_request(request, PUBLISH_EXPIRED, question)
+            await self._notify("publish_expired", question, extra={"request_id": request.id})
+            request.status = PUBLISH_EXPIRED
+            await self._sync_approval_center(request)
+            count += 1
+        return count
+
+    async def get_request(self, request_id: int, user, *, now: datetime | None = None) -> PublishRequest:
+        """读取申请；读路径顺带惰性过期。"""
+        return await self._get_live_request(request_id, now=now or datetime.utcnow())
+
+    async def _get_live_request(self, request_id: int, *, now: datetime) -> PublishRequest:
+        request = await self.request_repo.get_by_id(int(request_id))
+        if request is None:
+            from bisheng.qa_expert.domain.services import QuestionNotFoundError
+
+            raise QuestionNotFoundError()
+        if request.status == PUBLISH_PENDING and request.expire_at <= now:
+            question = await self.question_repo.get_by_id(int(request.question_id))
+            if question is not None:
+                await self._close_request(request, PUBLISH_EXPIRED, question)
+                await self._notify("publish_expired", question, extra={"request_id": request.id})
+            request.status = PUBLISH_EXPIRED
+            await self._sync_approval_center(request)
+        return request
+
+    async def _snapshot(self, question, user, *, has_pending: bool | None = None) -> CapabilitySnapshot:
+        invite_map = await self.invite_repo.list_user_ids_by_question_ids([int(question.id)])
+        invited = invite_map.get(int(question.id), set())
+        uid = int(user.user_id)
+        expert = await self.expert_repo.get_by_user_id(uid)
+        has_answer = await self.answer_repo.has_effective_answer(int(question.id), uid)
+        pending = await self.request_repo.get_pending_by_question(int(question.id))
+        pending_flag = pending is not None if has_pending is None else has_pending
+        latest = pending or await self.request_repo.get_latest_by_question(int(question.id))
+        approver_ids: set[int] = set()
+        if pending is not None:
+            for row in await self.approver_repo.list_by_request(int(pending.id)):
+                approver_ids.add(int(row.user_id))
+        return CapabilitySnapshot(
+            expert=expert,
+            invited_user_ids=frozenset(invited),
+            effective_answer_count=int(getattr(question, "answer_count", 0) or 0),
+            user_has_effective_answer=has_answer,
+            has_pending_publish=pending_flag,
+            latest_publish_status=str(latest.status) if latest is not None else None,
+            approver_user_ids=frozenset(approver_ids),
+        )
+
+    async def _build_approvers(
+        self,
+        question,
+        request: PublishRequest,
+        initiator,
+        now: datetime,
+    ) -> list[PublishApprover]:
+        tenant_id = int(getattr(question, "tenant_id", 1) or 1)
+        asker_id = int(question.user_id)
+        initiator_id = int(initiator.user_id)
+        answers = await self.answer_repo.list_all_by_question_id(int(question.id))
+        answerer_ids: list[int] = []
+        seen: set[int] = set()
+        for answer in answers:
+            if int(getattr(answer, "status", 1) or 0) == ANSWER_STATUS_DELETED:
+                continue
+            uid = getattr(answer, "user_id", None)
+            if uid is None:
+                continue
+            uid = int(uid)
+            if uid in seen or uid == asker_id:
+                continue
+            seen.add(uid)
+            answerer_ids.append(uid)
+        rows: list[PublishApprover] = []
+        rows.append(
+            PublishApprover(
+                tenant_id=tenant_id,
+                request_id=int(request.id),
+                user_id=asker_id,
+                role_in_request=ROLE_ASKER,
+                decision=DECISION_APPROVED if initiator_id == asker_id else DECISION_PENDING,
+                decided_at=now if initiator_id == asker_id else None,
+            )
+        )
+        for uid in answerer_ids:
+            auto = uid == initiator_id
+            rows.append(
+                PublishApprover(
+                    tenant_id=tenant_id,
+                    request_id=int(request.id),
+                    user_id=uid,
+                    role_in_request=ROLE_ANSWERER,
+                    decision=DECISION_APPROVED if auto else DECISION_PENDING,
+                    decided_at=now if auto else None,
+                )
+            )
+        return rows
+
+    async def _maybe_finalize(self, request: PublishRequest, question, *, now: datetime) -> PublishRequest:
+        approvers = await self.approver_repo.list_by_request(int(request.id))
+        if any(str(row.decision) == DECISION_PENDING for row in approvers):
+            return request
+        if any(str(row.decision) == DECISION_REJECTED for row in approvers):
+            await self._close_request(request, PUBLISH_REJECTED, question)
+            request.status = PUBLISH_REJECTED
+            return request
+        await self._approve_question(request, question)
+        await self._notify("publish_approved", question, extra={"request_id": request.id})
+        request.status = PUBLISH_APPROVED
+        return request
+
+    async def add_late_answerer(self, question, user_id: int) -> None:
+        """pending 转公开期间新回答的受邀专家加入会签，并补待办。"""
+        request = await self.request_repo.get_pending_by_question(int(question.id))
+        if request is None:
+            return
+        existing = await self.approver_repo.get_for_user(int(request.id), int(user_id))
+        if existing is not None:
+            return
+        row = PublishApprover(
+            tenant_id=int(getattr(question, "tenant_id", 1) or 1),
+            request_id=int(request.id),
+            user_id=int(user_id),
+            role_in_request=ROLE_ANSWERER,
+            decision=DECISION_PENDING,
+            decided_at=None,
+        )
+        await self.approver_repo.create_many([row])
+        refreshed = await self.request_repo.get_by_id(int(request.id))
+        if refreshed is None or str(refreshed.status) != PUBLISH_PENDING:
+            created = await self.approver_repo.get_for_user(int(request.id), int(user_id))
+            if created is not None and str(created.decision) == DECISION_PENDING:
+                await self.approver_repo.delete(int(created.id))
+            return
+        from bisheng.qa_expert.domain.publish_approval_bridge import add_pending_task
+
+        await add_pending_task(refreshed, question, int(user_id))
+        await self._notify(
+            "publish_approver_added",
+            question,
+            extra={"request_id": request.id, "added_user_id": int(user_id)},
+        )
+
+    async def _sync_approval_center(self, request) -> None:
+        """把 qa_publish_* 状态同步到审批中心待办。"""
+        if request is None:
+            return
+        from bisheng.qa_expert.domain.publish_approval_bridge import sync_from_publish_request
+
+        await sync_from_publish_request(request)
+
+    async def _approve_question(self, request: PublishRequest, question) -> None:
+        """全体同意后不可逆公开；定向首次采纳未写 eligibility 时在此补快照。"""
+        await self.request_repo.update(int(request.id), status=PUBLISH_APPROVED)
+        await self.question_repo.update(
+            int(question.id),
+            question_type=QUESTION_TYPE_PUBLIC,
+            active_publish_request_id=None,
+        )
+        question.question_type = QUESTION_TYPE_PUBLIC
+        question.active_publish_request_id = None
+        await self._write_eligibility_if_missing(question)
+
+    async def _write_eligibility_if_missing(self, question) -> None:
+        existing = await self.eligibility_repo.list_user_ids(int(question.id))
+        if existing:
+            return
+        invite_map = await self.invite_repo.list_user_ids_by_question_ids([int(question.id)])
+        invited = set(invite_map.get(int(question.id), set()))
+        answers = await self.answer_repo.list_all_by_question_id(int(question.id))
+        tenant_id = int(getattr(question, "tenant_id", 1) or 1)
+        rows: list[AnswerEligibility] = []
+        seen: set[int] = set()
+        for uid in invited:
+            uid = int(uid)
+            if uid in seen:
+                continue
+            seen.add(uid)
+            rows.append(
+                AnswerEligibility(
+                    tenant_id=tenant_id,
+                    question_id=int(question.id),
+                    user_id=uid,
+                    source=ELIGIBILITY_INVITED,
+                )
+            )
+        for answer in answers:
+            uid = getattr(answer, "user_id", None)
+            if uid is None:
+                continue
+            uid = int(uid)
+            if uid in seen:
+                continue
+            seen.add(uid)
+            rows.append(
+                AnswerEligibility(
+                    tenant_id=tenant_id,
+                    question_id=int(question.id),
+                    user_id=uid,
+                    source=ELIGIBILITY_ANSWER,
+                )
+            )
+        await self.eligibility_repo.create_many(rows)
+
+    async def _close_request(self, request: PublishRequest, status: str, question) -> None:
+        await self.request_repo.update(int(request.id), status=status)
+        if int(getattr(question, "active_publish_request_id", 0) or 0) == int(request.id):
+            await self.question_repo.update(int(question.id), active_publish_request_id=None)
+
+    async def _notify(self, event: str, question, extra: dict[str, Any] | None = None) -> None:
+        hook = self.notify
+        if callable(hook):
+            await hook(event, question, extra or {})
+            return
+        try:
+            await self._send_inbox(event, question, extra or {})
+        except Exception:
+            logger.exception("qa.publish.notify_failed event={}", event)
+
+    async def _send_inbox(self, event: str, question, extra: dict[str, Any]) -> None:
+        """转公开站内信：相关人通知；待办入口靠 approval_instance_id。"""
+        from bisheng.approval.domain.repositories.approval_instance_repository import (
+            ApprovalInstanceRepository,
+        )
+        from bisheng.qa_expert.domain.inbox_notice import display_name_for_trigger, send_qa_inbox
+        from bisheng.qa_expert.domain.publish_approval_bridge import business_key_for
+
+        sender = extra.get("user")
+        sender_id = int(getattr(sender, "user_id", 0) or 0) if sender is not None else 0
+        if sender_id <= 0:
+            sender_id = int(question.user_id)
+        real_name = extra.get("sender_name") or getattr(sender, "user_name", "") or ""
+        asker_anonymous = bool(int(getattr(question, "asker_anonymous", 0) or 0))
+        anonymous = bool(asker_anonymous) if sender_id == int(question.user_id) else bool(extra.get("anonymous"))
+        display, masked = await display_name_for_trigger(
+            question,
+            user_id=sender_id,
+            real_name=real_name,
+            anonymous=anonymous,
+            reveal_on_public=getattr(question, "asker_reveal_on_public", None)
+            if sender_id == int(question.user_id)
+            else extra.get("reveal_on_public"),
+        )
+        receivers: list[int] = []
+        request_id = extra.get("request_id")
+        if request_id:
+            for row in await self.approver_repo.list_by_request(int(request_id)):
+                receivers.append(int(row.user_id))
+        receivers.append(int(question.user_id))
+        added = extra.get("added_user_id")
+        if added:
+            receivers.append(int(added))
+        instance_id = None
+        if request_id:
+            inst = await ApprovalInstanceRepository.find_latest_by_business_key(
+                tenant_id=int(getattr(question, "tenant_id", 1) or 1),
+                scenario_code="qa_question_publish",
+                business_key=business_key_for(int(request_id)),
+            )
+            if inst is not None:
+                instance_id = int(inst.id)
+        todo_events = {"publish_started", "publish_approver_added"}
+        result_events = {
+            "publish_approved",
+            "publish_rejected",
+            "publish_expired",
+            "publish_ended",
+            "publish_default_approved",
+        }
+        business_type = "approval_instance_id" if event in todo_events and instance_id else "qa_question"
+        await send_qa_inbox(
+            action_code=f"qa_{event}",
+            system_text=f"qa_expert_{event}",
+            question=question,
+            receivers=receivers,
+            sender_user_id=sender_id,
+            sender_display=display or "系统",
+            sender_anonymous=masked,
+            request_id=int(request_id) if request_id else None,
+            instance_id=instance_id,
+            business_type=business_type if event in todo_events or event in result_events else "qa_question",
+        )

--- a/src/backend/bisheng/qa_expert/domain/publish_service.py
+++ b/src/backend/bisheng/qa_expert/domain/publish_service.py
@@ -52,8 +52,16 @@ ELIGIBILITY_INVITED = "invited"
 ELIGIBILITY_ANSWER = "pre_adopt_answer"
 
 
-def serialize_publish_request(row: PublishRequest) -> dict[str, Any]:
-    """详情挂载用的转公开申请摘要。"""
+def serialize_publish_request(
+    row: PublishRequest,
+    *,
+    viewer_decision: str | None = None,
+) -> dict[str, Any]:
+    """详情挂载用的转公开申请摘要。
+
+    viewer_decision 是当前登录用户在 qa_publish_approver 上的决策；
+    发起人创建时已默认同意，详情右上角据此展示「已同意」。
+    """
     expire_at = getattr(row, "expire_at", None)
     return {
         "id": int(row.id),
@@ -61,6 +69,7 @@ def serialize_publish_request(row: PublishRequest) -> dict[str, Any]:
         "duration_days": int(getattr(row, "duration_days", 0) or 0),
         "expire_at": expire_at.isoformat() if expire_at is not None else None,
         "extension_days": int(getattr(row, "extension_days", 0) or 0),
+        "viewer_decision": viewer_decision,
     }
 
 
@@ -287,9 +296,15 @@ class PublishService:
         pending_flag = pending is not None if has_pending is None else has_pending
         latest = pending or await self.request_repo.get_latest_by_question(int(question.id))
         approver_ids: set[int] = set()
-        if pending is not None:
-            for row in await self.approver_repo.list_by_request(int(pending.id)):
-                approver_ids.add(int(row.user_id))
+        viewer_decision: str | None = None
+        source = pending if pending is not None else latest
+        if source is not None:
+            for row in await self.approver_repo.list_by_request(int(source.id)):
+                if int(row.user_id) == uid:
+                    viewer_decision = str(row.decision)
+                # 已决策的人（含发起人默认同意）不再出现同意/拒绝按钮。
+                if pending is not None and str(row.decision) == DECISION_PENDING:
+                    approver_ids.add(int(row.user_id))
         return CapabilitySnapshot(
             expert=expert,
             invited_user_ids=frozenset(invited),
@@ -298,6 +313,7 @@ class PublishService:
             has_pending_publish=pending_flag,
             latest_publish_status=str(latest.status) if latest is not None else None,
             approver_user_ids=frozenset(approver_ids),
+            viewer_publish_decision=viewer_decision,
         )
 
     async def _build_approvers(
@@ -307,6 +323,7 @@ class PublishService:
         initiator,
         now: datetime,
     ) -> list[PublishApprover]:
+        """组装会签人：提问者 + 有效回答专家；发起人对应行默认 approved。"""
         tenant_id = int(getattr(question, "tenant_id", 1) or 1)
         asker_id = int(question.user_id)
         initiator_id = int(initiator.user_id)
@@ -324,6 +341,7 @@ class PublishService:
                 continue
             seen.add(uid)
             answerer_ids.append(uid)
+        # 谁发起谁默认同意：提问者发起则 asker 行直接 approved，回答专家发起则该专家行直接 approved。
         rows: list[PublishApprover] = []
         rows.append(
             PublishApprover(

--- a/src/backend/bisheng/qa_expert/domain/question_query.py
+++ b/src/backend/bisheng/qa_expert/domain/question_query.py
@@ -1,0 +1,141 @@
+# ruff: noqa: RUF001, RUF002, RUF003
+"""提问/列表辅助：邀请解析、筛参归一、展示态匹配。不查库。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from bisheng.qa_expert.domain.capability import (
+    derive_display_status,
+    is_unresolved,
+)
+
+MAX_INVITES = 3
+QUESTION_TYPE_PUBLIC = "public"
+QUESTION_TYPE_DIRECTED = "directed"
+FILTER_MINE = "mine"
+FILTER_INVITED_ME = "invited_me"
+# 现网列表 status=3/4 只表示「我的 / 邀请我的」，不是待采纳
+LEGACY_STATUS_MINE = 3
+LEGACY_STATUS_INVITED_ME = 4
+
+
+def parse_invite_expert_ids(*, invited_expert_ids: list[int] | None, invited_experts: str | None) -> list[int]:
+    """合并 invited_expert_ids 与分号串，去重保序。"""
+    values: list[int] = []
+    seen: set[int] = set()
+    source: list[Any] = list(invited_expert_ids or [])
+    if not source and invited_experts:
+        source = [part for part in str(invited_experts).replace("，", ";").split(";") if part.strip()]
+    for item in source:
+        try:
+            expert_id = int(item)
+        except (TypeError, ValueError):
+            continue
+        if expert_id <= 0 or expert_id in seen:
+            continue
+        seen.add(expert_id)
+        values.append(expert_id)
+    return values
+
+
+def serialize_invite_ids(expert_ids: list[int]) -> str | None:
+    """双写旧列 invited_experts，供存量读路径过渡。"""
+    if not expert_ids:
+        return None
+    return ";".join(str(item) for item in expert_ids)
+
+
+def serialize_expert_names(experts: list[Any]) -> str | None:
+    """按邀请顺序拼接专家姓名，写入 qa_question.experts_names。"""
+    names: list[str] = []
+    for expert in experts:
+        name = str(getattr(expert, "expert_name", "") or "").strip()
+        if name:
+            names.append(name)
+    if not names:
+        return None
+    return ";".join(names)
+
+
+def invite_display_names_need_hydrate(experts_names: str | None, invited_experts: str | None) -> bool:
+    """名字为空，或误把专家 ID 串当成名字时，需要按档案回填。"""
+    ids = parse_invite_expert_ids(invited_expert_ids=None, invited_experts=invited_experts)
+    if not ids:
+        return False
+    names = (experts_names or "").strip()
+    if not names:
+        return True
+    tokens = [part.strip() for part in names.replace("，", ";").split(";") if part.strip()]
+    return bool(tokens) and all(token.isdigit() for token in tokens)
+
+
+def serialize_related_doc_ids(related_doc_ids: list[str] | None, related_docs: str | None) -> str | None:
+    """优先 related_doc_ids；否则沿用已有 related_docs 串。"""
+    if related_doc_ids:
+        tokens = [str(item).strip() for item in related_doc_ids if str(item).strip()]
+        return ";".join(tokens) if tokens else None
+    if related_docs and str(related_docs).strip():
+        return str(related_docs).strip()
+    return None
+
+
+def parse_related_doc_tokens(raw: str | None) -> list[str]:
+    if not raw:
+        return []
+    text = str(raw).strip()
+    if not text:
+        return []
+    return [part.strip() for part in text.replace(",", ";").split(";") if part.strip()]
+
+
+def parse_related_doc_ref(token: str) -> tuple[int, int] | None:
+    """解析 `{spaceId}-{fileId}`；失败返回 None。"""
+    parts = str(token).strip().split("-", 1)
+    if len(parts) != 2:
+        return None
+    try:
+        space_id = int(parts[0])
+        file_id = int(parts[1])
+    except (TypeError, ValueError):
+        return None
+    if space_id <= 0 or file_id <= 0:
+        return None
+    return space_id, file_id
+
+
+def normalize_list_filter(*, status: int | None, list_filter: str | None) -> str | None:
+    """filter 优先；status=3/4 映射为 mine/invited_me，禁止当成待采纳。"""
+    if list_filter in {FILTER_MINE, FILTER_INVITED_ME}:
+        return list_filter
+    if status == LEGACY_STATUS_MINE:
+        return FILTER_MINE
+    if status == LEGACY_STATUS_INVITED_ME:
+        return FILTER_INVITED_ME
+    return None
+
+
+def question_display_status(question: Any) -> str:
+    adopt_count = int(getattr(question, "adopt_count", 0) or 0)
+    effective = int(
+        getattr(question, "effective_answer_count", None)
+        if getattr(question, "effective_answer_count", None) is not None
+        else (getattr(question, "answer_count", 0) or 0)
+    )
+    return derive_display_status(effective_answer_count=effective, adopt_count=adopt_count)
+
+
+def matches_display_status(question: Any, display_status: str | None) -> bool:
+    if not display_status:
+        return True
+    current = question_display_status(question)
+    if display_status == "unresolved":
+        return is_unresolved(current)
+    return current == display_status
+
+
+def normalize_question_type(value: Any) -> str:
+    text = str(value or QUESTION_TYPE_PUBLIC).strip().lower()
+    if text == QUESTION_TYPE_DIRECTED:
+        return QUESTION_TYPE_DIRECTED
+    return QUESTION_TYPE_PUBLIC

--- a/src/backend/bisheng/qa_expert/domain/related_docs_access.py
+++ b/src/backend/bisheng/qa_expert/domain/related_docs_access.py
@@ -1,0 +1,36 @@
+# ruff: noqa: RUF002
+"""关联文档 knowledge 鉴权适配：无权=forbidden，无文件=not_found。不在本域另造映射。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+RELATED_DOC_ACCESS_TIMEOUT_SEC = 3.0
+
+
+async def check_related_doc_access(user: Any, space_id: int, file_id: int) -> bool | None:
+    """True 文件存在；None 文件不存在。
+
+    不在这里调 PermissionService / OpenFGA：当前 LoginUser 缺 get_visible_tenants，
+    list_accessible_ids 会卡住 uvicorn 单 worker，整道问题详情 8s 超时。
+    可见性由 QuestionService.hydrate_related_docs 按提问者/路人切开。
+    """
+    del user
+    try:
+        from sqlmodel import select
+
+        from bisheng.core.database import get_async_db_session
+        from bisheng.knowledge.domain.models.knowledge_file import KnowledgeFile
+    except Exception:
+        return None
+
+    async with get_async_db_session() as session:
+        stmt = select(KnowledgeFile).where(KnowledgeFile.id == int(file_id))
+        result = await session.exec(stmt)
+        row = result.first()
+    if row is None:
+        return None
+    knowledge_id = int(getattr(row, "knowledge_id", 0) or 0)
+    if knowledge_id and knowledge_id != int(space_id):
+        return None
+    return True

--- a/src/backend/bisheng/qa_expert/domain/repositories.py
+++ b/src/backend/bisheng/qa_expert/domain/repositories.py
@@ -1,5 +1,8 @@
+# ruff: noqa: RUF001, RUF002, RUF003
 """Expert QA Repositories - 数据访问层"""
 
+from datetime import datetime
+from types import SimpleNamespace
 
 from sqlalchemy import Integer, cast, desc, func, update
 from sqlmodel import and_, or_, select
@@ -7,12 +10,18 @@ from sqlmodel import and_, or_, select
 from bisheng.core.database import get_async_db_session  # 确保导入了异步方法
 from bisheng.database.models.department import Department
 from bisheng.database.models.qa_expert import (
+    AnonymousAlias,
     Answer,
+    AnswerAdopt,
+    AnswerEligibility,
     AnswerVote,
     Comment,
     Expert,
+    PublishApprover,
+    PublishRequest,
     QANotification,
     Question,
+    QuestionInvite,
     QuestionVote,
 )
 
@@ -37,6 +46,15 @@ class ExpertRepository:
             stmt = select(Expert).where(Expert.id == expert_id)
             result = await session.exec(stmt)
             return result.first()
+
+    async def get_by_ids(self, expert_ids: list[int]) -> list[Expert]:
+        """按档案 ID 批量读取专家。"""
+        if not expert_ids:
+            return []
+        async with get_async_db_session() as session:
+            stmt = select(Expert).where(Expert.id.in_(expert_ids))
+            result = await session.exec(stmt)
+            return list(result.all())
 
     async def get_by_user_name(self, name: str, user_id: int) -> Expert | None:
         """根据用户名称获取专家"""
@@ -232,6 +250,37 @@ class ExpertRepository:
             return result.first()
 
 
+class QuestionInviteRepository:
+    """问题邀请正规表。"""
+
+    async def create_many(self, invites: list[QuestionInvite]) -> None:
+        """写入一题的邀请行。"""
+        if not invites:
+            return
+        async with get_async_db_session() as session:
+            session.add_all(invites)
+            await session.commit()
+
+    async def list_user_ids_by_question_ids(self, question_ids: list[int]) -> dict[int, set[int]]:
+        """question_id -> 受邀专家 user_id 集合。"""
+        mapping: dict[int, set[int]] = {}
+        if not question_ids:
+            return mapping
+        async with get_async_db_session() as session:
+            stmt = select(QuestionInvite).where(QuestionInvite.question_id.in_(question_ids))
+            result = await session.exec(stmt)
+            for row in result.all():
+                mapping.setdefault(int(row.question_id), set()).add(int(row.user_id))
+        return mapping
+
+    async def list_question_ids_for_user(self, user_id: int) -> list[int]:
+        """当前用户作为受邀专家的问题 ID。"""
+        async with get_async_db_session() as session:
+            stmt = select(QuestionInvite.question_id).where(QuestionInvite.user_id == user_id)
+            result = await session.exec(stmt)
+            return [int(item) for item in result.all()]
+
+
 class QuestionRepository:
     """问题仓储"""
 
@@ -250,6 +299,75 @@ class QuestionRepository:
             stmt = select(Question).where(Question.id == question_id)
             result = await session.exec(stmt)
             return result.first()
+
+    async def get_by_id_for_update(self, question_id: int) -> Question | None:
+        """读取问题行。方法返回即结束事务，行锁不会保留；真正持锁写槽位用 apply_adopt_count_locked。"""
+        async with get_async_db_session() as session:
+            session.expire_on_commit = False
+            stmt = select(Question).where(Question.id == question_id).with_for_update()
+            result = await session.exec(stmt)
+            return result.first()
+
+    async def increment_answer_count(self, question_id: int, count: int = 1) -> None:
+        """原子自增 qa_question.answer_count，避免并发首答丢失更新。"""
+        async with get_async_db_session() as session:
+            stmt = update(Question).where(Question.id == question_id).values(answer_count=Question.answer_count + count)
+            await session.exec(stmt)
+            await session.commit()
+
+    async def apply_adopt_count_locked(
+        self,
+        question_id: int,
+        *,
+        answer_id: int,
+        expert_user_id: int,
+        adopted_by: int,
+        tenant_id: int,
+        max_adopt: int,
+    ) -> SimpleNamespace:
+        """
+        同一事务 SELECT FOR UPDATE 问题行（再锁回答行）：写 qa_answer_adopt、自增 adopt_count、标记 adopted。
+        返回 SimpleNamespace(question, status, is_first)；status 为 ok/not_found/limit/already/answer_missing/mismatch。
+        """
+        async with get_async_db_session() as session:
+            session.expire_on_commit = False
+            question = (
+                await session.exec(select(Question).where(Question.id == question_id).with_for_update())
+            ).first()
+            if question is None:
+                return SimpleNamespace(question=None, status="not_found", is_first=False)
+            answer = (await session.exec(select(Answer).where(Answer.id == answer_id).with_for_update())).first()
+            if answer is None or int(getattr(answer, "status", 0) or 0) == 3:
+                return SimpleNamespace(question=question, status="answer_missing", is_first=False)
+            if int(answer.question_id) != int(question_id):
+                return SimpleNamespace(question=question, status="mismatch", is_first=False)
+            if bool(getattr(answer, "adopted", False)):
+                return SimpleNamespace(question=question, status="already", is_first=False)
+            current = int(getattr(question, "adopt_count", 0) or 0)
+            if current >= max_adopt:
+                return SimpleNamespace(question=question, status="limit", is_first=False)
+            is_first = current == 0
+            session.add(
+                AnswerAdopt(
+                    tenant_id=tenant_id,
+                    question_id=question_id,
+                    answer_id=answer_id,
+                    expert_user_id=expert_user_id,
+                    adopted_by=adopted_by,
+                )
+            )
+            question.adopted_answer_id = answer_id
+            question.status = 1
+            question.adopt_count = current + 1
+            if is_first:
+                question.resolved_at = datetime.utcnow()
+            session.add(question)
+            answer.status = 1
+            answer.adopted = True
+            session.add(answer)
+            await session.commit()
+            await session.refresh(question)
+            return SimpleNamespace(question=question, status="ok", is_first=is_first)
 
     async def delete(self, question_id: int) -> bool:
         """删除问题"""
@@ -271,6 +389,11 @@ class QuestionRepository:
         skip: int = 0,
         limit: int = 20,
         expert_id: int | None = None,  # 邀请我的专家ID
+        list_filter: str | None = None,
+        display_status: str | None = None,
+        keyword: str | None = None,
+        viewer_user_id: int | None = None,
+        viewer_is_admin: bool = False,
     ) -> tuple[list[Question], int]:
         """列表查询问题"""
         async with get_async_db_session() as session:
@@ -279,16 +402,28 @@ class QuestionRepository:
             if business_domain:
                 stmt = stmt.where(Question.business_domain == business_domain)
 
-            if status in (1, 2):
+            if keyword:
+                stmt = stmt.where(Question.title.like(f"%{keyword.strip()}%"))
+
+            if list_filter == "mine" and (viewer_user_id or user_id) is not None:
+                stmt = stmt.where(Question.user_id == (viewer_user_id or user_id))
+            elif list_filter == "invited_me" and (viewer_user_id or user_id) is not None:
+                invitee = viewer_user_id or user_id
+                invited_ids = select(QuestionInvite.question_id).where(QuestionInvite.user_id == invitee)
+                stmt = stmt.where(Question.id.in_(invited_ids))
+            elif status in (1, 2):
                 # 状态为 1 (未解决) 或 2 (已解决) 时，直接按问题状态过滤
                 stmt = stmt.where(Question.status == status - 1)
             elif status == 3:
-                # 状态为 3 (我提问的) 时，按提问人 ID 过滤
+                # 状态为 3 (我提问的) 时，按提问人 ID 过滤；不是待采纳
                 if user_id is not None:
                     stmt = stmt.where(Question.user_id == user_id)
             elif status == 4:
-                # 状态为 4 (邀请我的) 时，按被邀请的专家 ID 过滤
-                if expert_id is not None:
+                # 状态为 4 (邀请我的)；优先 invite 表，兼容旧分号串
+                if viewer_user_id is not None:
+                    invited_ids = select(QuestionInvite.question_id).where(QuestionInvite.user_id == viewer_user_id)
+                    stmt = stmt.where(Question.id.in_(invited_ids))
+                elif expert_id is not None:
                     expert_id_str = str(expert_id)
                     stmt = stmt.where(
                         or_(
@@ -299,13 +434,34 @@ class QuestionRepository:
                         )
                     )
 
+            if display_status == "unanswered":
+                stmt = stmt.where(Question.adopt_count == 0, Question.answer_count == 0)
+            elif display_status == "pending_adopt":
+                stmt = stmt.where(Question.adopt_count == 0, Question.answer_count > 0)
+            elif display_status == "solved":
+                stmt = stmt.where(Question.adopt_count > 0)
+            elif display_status == "unresolved":
+                stmt = stmt.where(Question.adopt_count == 0)
+
+            if viewer_user_id is not None and not viewer_is_admin and list_filter not in {"mine", "invited_me"}:
+                invited_ids = select(QuestionInvite.question_id).where(QuestionInvite.user_id == viewer_user_id)
+                stmt = stmt.where(
+                    or_(
+                        Question.question_type == "public",
+                        Question.question_type.is_(None),
+                        Question.user_id == viewer_user_id,
+                        Question.id.in_(invited_ids),
+                    )
+                )
+
             # 排序相关的过滤条件需要在计算总数之前应用
             if sort_by == "unanswered":
                 stmt = stmt.where(Question.answer_count == 0)
 
             subquery = stmt.subquery()
             count_stmt = select(func.count()).select_from(subquery)
-            total = await session.exec(count_stmt) or 0
+            count_result = await session.execute(count_stmt)
+            total = int(count_result.scalar() or 0)
 
             # 排序
             if sort_by == "hot":
@@ -319,6 +475,21 @@ class QuestionRepository:
 
             result = await session.exec(stmt)
             return result.all(), total
+
+    async def search_by_title_like(self, text: str, limit: int = 5) -> list[Question]:
+        """标题模糊匹配类似问题；可见性由服务层再滤。"""
+        keyword = (text or "").strip()
+        if not keyword:
+            return []
+        async with get_async_db_session() as session:
+            stmt = (
+                select(Question)
+                .where(Question.title.like(f"%{keyword}%"))
+                .order_by(desc(Question.created_at))
+                .limit(limit)
+            )
+            result = await session.exec(stmt)
+            return list(result.all())
 
     async def update(self, question_id: int, **kwargs) -> Question | None:
         """更新问题"""
@@ -335,6 +506,18 @@ class QuestionRepository:
             await session.commit()
             await session.refresh(question)
             return question
+
+    async def try_lock_content(self, question_id: int) -> bool:
+        """CAS：仅允许 content_locked 0→1；已锁定返回 False，锁不可逆。"""
+        async with get_async_db_session() as session:
+            stmt = (
+                update(Question)
+                .where(Question.id == question_id, Question.content_locked == 0)
+                .values(content_locked=1)
+            )
+            result = await session.execute(stmt)
+            await session.commit()
+            return bool(getattr(result, "rowcount", 0))
 
     async def get_business_domains(self) -> list[str]:
         """获取所有业务域"""
@@ -433,15 +616,59 @@ class AnswerRepository:
     async def count_adopted_by_question_id(self, question_id: int) -> int:
         """统计同题未软删且已采纳的回答数（用于最多 3 个最佳答案上限）。"""
         async with get_async_db_session() as session:
-            stmt = select(func.count()).select_from(Answer).where(
-                and_(
-                    Answer.question_id == question_id,
-                    Answer.adopted.is_(True),
-                    Answer.status != 3,
+            stmt = (
+                select(func.count())
+                .select_from(Answer)
+                .where(
+                    and_(
+                        Answer.question_id == question_id,
+                        Answer.adopted.is_(True),
+                        Answer.status != 3,
+                    )
                 )
             )
             result = await session.exec(stmt)
             return int(result.one() or 0)
+
+    async def has_effective_answer(self, question_id: int, user_id: int) -> bool:
+        """当前用户在该题是否仍有未软删的有效回答。"""
+        async with get_async_db_session() as session:
+            stmt = (
+                select(func.count())
+                .select_from(Answer)
+                .where(
+                    and_(
+                        Answer.question_id == question_id,
+                        Answer.user_id == user_id,
+                        Answer.status != 3,
+                    )
+                )
+            )
+            result = await session.exec(stmt)
+            return int(result.one() or 0) > 0
+
+    async def list_latest_by_question_ids(self, question_ids: list[int]) -> dict[int, Answer]:
+        """每题一条未软删的最新回答；用 MAX(id) 子查询，避免把该页全部回答载入。"""
+        ids = [int(qid) for qid in question_ids if qid is not None]
+        if not ids:
+            return {}
+        async with get_async_db_session() as session:
+            latest_id = (
+                select(Answer.question_id, func.max(Answer.id).label("max_id"))
+                .where(and_(Answer.question_id.in_(ids), Answer.status != 3))
+                .group_by(Answer.question_id)
+                .subquery()
+            )
+            stmt = select(Answer).join(latest_id, Answer.id == latest_id.c.max_id)
+            rows = list((await session.exec(stmt)).all())
+        return {int(row.question_id): row for row in rows}
+
+    async def list_all_by_question_id(self, question_id: int) -> list[Answer]:
+        """列出该题全部回答（含软删），供公开题首次采纳写资格快照。"""
+        async with get_async_db_session() as session:
+            stmt = select(Answer).where(Answer.question_id == question_id)
+            result = await session.exec(stmt)
+            return list(result.all())
 
     async def get_by_question_id(
         self, question_id: int, skip: int = 0, limit: int = 100, sort_by: str | None = None
@@ -535,9 +762,7 @@ class CommentRepository:
     async def delete_by_answer_id(self, answer_id: int) -> int:
         """硬删除某回答下全部评论/追问。返回删除条数。"""
         async with get_async_db_session() as session:
-            rows = (
-                await session.exec(select(Comment).where(Comment.answer_id == answer_id))
-            ).all()
+            rows = (await session.exec(select(Comment).where(Comment.answer_id == answer_id))).all()
             for comment in rows:
                 await session.delete(comment)
             if rows:
@@ -620,6 +845,228 @@ class VoteRepository:
                 return False
             await session.delete(vote)
             return True
+
+
+class AnswerAdoptRepository:
+    """采纳槽位仓储。"""
+
+    async def create(self, row: AnswerAdopt) -> AnswerAdopt:
+        """写入一条采纳槽位。"""
+        async with get_async_db_session() as session:
+            session.add(row)
+            await session.commit()
+            await session.refresh(row)
+            return row
+
+
+class AnswerEligibilityRepository:
+    """公开题首次采纳后的回答资格快照。"""
+
+    async def create_many(self, rows: list[AnswerEligibility]) -> None:
+        """写入资格快照；已有 (question_id, user_id) 则跳过，避免并发首次采纳撞唯一键。"""
+        if not rows:
+            return
+        question_id = int(rows[0].question_id)
+        async with get_async_db_session() as session:
+            existing = {
+                int(uid)
+                for uid in (
+                    await session.exec(
+                        select(AnswerEligibility.user_id).where(AnswerEligibility.question_id == question_id)
+                    )
+                ).all()
+            }
+            fresh = [row for row in rows if int(row.user_id) not in existing]
+            if not fresh:
+                return
+            session.add_all(fresh)
+            await session.commit()
+
+    async def list_user_ids(self, question_id: int) -> set[int]:
+        """读取该题快照内的专家用户 ID。"""
+        async with get_async_db_session() as session:
+            stmt = select(AnswerEligibility.user_id).where(AnswerEligibility.question_id == question_id)
+            result = await session.exec(stmt)
+            return {int(item) for item in result.all()}
+
+
+class AnonymousAliasRepository:
+    """题内稳定匿名别名。"""
+
+    async def get_by_question_user(self, question_id: int, user_id: int) -> AnonymousAlias | None:
+        """同题同用户已分配的别名；没有则返回 None。"""
+        async with get_async_db_session() as session:
+            stmt = select(AnonymousAlias).where(
+                AnonymousAlias.question_id == question_id,
+                AnonymousAlias.user_id == user_id,
+            )
+            result = await session.exec(stmt)
+            return result.first()
+
+    async def list_by_question_ids(self, question_ids: list[int]) -> list[AnonymousAlias]:
+        """一批题的已有别名；列表补水时避免按题逐条查。"""
+        ids = [int(qid) for qid in question_ids if qid is not None]
+        if not ids:
+            return []
+        async with get_async_db_session() as session:
+            stmt = select(AnonymousAlias).where(AnonymousAlias.question_id.in_(ids))
+            result = await session.exec(stmt)
+            return list(result.all())
+
+    async def next_alias_ord(self, question_id: int) -> int:
+        """下一序号 = max(alias_ord)+1；删内容不回收。"""
+        async with get_async_db_session() as session:
+            stmt = select(func.max(AnonymousAlias.alias_ord)).where(AnonymousAlias.question_id == question_id)
+            result = await session.exec(stmt)
+            current = result.first() or 0
+            return int(current or 0) + 1
+
+    async def create(self, row: AnonymousAlias) -> AnonymousAlias:
+        """写入一条别名。"""
+        async with get_async_db_session() as session:
+            session.add(row)
+            await session.commit()
+            await session.refresh(row)
+            return row
+
+
+class PublishRequestRepository:
+    """转公开申请头。"""
+
+    async def create(self, row: PublishRequest) -> PublishRequest:
+        """写入申请头。"""
+        async with get_async_db_session() as session:
+            session.add(row)
+            await session.commit()
+            await session.refresh(row)
+            return row
+
+    async def get_by_id(self, request_id: int) -> PublishRequest | None:
+        """按主键读取申请。"""
+        async with get_async_db_session() as session:
+            return await session.get(PublishRequest, request_id)
+
+    async def get_pending_by_question(self, question_id: int) -> PublishRequest | None:
+        """同题当前 pending 申请；至多一条。"""
+        async with get_async_db_session() as session:
+            stmt = select(PublishRequest).where(
+                PublishRequest.question_id == question_id,
+                PublishRequest.status == "pending",
+            )
+            result = await session.exec(stmt)
+            return result.first()
+
+    async def get_latest_by_question(self, question_id: int) -> PublishRequest | None:
+        """同题最近一条转公开申请（含终态），用于详情状态机。"""
+        async with get_async_db_session() as session:
+            stmt = (
+                select(PublishRequest)
+                .where(PublishRequest.question_id == question_id)
+                .order_by(desc(PublishRequest.id))
+                .limit(1)
+            )
+            result = await session.exec(stmt)
+            return result.first()
+
+    async def list_pending_for_asker(self, user_id: int) -> list[PublishRequest]:
+        """提问者名下仍 pending 的转公开申请（账号停用时结束）。"""
+        async with get_async_db_session() as session:
+            stmt = (
+                select(PublishRequest)
+                .join(Question, Question.id == PublishRequest.question_id)
+                .where(
+                    PublishRequest.status == "pending",
+                    Question.user_id == int(user_id),
+                )
+            )
+            result = await session.exec(stmt)
+            return list(result.all())
+
+    async def update(self, request_id: int, **kwargs) -> PublishRequest | None:
+        """更新申请头字段。"""
+        async with get_async_db_session() as session:
+            row = await session.get(PublishRequest, request_id)
+            if not row:
+                return None
+            for key, value in kwargs.items():
+                if hasattr(row, key):
+                    setattr(row, key, value)
+            session.add(row)
+            await session.commit()
+            await session.refresh(row)
+            return row
+
+    async def list_expired_pending(self, now) -> list[PublishRequest]:
+        """Beat / 惰性过期：pending 且 expire_at<=now。"""
+        async with get_async_db_session() as session:
+            stmt = select(PublishRequest).where(
+                PublishRequest.status == "pending",
+                PublishRequest.expire_at <= now,
+            )
+            result = await session.exec(stmt)
+            return list(result.all())
+
+
+class PublishApproverRepository:
+    """转公开审批人明细。"""
+
+    async def create_many(self, rows: list[PublishApprover]) -> None:
+        """写入审批人；空列表不访问库。"""
+        if not rows:
+            return
+        async with get_async_db_session() as session:
+            session.add_all(rows)
+            await session.commit()
+
+    async def list_by_request(self, request_id: int) -> list[PublishApprover]:
+        """某申请的全部审批人。"""
+        async with get_async_db_session() as session:
+            stmt = select(PublishApprover).where(PublishApprover.request_id == request_id)
+            result = await session.exec(stmt)
+            return list(result.all())
+
+    async def get_for_user(self, request_id: int, user_id: int) -> PublishApprover | None:
+        """某申请中指定审批人。"""
+        async with get_async_db_session() as session:
+            stmt = select(PublishApprover).where(
+                PublishApprover.request_id == request_id,
+                PublishApprover.user_id == user_id,
+            )
+            result = await session.exec(stmt)
+            return result.first()
+
+    async def update(self, row_id: int, **kwargs) -> PublishApprover | None:
+        """更新审批决策。"""
+        async with get_async_db_session() as session:
+            row = await session.get(PublishApprover, row_id)
+            if not row:
+                return None
+            for key, value in kwargs.items():
+                if hasattr(row, key):
+                    setattr(row, key, value)
+            session.add(row)
+            await session.commit()
+            await session.refresh(row)
+            return row
+
+    async def list_pending_for_user(self, user_id: int) -> list[PublishApprover]:
+        """用户仍为 pending 的审批行（专家停用时改 default_approved）。"""
+        async with get_async_db_session() as session:
+            stmt = select(PublishApprover).where(
+                PublishApprover.user_id == user_id,
+                PublishApprover.decision == "pending",
+            )
+            result = await session.exec(stmt)
+            return list(result.all())
+
+    async def delete(self, row_id: int) -> None:
+        """删除审批人行（中途加人后发现申请已结束时回滚）。"""
+        async with get_async_db_session() as session:
+            row = await session.get(PublishApprover, row_id)
+            if row is None:
+                return
+            await session.delete(row)
+            await session.commit()
 
 
 class NotificationRepository:

--- a/src/backend/bisheng/qa_expert/domain/schemas.py
+++ b/src/backend/bisheng/qa_expert/domain/schemas.py
@@ -106,7 +106,7 @@ class ExpertCreateRequest(BaseModel):
     position: str | None = Field(None, description="所属岗位")
     job_family: str | None = Field(None, description="所属岗位族")
     job_category: str | None = Field(None, description="所属岗位分类")
-    wechat_user_id: str | None =  Field(None, description="绑定企业微信用户id")
+    wechat_user_id: str | None = Field(None, description="绑定企业微信用户id")
 
 
 class ExpertUpdateRequest(BaseModel):
@@ -119,7 +119,7 @@ class ExpertUpdateRequest(BaseModel):
     position: str | None = Field(None, description="所属岗位")
     job_family: str | None = Field(None, description="所属岗位族")
     job_category: str | None = Field(None, description="所属岗位分类")
-    wechat_user_id: str | None =  Field(None, description="绑定企业微信用户id")
+    wechat_user_id: str | None = Field(None, description="绑定企业微信用户id")
 
 
 class ExpertResponse(BaseModel):
@@ -143,6 +143,7 @@ class ExpertResponse(BaseModel):
     vote_count: int = 0
     expert_score: int = 0
     helpful_count: int = 0
+    status: int | None = Field(default=1, description="1有效 0停用")
     created_at: datetime
 
     class Config:
@@ -165,9 +166,14 @@ class QuestionCreateRequest(BaseModel):
 
     attachments: str | None = Field(default=None, description="附件列表")
     related_docs: str | None = Field(default=None, description="关联文档ID")
+    related_doc_ids: list[str] | None = Field(default=None, description="关联文档 `{spaceId}-{fileId}` 列表")
 
     invited_experts: str | None = Field(default=None, description="邀请专家ID，多个用分号;分割")
+    invited_expert_ids: list[int] | None = Field(default=None, description="邀请专家档案 ID 列表")
     experts_names: str | None = Field(default=None, description="邀请专家名称，多个用分号;分割")
+    question_type: str = Field(default="public", description="directed / public，缺省公开")
+    asker_anonymous: bool = Field(default=False, description="提问者是否匿名（公开/定向均可）")
+    asker_reveal_on_public: bool | None = Field(default=None, description="定向且匿名时：转公开后是否公开姓名")
 
     image_url: str | None = Field(default=None, max_length=1024, schema_extra={"comment": "图片URL"})
     file_url: str | None = Field(default=None, max_length=1024, schema_extra={"comment": "文件URL"})
@@ -277,9 +283,16 @@ class QuestionDetailResponse(BaseModel):
     business_domain: str
     status: str
     user_id: int
-    anonymous: bool
+    question_type: str | None = None
+    display_status: str | None = None
+    content_locked: int | bool | None = None
+    adopt_count: int | None = None
+    capabilities: dict | None = None
+    related_doc_views: list[dict] | None = None
+    asker: dict | None = None
+    anonymous: bool | None = None
     attachments: str | None = Field(default=None, description="分号分隔的附件URL或业务ID")
-    related_docs: str | None = None
+    related_docs: str | list[dict] | None = None
     invited_experts: str | None = None
     experts_names: str | None = Field(default=None, description="邀请专家名称，多个用分号;分割")
     adopted_answer_id: int | None
@@ -311,6 +324,8 @@ class AnswerCreateRequest(BaseModel):
     attachments: str | None = Field(default=None, description="附件列表")
     related_docs: str | None = Field(default=None, description="关联文档ID")
     images_url: str | None = Field(default=None, description="图片URL")
+    anonymous: bool = Field(default=False, description="专家回答是否匿名（公开/定向均可）")
+    reveal_on_public: bool | None = Field(default=None, description="定向且匿名时：转公开后是否公开姓名")
 
 
 class AnswerUpdateRequest(BaseModel):
@@ -359,6 +374,8 @@ class CommentCreateRequest(BaseModel):
     content: str = Field(..., description="评论内容")
     is_follow_up: bool = Field(default=False, description="是否为追问")
     question_id: int | None = Field(None, description="问题ID（仅追问时需要）")
+    anonymous: bool = Field(default=False, description="评论他人回答时是否匿名；追问/自评继承已有状态")
+    reveal_on_public: bool | None = Field(default=None, description="定向且匿名时：转公开后是否公开姓名")
 
 
 class GetCommentsRequest(BaseModel):
@@ -389,20 +406,33 @@ class CommentDetailResponse(BaseModel):
     is_follow_up: bool
     vote_count: int
     created_at: datetime
+    anonymous: bool = False
+    author: dict[str, Any] | None = None
 
     @classmethod
     def from_comment(cls, comment: Any) -> "CommentDetailResponse":
-        """Build a JSON-safe response DTO from a database comment entity."""
+        """把评论 ORM 转成 JSON；匿名时 user_name 用别名，不把真名写回表列。"""
+        author = getattr(comment, "author", None)
+        if not isinstance(author, dict):
+            author = None
+        user_name = _decode_db_text(getattr(comment, "user_name", None))
+        shown_anonymous = bool(getattr(comment, "anonymous", False))
+        if author is not None:
+            shown_anonymous = bool(author.get("anonymous"))
+            if shown_anonymous and "real_name" not in author:
+                user_name = author.get("display_name") or user_name
         return cls(
             id=_coerce_db_int(getattr(comment, "id", None)),
             answer_id=_coerce_db_int(getattr(comment, "answer_id", None)),
             question_id=_coerce_db_int(getattr(comment, "question_id", None)),
             user_id=_coerce_db_int(getattr(comment, "user_id", None)),
-            user_name=_decode_db_text(getattr(comment, "user_name", None)),
+            user_name=user_name,
             content=_decode_db_text(getattr(comment, "content", None)) or "",
             is_follow_up=_coerce_db_bool(getattr(comment, "is_follow_up", False)),
             vote_count=_coerce_db_int(getattr(comment, "vote_count", None)),
             created_at=comment.created_at,
+            anonymous=shown_anonymous,
+            author=author,
         )
 
     class Config:
@@ -435,6 +465,12 @@ class AdoptAnswerRequest(BaseModel):
     answer_id: int = Field(..., description="回答ID")
 
 
+class PublishCreateRequest(BaseModel):
+    """发起转公开 - 请求"""
+
+    duration_days: int = Field(..., description="有效期天数：1/3/7")
+
+
 # ==================== 通知 Schemas ====================
 
 
@@ -460,7 +496,10 @@ class QuestionListQuery(BaseModel):
     """问题列表查询条件"""
 
     domain: str | None = Field(None, description="业务域")
-    status: int | None = Field(0, description="状态: unsolved/solved/closed")
+    status: int | None = Field(None, description="兼容：3=我提问的 4=邀请我的，不得当待采纳")
+    filter: str | None = Field(default=None, description="mine | invited_me")
+    display_status: str | None = Field(default=None, description="unanswered | pending_adopt | solved | unresolved")
+    keyword: str | None = Field(default=None, description="标题关键字")
     sort_by: str = Field(default="latest", description="排序: latest/hottest/unanswered")
     page: int = Field(default=1, ge=1)
     page_size: int = Field(default=20, ge=1, le=100)

--- a/src/backend/bisheng/qa_expert/domain/services.py
+++ b/src/backend/bisheng/qa_expert/domain/services.py
@@ -935,7 +935,10 @@ class QuestionService:
         result = self.capability_resolver.resolve(viewer, resolved, snapshot)
         self._annotate(resolved, capabilities=result.capabilities.__dict__)
         if latest_publish is not None:
-            payload = serialize_publish_request(latest_publish)
+            payload = serialize_publish_request(
+                latest_publish,
+                viewer_decision=snapshot.viewer_publish_decision,
+            )
             self._annotate(resolved, latest_publish_request=payload)
             if str(latest_publish.status) == "pending":
                 self._annotate(resolved, active_publish_request=payload)
@@ -962,9 +965,16 @@ class QuestionService:
             latest_publish = await self.publish_request_repo.get_latest_by_question(int(question.id))
         pending = latest_publish if latest_publish is not None and str(latest_publish.status) == "pending" else None
         approver_ids: set[int] = set()
-        if pending is not None:
-            for row in await self.publish_approver_repo.list_by_request(int(pending.id)):
-                approver_ids.add(int(row.user_id))
+        viewer_decision: str | None = None
+        uid_int = int(uid) if uid else None
+        # 终态也要带回本人决策，右上角才能在拒绝后显示「已拒绝」。
+        source = pending if pending is not None else latest_publish
+        if source is not None:
+            for row in await self.publish_approver_repo.list_by_request(int(source.id)):
+                if uid_int is not None and int(row.user_id) == uid_int:
+                    viewer_decision = str(row.decision)
+                if pending is not None and str(row.decision) == "pending":
+                    approver_ids.add(int(row.user_id))
         return CapabilitySnapshot(
             expert=expert,
             invited_user_ids=frozenset(invited),
@@ -974,6 +984,7 @@ class QuestionService:
             has_pending_publish=pending is not None,
             latest_publish_status=str(latest_publish.status) if latest_publish is not None else None,
             approver_user_ids=frozenset(approver_ids),
+            viewer_publish_decision=viewer_decision,
         )
 
     async def find_similar_questions(self, user, text: str, limit: int = 5) -> list[Question]:

--- a/src/backend/bisheng/qa_expert/domain/services.py
+++ b/src/backend/bisheng/qa_expert/domain/services.py
@@ -1,3 +1,4 @@
+# ruff: noqa: RUF001, RUF002, RUF003
 """
 Expert QA Services - 业务逻辑层
 核心流程：
@@ -7,15 +8,37 @@ Expert QA Services - 业务逻辑层
 - 互动流程：评论、投票、通知
 """
 
+import asyncio
+import inspect
 from datetime import datetime
+from types import SimpleNamespace
 
 from loguru import logger
 
 from bisheng.common.errcode.base import BaseErrorCode
+from bisheng.common.errcode.qa_expert import (
+    QaExpertAdminRequiredError,
+    QaExpertAdoptLimitError,
+    QaExpertAnswerNotAllowedError,
+    QaExpertCommentNotAllowedError,
+    QaExpertContentLockedError,
+    QaExpertDisabledError,
+    QaExpertQuestionAccessDeniedError,
+)
 from bisheng.core.database import get_async_db_session
 from bisheng.core.storage.minio.minio_manager import get_minio_storage
 from bisheng.database.models.department import DepartmentDao
-from bisheng.database.models.qa_expert import Answer, Comment, Expert, QANotification, Question
+from bisheng.database.models.qa_expert import (
+    EXPERT_STATUS_ACTIVE,
+    EXPERT_STATUS_DISABLED,
+    Answer,
+    AnswerEligibility,
+    Comment,
+    Expert,
+    QANotification,
+    Question,
+    QuestionInvite,
+)
 from bisheng.department.domain.services.department_display_service import (
     build_department_name_projection,
 )
@@ -23,12 +46,43 @@ from bisheng.dictionary.domain.repositories.implementations.system_dictionary_re
     SystemDictionaryRepositoryImpl,
 )
 from bisheng.qa_expert.domain.asset_service import QaAssetService, new_owner_stable_id
+from bisheng.qa_expert.domain.capability import (
+    CapabilityResolver,
+    CapabilitySnapshot,
+    is_expert_library_admin,
+)
+from bisheng.qa_expert.domain.identity import (
+    IdentityService,
+    copy_stored_anonymous_flags,
+    persist_anonymous_choice,
+)
+from bisheng.qa_expert.domain.question_query import (
+    MAX_INVITES,
+    QUESTION_TYPE_DIRECTED,
+    QUESTION_TYPE_PUBLIC,
+    invite_display_names_need_hydrate,
+    matches_display_status,
+    normalize_list_filter,
+    normalize_question_type,
+    parse_invite_expert_ids,
+    parse_related_doc_ref,
+    parse_related_doc_tokens,
+    question_display_status,
+    serialize_expert_names,
+    serialize_invite_ids,
+    serialize_related_doc_ids,
+)
 from bisheng.qa_expert.domain.repositories import (
+    AnswerAdoptRepository,
+    AnswerEligibilityRepository,
     AnswerRepository,
     CommentRepository,
     ExpertRepository,
     NotificationRepository,
+    PublishApproverRepository,
+    PublishRequestRepository,
     QAExpertStatsRepository,
+    QuestionInviteRepository,
     QuestionRepository,
     VoteRepository,
 )
@@ -83,15 +137,14 @@ class PermissionDeniedError(BaseErrorCode):
     Msg = "Permission denied"
 
 
-class AdoptLimitExceededError(BaseErrorCode):
-    """每个问题最多采纳 3 个最佳答案"""
-
-    Code = 10906
-    Msg = "每个问题最多采纳 3 个最佳答案"
+class AdoptLimitExceededError(QaExpertAdoptLimitError):
+    """兼容旧类名；错误码 18304。"""
 
 
 # 同题未删除回答中，adopted=true 的上限
 MAX_ADOPTED_ANSWERS_PER_QUESTION = 3
+ELIGIBILITY_SOURCE_INVITED = "invited"
+ELIGIBILITY_SOURCE_PRE_ADOPT_ANSWER = "pre_adopt_answer"
 
 
 class QAExpertStatsService:
@@ -111,6 +164,20 @@ class ExpertService:
 
     def __init__(self):
         self.repository = ExpertRepository()
+        self.publish_service = None
+
+    def _publish(self):
+        if self.publish_service is None:
+            from bisheng.qa_expert.domain.publish_service import PublishService
+
+            self.publish_service = PublishService()
+        return self.publish_service
+
+    @staticmethod
+    def _require_admin(user) -> None:
+        """写专家库仅专家库管理员（Portal isPortalAdmin），不是平台超管。"""
+        if not is_expert_library_admin(user):
+            raise QaExpertAdminRequiredError()
 
     @staticmethod
     def _with_department_projection(expert: Expert, department) -> dict:
@@ -143,8 +210,9 @@ class ExpertService:
         user.update_time = datetime.now()
         await UserDao.aupdate_user(user)
 
-    async def create_expert(self, request: ExpertCreateRequest) -> dict:
-        """创建专家（后台管理员操作）"""
+    async def create_expert(self, request: ExpertCreateRequest, user=None) -> dict:
+        """创建专家（专家库管理员操作）"""
+        self._require_admin(user)
         # 检查是否已是专家
         existing = await self.repository.get_by_user_name(request.expert_name, request.user_id)
         if existing:
@@ -165,8 +233,9 @@ class ExpertService:
         depart = await DepartmentDao.aget_by_id(temp_expert.depart_ment)
         return self._with_department_projection(temp_expert, depart)
 
-    async def update_expert(self, expert_id: int, request: ExpertUpdateRequest) -> dict:
+    async def update_expert(self, expert_id: int, request: ExpertUpdateRequest, user=None) -> dict:
         """更新专家信息"""
+        self._require_admin(user)
         expert = await self.repository.get_by_id(expert_id)
         if not expert:
             raise ExpertNotFoundError()
@@ -213,16 +282,8 @@ class ExpertService:
         )
         experts_all = await self._build_expert_rows(experts)
         if sort_by_department:
-            populated = [
-                item
-                for item in experts_all
-                if str(item.get("department_display_name") or "").strip()
-            ]
-            empty = [
-                item
-                for item in experts_all
-                if not str(item.get("department_display_name") or "").strip()
-            ]
+            populated = [item for item in experts_all if str(item.get("department_display_name") or "").strip()]
+            empty = [item for item in experts_all if not str(item.get("department_display_name") or "").strip()]
             populated.sort(
                 key=lambda item: (
                     str(item.get("department_display_name") or "").casefold(),
@@ -340,9 +401,7 @@ class ExpertService:
                 major_keys.add(expert.major)
 
         departments = await DepartmentDao.aget_by_ids(sorted(department_ids))
-        department_map = {
-            int(department.id): department for department in departments if department.id is not None
-        }
+        department_map = {int(department.id): department for department in departments if department.id is not None}
 
         users = await UserDao.aget_user_by_ids(list(set(user_ids))) or []
         wechat_user_ids = {user.user_id: user.wechat_user_id for user in users if user.user_id is not None}
@@ -377,9 +436,29 @@ class ExpertService:
             experts_all.append(expert_dict)
         return experts_all
 
-    async def delete_expert(self, expert_id: int) -> bool:
-        """删除专家"""
-        return await self.repository.delete(expert_id)
+    async def disable_expert(self, expert_id: int, user) -> Expert:
+        """停用专家：status=0；回调转公开默认同意。"""
+        self._require_admin(user)
+        expert = await self.repository.get_by_id(expert_id)
+        if not expert:
+            raise ExpertNotFoundError()
+        updated = await self.repository.update(expert_id, status=EXPERT_STATUS_DISABLED)
+        await self._publish().on_expert_disabled(int(expert.user_id))
+        return updated or expert
+
+    async def enable_expert(self, expert_id: int, user) -> Expert:
+        """恢复专家：不加入历史已结束转公开申请。"""
+        self._require_admin(user)
+        expert = await self.repository.get_by_id(expert_id)
+        if not expert:
+            raise ExpertNotFoundError()
+        updated = await self.repository.update(expert_id, status=EXPERT_STATUS_ACTIVE)
+        return updated or expert
+
+    async def delete_expert(self, expert_id: int, user=None) -> bool:
+        """兼容 DELETE：映射为停用，不硬删。"""
+        await self.disable_expert(expert_id, user)
+        return True
 
     async def get_expertinfo(self, expert_name: str) -> dict | None:
         """获取专家信息"""
@@ -401,9 +480,23 @@ class QuestionService:
     def __init__(self, asset_service: QaAssetService | None = None):
         self.repository = QuestionRepository()
         self.expert_repo = ExpertRepository()
+        self.invite_repo = QuestionInviteRepository()
         self.answer_repo = AnswerRepository()
         self.notification_repo = NotificationRepository()
+        self.adopt_repo = AnswerAdoptRepository()
+        self.eligibility_repo = AnswerEligibilityRepository()
+        self.publish_request_repo = PublishRequestRepository()
+        self.publish_approver_repo = PublishApproverRepository()
         self.asset_service = asset_service
+        self.capability_resolver = CapabilityResolver()
+        self.related_docs_access_checker = None
+        self.identity_service = None
+
+    async def _identity(self) -> IdentityService:
+        """懒加载身份脱敏；单测可注入 identity_service 避免打库。"""
+        if self.identity_service is None:
+            self.identity_service = IdentityService()
+        return self.identity_service
 
     async def _assets(self) -> QaAssetService:
         if self.asset_service is None:
@@ -430,7 +523,24 @@ class QuestionService:
         user_name: str,
         tenant_id: int | None = None,
     ) -> Question:
-        """创建问题"""
+        """创建问题：写 qa_question + qa_question_invite；存量默认 public。"""
+        if not user_id:
+            raise QaExpertQuestionAccessDeniedError()
+        question_type = normalize_question_type(getattr(request, "question_type", None))
+        invite_ids = parse_invite_expert_ids(
+            invited_expert_ids=getattr(request, "invited_expert_ids", None),
+            invited_experts=request.invited_experts,
+        )
+        experts = await self._validate_invites(user_id, question_type, invite_ids, request)
+        related_docs = serialize_related_doc_ids(
+            getattr(request, "related_doc_ids", None),
+            request.related_docs,
+        )
+        asker_anonymous = 1 if bool(getattr(request, "asker_anonymous", False)) else 0
+        reveal = getattr(request, "asker_reveal_on_public", None)
+        # 未匿名时转公开姓名选项无意义，不落库，避免旧客户端误带 true/false。
+        asker_reveal_on_public = None if (not asker_anonymous or reveal is None) else (1 if reveal else 0)
+
         asset_values = {
             "image_url": request.image_url,
             "file_url": request.file_url,
@@ -451,13 +561,17 @@ class QuestionService:
             description=request.description,
             business_domain=request.business_domain,
             attachments=asset_values["attachments"],
-            related_docs=request.related_docs,
-            invited_experts=request.invited_experts,
-            experts_names=request.experts_names,
+            related_docs=related_docs,
+            invited_experts=serialize_invite_ids(invite_ids),
+            experts_names=serialize_expert_names(experts),
             image_url=asset_values["image_url"],
             file_url=asset_values["file_url"],
             file_name=request.file_name,
             created_by=user_name,
+            tenant_id=tenant_id or 1,
+            question_type=question_type,
+            asker_anonymous=asker_anonymous,
+            asker_reveal_on_public=asker_reveal_on_public,
         )
 
         try:
@@ -466,6 +580,18 @@ class QuestionService:
             if promotion is not None:
                 await (await self._assets()).compensate(promotion)
             raise
+        if invite_ids:
+            await self.invite_repo.create_many(
+                [
+                    QuestionInvite(
+                        tenant_id=tenant_id or 1,
+                        question_id=question.id,
+                        expert_id=expert.id,
+                        user_id=expert.user_id,
+                    )
+                    for expert in experts
+                ]
+            )
         if promotion is not None:
             await (await self._assets()).cleanup_sources(promotion)
         # 发送邀请通知
@@ -492,6 +618,227 @@ class QuestionService:
         logger.info(f"Question created: {question.id} by user {user_id}")
         return await self._resolve_question(question)
 
+    async def _validate_invites(
+        self,
+        user_id: int,
+        question_type: str,
+        invite_ids: list[int],
+        request: QuestionCreateRequest,
+    ) -> list:
+        """校验邀请人数与专家有效性；定向且匿名时须预选转公开后是否公开姓名。"""
+        if question_type == QUESTION_TYPE_DIRECTED:
+            if (
+                bool(getattr(request, "asker_anonymous", False))
+                and getattr(request, "asker_reveal_on_public", None) is None
+            ):
+                raise InvalidInvitationError(msg="定向匿名题须选择转公开后是否公开姓名")
+            if not (1 <= len(invite_ids) <= MAX_INVITES):
+                raise InvalidInvitationError(msg="定向题须邀请 1–3 位有效专家")
+        elif len(invite_ids) > MAX_INVITES:
+            raise InvalidInvitationError(msg="公开题最多邀请 3 位专家")
+        experts = []
+        for expert_id in invite_ids:
+            expert = await self.expert_repo.get_by_id(expert_id)
+            if expert is None:
+                raise InvalidInvitationError(msg="邀请的专家不存在")
+            if int(getattr(expert, "status", 1) or 0) != 1:
+                raise QaExpertDisabledError()
+            if int(expert.user_id) == int(user_id):
+                raise InvalidInvitationError(msg="不能邀请自己")
+            experts.append(expert)
+        return experts
+
+    def _require_user(self, user, user_id: int | None):
+        if user is not None:
+            return user
+        if user_id:
+            return SimpleNamespace(user_id=user_id, is_admin=lambda: False, role=None, user_name="")
+        raise QaExpertQuestionAccessDeniedError()
+
+    async def _invite_map(self, questions: list) -> dict[int, set[int]]:
+        ids = [int(q.id) for q in questions if getattr(q, "id", None) is not None]
+        return await self.invite_repo.list_user_ids_by_question_ids(ids)
+
+    async def _hydrate_invite_names(self, questions: list) -> None:
+        """列表/详情把 invited_experts 的档案姓名填进 experts_names，避免页面展示专家 ID。"""
+        need: list = []
+        expert_ids: list[int] = []
+        seen: set[int] = set()
+        for question in questions:
+            invited = getattr(question, "invited_experts", None)
+            names = getattr(question, "experts_names", None)
+            if not invite_display_names_need_hydrate(names, invited):
+                continue
+            need.append(question)
+            for expert_id in parse_invite_expert_ids(invited_expert_ids=None, invited_experts=invited):
+                if expert_id not in seen:
+                    seen.add(expert_id)
+                    expert_ids.append(expert_id)
+        if not need or not expert_ids:
+            return
+        experts = await self.expert_repo.get_by_ids(expert_ids)
+        name_by_id = {
+            int(expert.id): str(getattr(expert, "expert_name", "") or "").strip()
+            for expert in experts
+            if getattr(expert, "id", None) is not None
+        }
+        for question in need:
+            invited = getattr(question, "invited_experts", None)
+            labels = [
+                name_by_id.get(expert_id) or str(expert_id)
+                for expert_id in parse_invite_expert_ids(invited_expert_ids=None, invited_experts=invited)
+            ]
+            filled = ";".join(label for label in labels if label)
+            if filled:
+                self._annotate(question, experts_names=filled)
+
+    def _is_question_visible(self, user, question, invited_user_ids: set[int]) -> bool:
+        snapshot = CapabilitySnapshot(invited_user_ids=frozenset(invited_user_ids))
+        result = self.capability_resolver.resolve(user, question, snapshot)
+        return bool(result.capabilities.visible)
+
+    @staticmethod
+    def _annotate(row, **fields):
+        """给 ORM 行挂响应态字段（非表列）；Pydantic 禁止直接 setattr。"""
+        for name, value in fields.items():
+            object.__setattr__(row, name, value)
+        return row
+
+    def _attach_display_status(self, question):
+        return self._annotate(question, display_status=question_display_status(question))
+
+    async def _attach_asker(self, viewer, question, *, can_view_real_identity: bool) -> None:
+        """列表/详情挂脱敏后的 asker；不改表列 created_by，避免别名被写回库。"""
+        asker_view = await (await self._identity()).mask_identity(
+            viewer,
+            question_id=int(question.id),
+            user_id=int(question.user_id),
+            real_name=str(getattr(question, "created_by", "") or ""),
+            anonymous=bool(int(getattr(question, "asker_anonymous", 0) or 0)),
+            question_type=str(getattr(question, "question_type", "") or QUESTION_TYPE_PUBLIC),
+            reveal_on_public=getattr(question, "asker_reveal_on_public", None),
+            tenant_id=int(getattr(question, "tenant_id", 1) or 1),
+        )
+        self._annotate(
+            question,
+            asker=asker_view.to_dict(can_view_real_identity=can_view_real_identity),
+        )
+
+    async def _attach_latest_answers(self, viewer, questions: list, *, can_view_real_identity: bool) -> None:
+        """列表卡片挂每题最新一条未删回答；一批查出，不按卡打回答接口。"""
+        ids = [int(question.id) for question in questions if getattr(question, "id", None) is not None]
+        if not ids:
+            return
+        latest_map = await self.answer_repo.list_latest_by_question_ids(ids)
+        if not latest_map:
+            return
+        identity = await self._identity()
+        for question in questions:
+            answer = latest_map.get(int(question.id))
+            if answer is None:
+                continue
+            real_name = str(getattr(answer, "expert_name", "") or "")
+            anonymous = bool(int(getattr(answer, "anonymous", 0) or 0))
+            user_id = int(getattr(answer, "user_id", 0) or 0)
+            display_name = real_name or "专家"
+            shown_anonymous = False
+            if anonymous and user_id:
+                view = await identity.mask_identity(
+                    viewer,
+                    question_id=int(question.id),
+                    user_id=user_id,
+                    real_name=real_name,
+                    anonymous=True,
+                    question_type=str(getattr(question, "question_type", "") or QUESTION_TYPE_PUBLIC),
+                    reveal_on_public=getattr(answer, "reveal_on_public", None),
+                    tenant_id=int(getattr(question, "tenant_id", 1) or 1),
+                )
+                payload = view.to_dict(can_view_real_identity=can_view_real_identity)
+                display_name = str(payload.get("display_name") or "匿名同事")
+                shown_anonymous = bool(payload.get("anonymous"))
+            excerpt = question_description_to_plain_text(str(getattr(answer, "content", "") or ""))
+            if len(excerpt) > 120:
+                excerpt = f"{excerpt[:120]}..."
+            self._annotate(
+                question,
+                latest_answer={
+                    "id": int(answer.id),
+                    "excerpt": excerpt,
+                    "adopted": bool(getattr(answer, "adopted", False)),
+                    "expert_name": display_name,
+                    "anonymous": shown_anonymous,
+                },
+            )
+
+    async def hydrate_related_docs(
+        self, related_docs: str | None, user=None, owner_user_id: int | None = None
+    ) -> list[dict]:
+        """解析关联文档串；无权用 forbidden，禁止用 not_found 表示无权限。
+
+        不调 OpenFGA：提问者视为有权，其他浏览者一律 forbidden。避免 LoginUser
+        缺 get_visible_tenants 时 list_accessible_ids 卡住整道详情。
+        """
+        views: list[dict] = []
+        checker = getattr(self, "related_docs_access_checker", None)
+        if checker is None:
+            from bisheng.qa_expert.domain.related_docs_access import check_related_doc_access
+
+            checker = check_related_doc_access
+        viewer_id = getattr(user, "user_id", None) if user is not None else None
+        is_owner = owner_user_id is not None and viewer_id is not None and int(viewer_id) == int(owner_user_id)
+        for token in parse_related_doc_tokens(related_docs):
+            parsed = parse_related_doc_ref(token)
+            if parsed is None:
+                views.append(
+                    {
+                        "id": token,
+                        "space_id": None,
+                        "file_id": None,
+                        "title": None,
+                        "accessible": False,
+                        "unavailable_reason": "not_found",
+                    }
+                )
+                continue
+            space_id, file_id = parsed
+            doc_id = f"{space_id}-{file_id}"
+            accessible = True
+            reason = None
+            if callable(checker):
+                access = checker(user, space_id, file_id)
+                if inspect.isawaitable(access):
+                    try:
+                        from bisheng.qa_expert.domain.related_docs_access import (
+                            RELATED_DOC_ACCESS_TIMEOUT_SEC,
+                        )
+
+                        access = await asyncio.wait_for(access, timeout=RELATED_DOC_ACCESS_TIMEOUT_SEC)
+                    except Exception:
+                        access = False
+                if access is None:
+                    accessible = False
+                    reason = "not_found"
+                elif access is False:
+                    accessible = False
+                    reason = "forbidden"
+                elif is_owner or owner_user_id is None:
+                    accessible = True
+                    reason = None
+                else:
+                    accessible = False
+                    reason = "forbidden"
+            views.append(
+                {
+                    "id": doc_id,
+                    "space_id": space_id,
+                    "file_id": file_id,
+                    "title": None,
+                    "accessible": accessible,
+                    "unavailable_reason": reason,
+                }
+            )
+        return views
+
     async def list_questions(
         self,
         business_domain: str | None = None,
@@ -500,49 +847,194 @@ class QuestionService:
         user_id: int | None = None,
         skip: int = 0,
         limit: int = 20,
+        user=None,
+        list_filter: str | None = None,
+        display_status: str | None = None,
+        keyword: str | None = None,
     ) -> tuple[list[Question], int]:
-        """列表查询问题"""
+        """列表：filter=mine|invited_me 与 display_status；status=3/4 不当待采纳。"""
+        viewer = self._require_user(user, user_id)
+        viewer_id = int(viewer.user_id)
+        normalized_filter = normalize_list_filter(status=status, list_filter=list_filter)
         expert_id = None
-        if status == 4:
-            # 状态为 4 (邀请我的) 时，按被邀请的专家 ID 过滤
+        if status == 4 and normalized_filter != "invited_me":
             if user_id is not None:
                 expert = await self.expert_repo.get_by_user_id(user_id)
                 if not expert:
                     return [], 0
                 expert_id = expert.id
-        questions, total = await self.repository.list_all(
+        questions, repo_total = await self.repository.list_all(
             business_domain=business_domain,
             status=status,
             sort_by=sort_by,
-            user_id=user_id,
+            user_id=viewer_id if normalized_filter == "mine" else user_id,
             skip=skip,
             limit=limit,
             expert_id=expert_id,
+            list_filter=normalized_filter,
+            display_status=display_status,
+            keyword=keyword,
+            viewer_user_id=viewer_id,
+            viewer_is_admin=is_expert_library_admin(viewer),
         )
-        if questions and len(questions) > 0:
-            for question in questions:
-                vote_count = await self.answer_repo.get_answer_vote_count(question.id)
-                question.vote_count = vote_count
-        return [await self._resolve_question(question) for question in questions], total
+        await self._hydrate_invite_names(list(questions))
+        invite_map = await self._invite_map(list(questions))
+        can_view_real = is_expert_library_admin(viewer)
+        identity = await self._identity()
+        await identity.preload_for_questions(
+            [int(question.id) for question in questions if getattr(question, "id", None) is not None]
+        )
+        visible: list[Question] = []
+        for question in questions:
+            invited = invite_map.get(int(question.id), set())
+            if not self._is_question_visible(viewer, question, invited):
+                continue
+            if not matches_display_status(question, display_status):
+                continue
+            # 列表卡片用 qa_question.vote_count（问题点赞），不再逐条 SUM 回答赞。
+            # 列表不展示图片/附件，跳过 MinIO 预签名，避免每条一次远端往返。
+            self._attach_display_status(question)
+            await self._attach_asker(viewer, question, can_view_real_identity=can_view_real)
+            visible.append(question)
+        await self._attach_latest_answers(viewer, visible, can_view_real_identity=can_view_real)
+        # 分页总数用仓储计数；页内可见性再滤只影响本页条目，不能把 total 收成当前页长度。
+        return visible, int(repo_total or 0)
 
-    async def get_question_detail(self, question_id: int, user_id: int | None = None) -> Question:
-        """获取问题详情"""
+    async def get_question_detail(
+        self,
+        question_id: int,
+        user_id: int | None = None,
+        user=None,
+    ) -> Question:
+        """详情：定向不可见返回 18301，不泄露标题，不增加浏览数。"""
+        viewer = self._require_user(user, user_id)
         question = await self.repository.get_by_id(question_id)
         if not question:
             raise QuestionNotFoundError()
-
-        # 增加浏览数
-        question.view_count += 1
+        await self._hydrate_invite_names([question])
+        invite_map = await self._invite_map([question])
+        invited = invite_map.get(int(question.id), set())
+        if not self._is_question_visible(viewer, question, invited):
+            raise QaExpertQuestionAccessDeniedError()
+        question.view_count = int(getattr(question, "view_count", 0) or 0) + 1
         await self.repository.update(question_id, view_count=question.view_count)
-        return await self._resolve_question(question)
+        resolved = await self._resolve_question(question)
+        self._attach_display_status(resolved)
+        self._annotate(
+            resolved,
+            related_doc_views=await self.hydrate_related_docs(
+                getattr(resolved, "related_docs", None),
+                user=viewer,
+                owner_user_id=int(getattr(resolved, "user_id", 0) or 0),
+            ),
+        )
+        from bisheng.qa_expert.domain.publish_service import PublishService, serialize_publish_request
+
+        latest_publish = await PublishService().refresh_latest_for_question(int(resolved.id))
+        snapshot = await self._capability_snapshot(resolved, viewer, latest_publish=latest_publish)
+        result = self.capability_resolver.resolve(viewer, resolved, snapshot)
+        self._annotate(resolved, capabilities=result.capabilities.__dict__)
+        if latest_publish is not None:
+            payload = serialize_publish_request(latest_publish)
+            self._annotate(resolved, latest_publish_request=payload)
+            if str(latest_publish.status) == "pending":
+                self._annotate(resolved, active_publish_request=payload)
+        await self._attach_asker(
+            viewer,
+            resolved,
+            can_view_real_identity=bool(result.capabilities.can_view_real_identity),
+        )
+        return resolved
+
+    async def _capability_snapshot(self, question, user, *, latest_publish=None):
+        """详情/写路径共用快照，避免列表与详情资格不一致。"""
+        invite_map = await self._invite_map([question])
+        invited = invite_map.get(int(question.id), set())
+        uid = getattr(user, "user_id", None)
+        expert = await self.expert_repo.get_by_user_id(int(uid)) if uid else None
+        eligibility: set[int] = set()
+        if int(getattr(question, "adopt_count", 0) or 0) > 0:
+            eligibility = set(await self.eligibility_repo.list_user_ids(int(question.id)))
+        has_answer = False
+        if uid:
+            has_answer = await self.answer_repo.has_effective_answer(int(question.id), int(uid))
+        if latest_publish is None:
+            latest_publish = await self.publish_request_repo.get_latest_by_question(int(question.id))
+        pending = latest_publish if latest_publish is not None and str(latest_publish.status) == "pending" else None
+        approver_ids: set[int] = set()
+        if pending is not None:
+            for row in await self.publish_approver_repo.list_by_request(int(pending.id)):
+                approver_ids.add(int(row.user_id))
+        return CapabilitySnapshot(
+            expert=expert,
+            invited_user_ids=frozenset(invited),
+            eligibility_user_ids=frozenset(eligibility),
+            effective_answer_count=int(getattr(question, "answer_count", 0) or 0),
+            user_has_effective_answer=has_answer,
+            has_pending_publish=pending is not None,
+            latest_publish_status=str(latest_publish.status) if latest_publish is not None else None,
+            approver_user_ids=frozenset(approver_ids),
+        )
+
+    async def find_similar_questions(self, user, text: str, limit: int = 5) -> list[Question]:
+        """类似问题仅返回当前用户可见的题；不合并、不阻断发布。"""
+        viewer = self._require_user(user, getattr(user, "user_id", None) if user is not None else None)
+        rows = await self.repository.search_by_title_like(text, limit=max(limit, 5))
+        invite_map = await self._invite_map(rows)
+        can_view_real = is_expert_library_admin(viewer)
+        visible: list[Question] = []
+        for question in rows:
+            invited = invite_map.get(int(question.id), set())
+            if not self._is_question_visible(viewer, question, invited):
+                continue
+            resolved = await self._resolve_question(question)
+            self._attach_display_status(resolved)
+            await self._attach_asker(viewer, resolved, can_view_real_identity=can_view_real)
+            visible.append(resolved)
+            if len(visible) >= limit:
+                break
+        return visible
+
+    async def _answerer_user_id(self, answer) -> int | None:
+        """解析回答者平台用户 ID：优先 qa_answer.user_id，否则走专家档案。"""
+        if getattr(answer, "user_id", None):
+            return int(answer.user_id)
+        if getattr(answer, "expert_id", None):
+            expert = await self.expert_repo.get_by_id(answer.expert_id)
+            if expert is not None and getattr(expert, "user_id", None) is not None:
+                return int(expert.user_id)
+        return None
+
+    async def _write_public_eligibility(self, question, *, tenant_id: int) -> None:
+        """公开题首次采纳：受邀 ∪ 采纳前回答者（含已删未采纳）。"""
+        invite_map = await self.invite_repo.list_user_ids_by_question_ids([int(question.id)])
+        invited = set(invite_map.get(int(question.id), set()))
+        answers = await self.answer_repo.list_all_by_question_id(int(question.id))
+        answerers: set[int] = set()
+        for row in answers:
+            user_id = await self._answerer_user_id(row)
+            if user_id:
+                answerers.add(user_id)
+        rows: list[AnswerEligibility] = []
+        for user_id in sorted(invited | answerers):
+            source = ELIGIBILITY_SOURCE_PRE_ADOPT_ANSWER if user_id in answerers else ELIGIBILITY_SOURCE_INVITED
+            rows.append(
+                AnswerEligibility(
+                    tenant_id=tenant_id,
+                    question_id=int(question.id),
+                    user_id=user_id,
+                    source=source,
+                )
+            )
+        if rows:
+            await self.eligibility_repo.create_many(rows)
 
     async def adopt_answer(self, question_id: int, answer_id: int, operator_id: int) -> Question:
-        """采纳最佳回答：同题最多 3 条；已采纳幂等；G4 按同题同回答者只发一次。"""
-        question = await self.repository.get_by_id(question_id)
+        """采纳：锁问题行、写 qa_answer_adopt、首次置已解决；公开题写资格快照；只调 F070 挂钩。"""
+        question = await self.repository.get_by_id_for_update(question_id)
         if not question:
             raise QuestionNotFoundError()
 
-        # 只有提问者可以采纳
         if question.user_id != operator_id:
             raise PermissionDeniedError(msg="Only question author can adopt answer")
 
@@ -553,7 +1045,6 @@ class QuestionService:
         if answer.question_id != question_id:
             raise InvalidInvitationError(msg="Answer does not belong to this question")
 
-        # 已采纳：幂等返回，不重复加采纳数 / 通知 / G4 旁路
         if bool(getattr(answer, "adopted", False)):
             logger.info(
                 "Answer %s already adopted for question %s; idempotent return",
@@ -562,46 +1053,63 @@ class QuestionService:
             )
             return question
 
-        adopted_count = await self.answer_repo.count_adopted_by_question_id(question_id)
+        adopted_count = int(getattr(question, "adopt_count", 0) or 0)
         if adopted_count >= MAX_ADOPTED_ANSWERS_PER_QUESTION:
             raise AdoptLimitExceededError()
 
-        # 更新问题状态（adopted_answer_id = 最近一次采纳）
-        question.adopted_answer_id = answer_id
-        question.status = 1  # 已解决
-        await self.repository.update(question_id, adopted_answer_id=answer_id, status=1)
+        expert_user_id = await self._answerer_user_id(answer)
+        if expert_user_id is None:
+            raise AnswerNotFoundError()
 
-        # 采纳标记以 adopted 为准；status 保持与现网写路径一致（列表过滤看 status!=3）
-        await self.answer_repo.update(answer_id, status=1, adopted=True)
+        locked = await self.repository.apply_adopt_count_locked(
+            question_id,
+            answer_id=answer_id,
+            expert_user_id=expert_user_id,
+            adopted_by=operator_id,
+            tenant_id=int(getattr(question, "tenant_id", 1) or 1),
+            max_adopt=MAX_ADOPTED_ANSWERS_PER_QUESTION,
+        )
+        if locked.status == "limit":
+            raise AdoptLimitExceededError()
+        if locked.status == "already":
+            return locked.question or question
+        if locked.status == "mismatch":
+            raise InvalidInvitationError(msg="Answer does not belong to this question")
+        if locked.status != "ok" or locked.question is None:
+            raise AnswerNotFoundError()
+        question = locked.question
+        is_first = bool(locked.is_first)
         if getattr(answer, "expert_id", None):
             await self.expert_repo.increment_adoption_count(answer.expert_id, count=1)
 
-        # 发送采纳通知
+        if is_first and str(getattr(question, "question_type", QUESTION_TYPE_PUBLIC)) == QUESTION_TYPE_PUBLIC:
+            try:
+                await self._write_public_eligibility(
+                    question,
+                    tenant_id=int(getattr(question, "tenant_id", 1) or 1),
+                )
+            except Exception:
+                logger.exception("qa_answer_eligibility snapshot failed question_id={}", question_id)
+
         await self._send_adoption_notification(question, answer)
 
-        # 积分旁路：给回答者发 G4；expert.user_id 才是平台用户 ID。
         try:
             from bisheng.core.context.tenant import DEFAULT_TENANT_ID, get_current_tenant_id
             from bisheng.points.domain.services.points_award_hooks import notify_answer_adopted
 
-            answerer_id = None
-            if getattr(answer, "expert_id", None):
-                expert = await self.expert_repo.get_by_id(answer.expert_id)
-                if expert is not None and getattr(expert, "user_id", None) is not None:
-                    answerer_id = int(expert.user_id)
-            if answerer_id:
-                await notify_answer_adopted(
-                    tenant_id=int(get_current_tenant_id() or DEFAULT_TENANT_ID),
-                    question_id=int(question_id),
-                    answer_id=int(answer_id),
-                    answerer_id=answerer_id,
-                )
+            await notify_answer_adopted(
+                tenant_id=int(get_current_tenant_id() or getattr(question, "tenant_id", None) or DEFAULT_TENANT_ID),
+                question_id=int(question_id),
+                answer_id=int(answer_id),
+                answerer_id=expert_user_id,
+            )
         except Exception:
             logger.exception(
                 "points.award.hooks adopt notify failed answer_id=%s",
                 answer_id,
             )
 
+        self._attach_display_status(question)
         logger.info(f"Answer {answer_id} adopted for question {question_id}")
         return question
 
@@ -637,57 +1145,32 @@ class QuestionService:
         question: Question,
         answer: Answer,
     ):
-        """发送采纳通知到 inbox_message"""
+        """采纳结果通知回答作者；匿名提问者用同题别名。"""
         if not question or not answer:
             return
+        from bisheng.qa_expert.domain.inbox_notice import display_name_for_trigger, send_qa_inbox
 
-        from bisheng.core.database import get_async_db_session
-        from bisheng.message.domain.models.inbox_message import MessageStatusEnum, MessageTypeEnum
-        from bisheng.message.domain.repositories.implementations.inbox_message_read_repository_impl import (
-            InboxMessageReadRepositoryImpl,
+        receiver = int(getattr(answer, "user_id", 0) or 0)
+        if receiver <= 0:
+            return
+        display, masked = await display_name_for_trigger(
+            question,
+            user_id=int(question.user_id),
+            real_name=str(getattr(question, "created_by", "") or ""),
+            anonymous=bool(int(getattr(question, "asker_anonymous", 0) or 0)),
+            reveal_on_public=getattr(question, "asker_reveal_on_public", None),
         )
-        from bisheng.message.domain.repositories.implementations.inbox_message_repository_impl import (
-            InboxMessageRepositoryImpl,
+        await send_qa_inbox(
+            action_code="qa_answer_accepted",
+            system_text="qa_answer_accepted",
+            question=question,
+            receivers=[receiver],
+            sender_user_id=int(question.user_id),
+            sender_display=display,
+            sender_anonymous=masked,
+            answer_id=int(answer.id),
+            tooltip=(answer.content or "")[:50],
         )
-        from bisheng.message.domain.services.message_service import MessageService
-
-        content = [
-            {
-                "type": "user",
-                "content": f"@{question.created_by}",
-                "metadata": {"user_id": question.user_id},
-            },
-            {
-                "type": "system_text",
-                "content": "qa_answer_accepted",
-            },
-            {
-                "type": "business_url",
-                "content": f"--{question.title}",
-                "metadata": {
-                    "business_type": "qa_question",
-                    "data": {"question_id": str(question.id), "answer_id": str(answer.id)},
-                },
-            },
-            {
-                "type": "tooltip_text",
-                "content": (answer.content or "")[:50],
-            },
-        ]
-
-        async with get_async_db_session() as session:
-            service = MessageService(
-                message_repository=InboxMessageRepositoryImpl(session),
-                message_read_repository=InboxMessageReadRepositoryImpl(session),
-            )
-            await service.send_message(
-                content=content,
-                sender=question.user_id,
-                message_type=MessageTypeEnum.NOTIFY,
-                receiver=[answer.expert_id],
-                status=MessageStatusEnum.APPROVED,
-                action_code="qa_answer_accepted",
-            )
 
     async def get_answer_count_by_domain(self) -> list[dict]:
         """获取每个业务域的回答数"""
@@ -698,7 +1181,12 @@ class QuestionService:
         question_id: int,
         tenant_id: int | None = None,
     ) -> bool:
-        """删除问题"""
+        """删除问题；首答锁定后提问者不可删。"""
+        question = await self.repository.get_by_id(question_id)
+        if not question:
+            return False
+        if int(getattr(question, "content_locked", 0) or 0):
+            raise QaExpertContentLockedError()
         deleted = await self.repository.delete(question_id)
         if deleted:
             try:
@@ -720,12 +1208,16 @@ class QuestionService:
         request: QuestionUpdateRequest,
         tenant_id: int | None = None,
     ) -> Question:
-        """更新问题信息"""
+        """更新问题信息；首答后正文/类型/邀请已锁定。"""
         question = await self.repository.get_by_id(question_id)
         if not question:
             raise QuestionNotFoundError()
+        if int(getattr(question, "content_locked", 0) or 0):
+            raise QaExpertContentLockedError()
 
         update_data = request.model_dump(exclude_unset=True)
+        if update_data.get("status") == 2:
+            update_data.pop("status", None)
         asset_fields = {"image_url", "file_url", "attachments"}
         requested_assets = {name: update_data[name] for name in asset_fields if name in update_data}
         promotion = None
@@ -771,53 +1263,25 @@ class QuestionService:
         if not receiver_user_ids:
             return
 
-        from bisheng.core.database import get_async_db_session
-        from bisheng.message.domain.models.inbox_message import MessageStatusEnum, MessageTypeEnum
-        from bisheng.message.domain.repositories.implementations.inbox_message_read_repository_impl import (
-            InboxMessageReadRepositoryImpl,
-        )
-        from bisheng.message.domain.repositories.implementations.inbox_message_repository_impl import (
-            InboxMessageRepositoryImpl,
-        )
-        from bisheng.message.domain.services.message_service import MessageService
+        from bisheng.qa_expert.domain.inbox_notice import display_name_for_trigger, send_qa_inbox
 
-        content = [
-            {
-                "type": "user",
-                "content": f"@{sender_name}",
-                "metadata": {"user_id": sender_id},
-            },
-            {
-                "type": "system_text",
-                "content": "qa_expert_invited",
-            },
-            {
-                "type": "business_url",
-                "content": f"--{question.title}",
-                "metadata": {
-                    "business_type": "qa_question",
-                    "data": {"question_id": str(question.id)},
-                },
-            },
-            {
-                "type": "tooltip_text",
-                "content": question_description_to_plain_text(question.description)[:50],
-            },
-        ]
-
-        async with get_async_db_session() as session:
-            service = MessageService(
-                message_repository=InboxMessageRepositoryImpl(session),
-                message_read_repository=InboxMessageReadRepositoryImpl(session),
-            )
-            await service.send_message(
-                content=content,
-                sender=sender_id,
-                message_type=MessageTypeEnum.NOTIFY,
-                receiver=receiver_user_ids,
-                status=MessageStatusEnum.APPROVED,
-                action_code="qa_expert_invited",
-            )
+        display, masked = await display_name_for_trigger(
+            question,
+            user_id=int(sender_id),
+            real_name=sender_name or "",
+            anonymous=bool(int(getattr(question, "asker_anonymous", 0) or 0)),
+            reveal_on_public=getattr(question, "asker_reveal_on_public", None),
+        )
+        await send_qa_inbox(
+            action_code="qa_expert_invited",
+            system_text="qa_expert_invited",
+            question=question,
+            receivers=receiver_user_ids,
+            sender_user_id=int(sender_id),
+            sender_display=display,
+            sender_anonymous=masked,
+            tooltip=question_description_to_plain_text(question.description)[:50],
+        )
 
 
 # ==================== 回答服务 ====================
@@ -828,13 +1292,64 @@ class AnswerService:
         self.repository = AnswerRepository()
         self.question_repo = QuestionRepository()
         self.expert_repo = ExpertRepository()
+        self.invite_repo = QuestionInviteRepository()
+        self.eligibility_repo = AnswerEligibilityRepository()
         self.notification_repo = NotificationRepository()
         self.asset_service = asset_service
+        self.capability_resolver = CapabilityResolver()
+        self.identity_service = None
+
+    async def _identity(self) -> IdentityService:
+        """懒加载身份脱敏；单测可注入 identity_service 避免打库。"""
+        if self.identity_service is None:
+            self.identity_service = IdentityService()
+        return self.identity_service
 
     async def _assets(self) -> QaAssetService:
         if self.asset_service is None:
             self.asset_service = QaAssetService(await get_minio_storage())
         return self.asset_service
+
+    @staticmethod
+    def _annotate(row, **fields):
+        """给 ORM 行挂响应态字段（非表列）；Pydantic 禁止直接 setattr。"""
+        for name, value in fields.items():
+            object.__setattr__(row, name, value)
+        return row
+
+    async def _attach_answer_author(self, viewer, answer: Answer, question: Question) -> Answer:
+        """列表/详情挂脱敏后的回答者身份；不改表列 expert_name，避免别名被写回库。"""
+        identity = await self._identity()
+        real_name = str(getattr(answer, "expert_name", "") or "")
+        anonymous = bool(int(getattr(answer, "anonymous", 0) or 0))
+        user_id = int(getattr(answer, "user_id", 0) or 0)
+        can_view_real = is_expert_library_admin(viewer)
+        if anonymous and user_id:
+            view = await identity.mask_identity(
+                viewer,
+                question_id=int(question.id),
+                user_id=user_id,
+                real_name=real_name,
+                anonymous=True,
+                question_type=str(getattr(question, "question_type", "") or QUESTION_TYPE_PUBLIC),
+                reveal_on_public=getattr(answer, "reveal_on_public", None),
+                tenant_id=int(getattr(question, "tenant_id", 1) or 1),
+            )
+            payload = view.to_dict(can_view_real_identity=can_view_real)
+        else:
+            payload = {
+                "display_name": real_name or "专家",
+                "avatar_url": None,
+                "anonymous": False,
+            }
+        return self._annotate(answer, author=payload)
+
+    async def attach_author(self, answer: Answer, viewer) -> Answer:
+        """写接口返回前挂 author；缺题则原样返回。"""
+        question = await self.question_repo.get_by_id(int(answer.question_id))
+        if question is None:
+            return answer
+        return await self._attach_answer_author(viewer, answer, question)
 
     async def _resolve_answer(self, answer: Answer) -> Answer:
         values = {"images_url": answer.images_url, "attachments": answer.attachments}
@@ -850,16 +1365,52 @@ class AnswerService:
         user_id: int,
         request: AnswerCreateRequest,
         tenant_id: int | None = None,
+        user=None,
     ) -> Answer:
-        """发布回答"""
+        """提交有效回答：资格校验后写 qa_answer，CAS 置 content_locked。"""
+        return await self.submit_answer(user_id, request, tenant_id=tenant_id, user=user)
+
+    async def submit_answer(
+        self,
+        user_id: int,
+        request: AnswerCreateRequest,
+        tenant_id: int | None = None,
+        user=None,
+    ) -> Answer:
+        """发布回答：资格校验 → 插入回答 → 条件更新锁 → inbox 通知。"""
+        if not user_id:
+            raise QaExpertQuestionAccessDeniedError()
         question = await self.question_repo.get_by_id(request.question_id)
         if not question:
             raise QuestionNotFoundError()
 
-        # 检查是否为专家
         expert = await self.expert_repo.get_by_user_id(user_id)
         if not expert:
             raise ExpertNotFoundError(message="Only verified experts can answer questions")
+        if int(getattr(expert, "status", 1) or 0) != 1:
+            raise QaExpertDisabledError()
+
+        invite_map = await self.invite_repo.list_user_ids_by_question_ids([int(question.id)])
+        invited = invite_map.get(int(question.id), set())
+        eligibility: set[int] = set()
+        if int(getattr(question, "adopt_count", 0) or 0) > 0:
+            eligibility = set(await self.eligibility_repo.list_user_ids(int(question.id)))
+        viewer = user or SimpleNamespace(user_id=user_id, is_admin=lambda: False, role=None, user_name="")
+        snapshot = CapabilitySnapshot(
+            expert=expert,
+            invited_user_ids=frozenset(invited),
+            eligibility_user_ids=frozenset(eligibility),
+            effective_answer_count=int(getattr(question, "answer_count", 0) or 0),
+        )
+        caps = self.capability_resolver.resolve(viewer, question, snapshot).capabilities
+        if not caps.can_answer:
+            raise QaExpertAnswerNotAllowedError()
+
+        anonymous, reveal_on_public = persist_anonymous_choice(
+            anonymous=bool(getattr(request, "anonymous", False)),
+            reveal_on_public=getattr(request, "reveal_on_public", None),
+            question_type=str(getattr(question, "question_type", "") or QUESTION_TYPE_PUBLIC),
+        )
 
         asset_values = {"attachments": request.attachments, "images_url": request.images_url}
         promotion = None
@@ -875,11 +1426,15 @@ class AnswerService:
         answer = Answer(
             question_id=request.question_id,
             expert_id=expert.id,
+            user_id=user_id,
             content=request.content,
             attachments=asset_values["attachments"],
             related_docs=request.related_docs,
             images_url=asset_values["images_url"],
             expert_name=expert.expert_name,
+            tenant_id=tenant_id or getattr(question, "tenant_id", 1) or 1,
+            anonymous=anonymous,
+            reveal_on_public=reveal_on_public,
         )
 
         try:
@@ -891,35 +1446,55 @@ class AnswerService:
         if promotion is not None:
             await (await self._assets()).cleanup_sources(promotion)
 
-        # 更新问题的回答计数
-        question.answer_count += 1
-        await self.question_repo.update(request.question_id, answer_count=question.answer_count)
-
+        await self.question_repo.try_lock_content(int(question.id))
+        await self.question_repo.increment_answer_count(request.question_id)
         await self.expert_repo.increment_answer_count(expert.id, count=1)
-
-        # 发送回答通知给提问者
         await self._send_answer_notification(question, answer)
+        try:
+            from bisheng.qa_expert.domain.publish_service import PublishService
 
+            await PublishService().add_late_answerer(question, int(user_id))
+        except Exception:
+            logger.exception("qa.answer.join_publish_failed question_id={}", question.id)
         logger.info(f"Answer created: {answer.id} for question {request.question_id}")
         return await self._resolve_answer(answer)
 
     async def get_answers(
-        self, question_id: int, skip: int = 0, limit: int = 100, sort_by: str | None = None
+        self,
+        question_id: int,
+        skip: int = 0,
+        limit: int = 100,
+        sort_by: str | None = None,
+        user=None,
     ) -> tuple[list[Answer], int]:
-        """获取问题的回答列表"""
-        answers, total = await self.repository.get_by_question_id(
-            question_id, skip=skip, limit=limit, sort_by=sort_by
-        )
-        return [await self._resolve_answer(answer) for answer in answers], total
+        """获取问题的回答列表；匿名回答者 expert_name 在 JSON 层改成别名。"""
+        question = await self.question_repo.get_by_id(question_id)
+        answers, total = await self.repository.get_by_question_id(question_id, skip=skip, limit=limit, sort_by=sort_by)
+        viewer = user or SimpleNamespace(user_id=0, is_admin=lambda: False, role=None)
+        resolved: list[Answer] = []
+        for answer in answers:
+            item = await self._resolve_answer(answer)
+            if question is not None:
+                item = await self._attach_answer_author(viewer, item, question)
+            resolved.append(item)
+        return resolved, total
 
     async def get_by_expertname(
         self,
         expert_name: str,
         question_id: int,
+        user=None,
     ) -> Answer | None:
-        """获取问题的回答列表"""
+        """按专家名取回答；同样挂脱敏 author。"""
         answer = await self.repository.get_by_expertname(expert_name, question_id)
-        return await self._resolve_answer(answer) if answer else None
+        if answer is None:
+            return None
+        resolved = await self._resolve_answer(answer)
+        question = await self.question_repo.get_by_id(question_id)
+        if question is None:
+            return resolved
+        viewer = user or SimpleNamespace(user_id=0, is_admin=lambda: False, role=None)
+        return await self._attach_answer_author(viewer, resolved, question)
 
     async def update_answer(
         self,
@@ -977,69 +1552,53 @@ class AnswerService:
         return await self._resolve_answer(updated)
 
     async def delete_answer(self, answer_id: int, operator_id: int) -> bool:
-        """删除回答"""
+        """删除回答：有效回答数可回 0，content_locked 不解除。"""
         answer = await self.repository.get_by_id(answer_id)
         if not answer:
             raise AnswerNotFoundError()
 
-        # 只有回答者可以删除
-        if answer.user_id != operator_id:
+        author_id = getattr(answer, "user_id", None)
+        if author_id is None and getattr(answer, "expert_id", None) is not None:
+            expert = await self.expert_repo.get_by_id(answer.expert_id)
+            author_id = getattr(expert, "user_id", None) if expert is not None else None
+        if author_id != operator_id:
             raise PermissionDeniedError(message="Only answer author can delete")
 
-        return await self.repository.delete(answer_id)
+        deleted = await self.repository.delete(answer_id)
+        if deleted:
+            question = await self.question_repo.get_by_id(answer.question_id)
+            if question is not None:
+                new_count = max(int(getattr(question, "answer_count", 0) or 0) - 1, 0)
+                await self.question_repo.update(answer.question_id, answer_count=new_count)
+        return deleted
 
     async def _send_answer_notification(self, question: Question, answer: Answer):
-        """发送回答通知到 inbox_message"""
-        if not question:
+        """每次提交回答通知提问者；匿名专家用同题别名。"""
+        if not question or not answer:
             return
+        sender_id = int(getattr(answer, "user_id", 0) or 0)
+        if sender_id <= 0:
+            return
+        from bisheng.qa_expert.domain.inbox_notice import display_name_for_trigger, send_qa_inbox
 
-        from bisheng.core.database import get_async_db_session
-        from bisheng.message.domain.models.inbox_message import MessageStatusEnum, MessageTypeEnum
-        from bisheng.message.domain.repositories.implementations.inbox_message_read_repository_impl import (
-            InboxMessageReadRepositoryImpl,
+        display, masked = await display_name_for_trigger(
+            question,
+            user_id=sender_id,
+            real_name=str(getattr(answer, "expert_name", "") or ""),
+            anonymous=bool(int(getattr(answer, "anonymous", 0) or 0)),
+            reveal_on_public=getattr(answer, "reveal_on_public", None),
         )
-        from bisheng.message.domain.repositories.implementations.inbox_message_repository_impl import (
-            InboxMessageRepositoryImpl,
+        await send_qa_inbox(
+            action_code="qa_expert_answered",
+            system_text="qa_expert_answered",
+            question=question,
+            receivers=[int(question.user_id)],
+            sender_user_id=sender_id,
+            sender_display=display,
+            sender_anonymous=masked,
+            answer_id=int(answer.id),
+            tooltip=(answer.content or "")[:50],
         )
-        from bisheng.message.domain.services.message_service import MessageService
-
-        content = [
-            {
-                "type": "user",
-                "content": f"@{answer.expert_name}",
-                "metadata": {"user_id": answer.expert_id},
-            },
-            {
-                "type": "system_text",
-                "content": "qa_expert_answered",
-            },
-            {
-                "type": "business_url",
-                "content": f"--{question.title}",
-                "metadata": {
-                    "business_type": "qa_question",
-                    "data": {"question_id": str(question.id), "answer_id": str(answer.id)},
-                },
-            },
-            {
-                "type": "tooltip_text",
-                "content": (answer.content or "")[:50],
-            },
-        ]
-
-        async with get_async_db_session() as session:
-            service = MessageService(
-                message_repository=InboxMessageRepositoryImpl(session),
-                message_read_repository=InboxMessageReadRepositoryImpl(session),
-            )
-            await service.send_message(
-                content=content,
-                sender=answer.expert_id,
-                message_type=MessageTypeEnum.NOTIFY,
-                receiver=[question.user_id],
-                status=MessageStatusEnum.APPROVED,
-                action_code="qa_expert_answered",
-            )
 
 
 # ==================== 评论服务 ====================
@@ -1051,14 +1610,125 @@ class CommentService:
         self.answer_repo = AnswerRepository()
         self.notification_repo = NotificationRepository()
         self.question_repo = QuestionRepository()
+        self.expert_repo = ExpertRepository()
+        self.invite_repo = QuestionInviteRepository()
+        self.capability_resolver = CapabilityResolver()
+        self.identity_service = None
+
+    async def _identity(self) -> IdentityService:
+        """懒加载身份脱敏；单测可注入 identity_service 避免打库。"""
+        if self.identity_service is None:
+            self.identity_service = IdentityService()
+        return self.identity_service
+
+    @staticmethod
+    def _annotate(row, **fields):
+        """给 ORM 行挂响应态字段（非表列）；Pydantic 禁止直接 setattr。"""
+        for name, value in fields.items():
+            object.__setattr__(row, name, value)
+        return row
+
+    @staticmethod
+    def _is_answer_author(user_id: int, answer) -> bool:
+        """评论者是否该回答作者；只认 qa_answer.user_id，避免误伤未填 user_id 的 mock。"""
+        owner = int(getattr(answer, "user_id", 0) or 0)
+        return bool(owner) and owner == int(user_id)
+
+    def _resolve_comment_identity(
+        self,
+        user_id: int,
+        request: CommentCreateRequest,
+        question,
+        answer,
+    ) -> tuple[int, int | None]:
+        """追问继承问题匿名；自评继承回答匿名；评他人时用请求体并校验定向 reveal。"""
+        is_follow_up = bool(getattr(request, "is_follow_up", False)) or answer is None
+        if is_follow_up and int(user_id) == int(getattr(question, "user_id", 0) or 0):
+            return copy_stored_anonymous_flags(
+                getattr(question, "asker_anonymous", 0),
+                getattr(question, "asker_reveal_on_public", None),
+            )
+        if answer is not None and self._is_answer_author(user_id, answer):
+            return copy_stored_anonymous_flags(
+                getattr(answer, "anonymous", 0),
+                getattr(answer, "reveal_on_public", None),
+            )
+        return persist_anonymous_choice(
+            anonymous=bool(getattr(request, "anonymous", False)),
+            reveal_on_public=getattr(request, "reveal_on_public", None),
+            question_type=str(getattr(question, "question_type", "") or QUESTION_TYPE_PUBLIC),
+        )
+
+    async def _attach_comment_author(self, viewer, comment: Comment, question) -> Comment:
+        """列表/创建响应挂脱敏作者；不改表列 user_name。"""
+        identity = await self._identity()
+        real_name = str(getattr(comment, "user_name", "") or "")
+        anonymous = bool(int(getattr(comment, "anonymous", 0) or 0))
+        user_id = int(getattr(comment, "user_id", 0) or 0)
+        can_view_real = is_expert_library_admin(viewer)
+        if anonymous and user_id:
+            view = await identity.mask_identity(
+                viewer,
+                question_id=int(question.id),
+                user_id=user_id,
+                real_name=real_name,
+                anonymous=True,
+                question_type=str(getattr(question, "question_type", "") or QUESTION_TYPE_PUBLIC),
+                reveal_on_public=getattr(comment, "reveal_on_public", None),
+                tenant_id=int(getattr(question, "tenant_id", 1) or 1),
+            )
+            payload = view.to_dict(can_view_real_identity=can_view_real)
+        else:
+            payload = {
+                "display_name": real_name or "用户",
+                "avatar_url": None,
+                "anonymous": False,
+            }
+        return self._annotate(comment, author=payload)
+
+    async def attach_author(self, comment: Comment, viewer) -> Comment:
+        """写接口返回前挂 author。"""
+        question_id = int(getattr(comment, "question_id", 0) or 0)
+        question = await self.question_repo.get_by_id(question_id) if question_id else None
+        if question is None:
+            return comment
+        return await self._attach_comment_author(viewer, comment, question)
+
+    async def _assert_can_comment(self, user_id: int, user_name: str, question, *, is_follow_up: bool) -> None:
+        """定向题普通评论须先有有效回答；追问不受该门槛。"""
+        if not user_id:
+            raise QaExpertQuestionAccessDeniedError()
+        invite_map = await self.invite_repo.list_user_ids_by_question_ids([int(question.id)])
+        invited = invite_map.get(int(question.id), set())
+        expert = await self.expert_repo.get_by_user_id(user_id)
+        has_answer = await self.answer_repo.has_effective_answer(int(question.id), user_id)
+        snapshot = CapabilitySnapshot(
+            expert=expert,
+            invited_user_ids=frozenset(invited),
+            user_has_effective_answer=has_answer,
+            effective_answer_count=int(getattr(question, "answer_count", 0) or 0),
+        )
+        viewer = SimpleNamespace(user_id=user_id, is_admin=lambda: False, role=None, user_name=user_name)
+        caps = self.capability_resolver.resolve(viewer, question, snapshot).capabilities
+        if not caps.visible:
+            raise QaExpertQuestionAccessDeniedError()
+        if is_follow_up:
+            return
+        if not caps.can_comment:
+            raise QaExpertCommentNotAllowedError()
 
     async def create_comment(self, user_id: int, user_name: str, request: CommentCreateRequest) -> Comment:
-        """发布评论"""
+        """发布评论或追问；追问/自评继承匿名，评他人才用请求体。"""
         comment = None
         if request.answer_id and request.answer_id != 0:
             answer = await self.answer_repo.get_by_id(request.answer_id)
             if not answer:
                 raise AnswerNotFoundError()
+            question = await self.question_repo.get_by_id(answer.question_id)
+            if not question:
+                raise QuestionNotFoundError()
+            await self._assert_can_comment(user_id, user_name, question, is_follow_up=bool(request.is_follow_up))
+            anonymous, reveal_on_public = self._resolve_comment_identity(user_id, request, question, answer)
             comment = Comment(
                 answer_id=request.answer_id,
                 question_id=answer.question_id,
@@ -1066,13 +1736,13 @@ class CommentService:
                 user_name=user_name,
                 content=request.content,
                 is_follow_up=request.is_follow_up,
+                anonymous=anonymous,
+                reveal_on_public=reveal_on_public,
             )
 
             answer.comment_count += 1
             await self.answer_repo.update(request.answer_id, comment_count=answer.comment_count)
-            # 2. 统一执行创建操作
             comment = await self.repository.create(comment)
-            # 3. 发送评论通知 (按需开启)
             await self._send_comment_notification(
                 answer,
                 comment,
@@ -1083,7 +1753,8 @@ class CommentService:
             question = await self.question_repo.get_by_id(request.question_id)
             if not question:
                 raise QuestionNotFoundError()
-
+            await self._assert_can_comment(user_id, user_name, question, is_follow_up=True)
+            anonymous, reveal_on_public = self._resolve_comment_identity(user_id, request, question, None)
             comment = Comment(
                 answer_id=0,
                 question_id=request.question_id,
@@ -1091,83 +1762,79 @@ class CommentService:
                 content=request.content,
                 is_follow_up=True,
                 user_name=user_name,
+                anonymous=anonymous,
+                reveal_on_public=reveal_on_public,
             )
             question.comment_count += 1
             await self.question_repo.update(request.question_id, comment_count=question.comment_count)
-            # 2. 统一执行创建操作
             comment = await self.repository.create(comment)
 
         return comment
 
     async def get_comments(
-        self, answer_id: int | None = None, question_id: int | None = None, skip: int = 0, limit: int = 100
+        self,
+        answer_id: int | None = None,
+        question_id: int | None = None,
+        skip: int = 0,
+        limit: int = 100,
+        user=None,
     ) -> tuple[list[Comment], int]:
-        """获取回答的评论"""
-        return await self.repository.get_by_answer_id(answer_id, question_id=question_id, skip=skip, limit=limit)
+        """获取回答的评论；匿名评论 user_name 在 JSON 层改成别名。"""
+        comments, total = await self.repository.get_by_answer_id(
+            answer_id, question_id=question_id, skip=skip, limit=limit
+        )
+        if not comments:
+            return comments, total
+        question_ids = {
+            int(comment.question_id) for comment in comments if getattr(comment, "question_id", None) is not None
+        }
+        questions: dict[int, Question] = {}
+        for qid in question_ids:
+            row = await self.question_repo.get_by_id(qid)
+            if row is not None:
+                questions[qid] = row
+        viewer = user or SimpleNamespace(user_id=0, is_admin=lambda: False, role=None)
+        for comment in comments:
+            question = questions.get(int(getattr(comment, "question_id", 0) or 0))
+            if question is not None:
+                await self._attach_comment_author(viewer, comment, question)
+        return comments, total
 
     async def _send_comment_notification(
         self,
         answer: Answer,
         comment: Comment,
     ):
-        """发送评论通知到 inbox_message"""
+        """评论通知回答作者；匿名评论用同题别名。"""
         if not answer or not comment:
             return
         question = await self.question_repo.get_by_id(answer.question_id)
         if not question:
             return
+        receiver = int(getattr(answer, "user_id", 0) or 0)
+        if receiver <= 0:
+            return
+        from bisheng.qa_expert.domain.inbox_notice import display_name_for_trigger, send_qa_inbox
 
-        from bisheng.core.database import get_async_db_session
-        from bisheng.message.domain.models.inbox_message import MessageStatusEnum, MessageTypeEnum
-        from bisheng.message.domain.repositories.implementations.inbox_message_read_repository_impl import (
-            InboxMessageReadRepositoryImpl,
+        display, masked = await display_name_for_trigger(
+            question,
+            user_id=int(comment.user_id),
+            real_name=str(getattr(comment, "user_name", "") or ""),
+            anonymous=bool(int(getattr(comment, "anonymous", 0) or 0)),
+            reveal_on_public=getattr(comment, "reveal_on_public", None),
         )
-        from bisheng.message.domain.repositories.implementations.inbox_message_repository_impl import (
-            InboxMessageRepositoryImpl,
+        await send_qa_inbox(
+            action_code="qa_answer_commented",
+            system_text="qa_answer_commented",
+            question=question,
+            receivers=[receiver],
+            sender_user_id=int(comment.user_id),
+            sender_display=display,
+            sender_anonymous=masked,
+            answer_id=int(answer.id),
+            comment_id=int(comment.id) if comment.id else None,
+            tooltip=(comment.content or "")[:50],
         )
-        from bisheng.message.domain.services.message_service import MessageService
-
-        content = [
-            {
-                "type": "user",
-                "content": f"@{comment.user_name}",
-                "metadata": {"user_id": comment.user_id},
-            },
-            {
-                "type": "system_text",
-                "content": "qa_answer_commented",
-            },
-            {
-                "type": "business_url",
-                "content": f"--{question.title}",
-                "metadata": {
-                    "business_type": "qa_question",
-                    "data": {
-                        "question_id": str(question.id),
-                        "answer_id": str(answer.id),
-                        "comment_id": str(comment.id),
-                    },
-                },
-            },
-            {
-                "type": "tooltip_text",
-                "content": (comment.content or "")[:50],
-            },
-        ]
-
-        async with get_async_db_session() as session:
-            service = MessageService(
-                message_repository=InboxMessageRepositoryImpl(session),
-                message_read_repository=InboxMessageReadRepositoryImpl(session),
-            )
-            await service.send_message(
-                content=content,
-                sender=comment.user_id,
-                message_type=MessageTypeEnum.NOTIFY,
-                receiver=[answer.expert_id],
-                status=MessageStatusEnum.APPROVED,
-                action_code="qa_answer_commented",
-            )
 
 
 # ==================== 投票服务 ====================

--- a/src/backend/bisheng/user/api/user.py
+++ b/src/backend/bisheng/user/api/user.py
@@ -187,6 +187,20 @@ async def get_admins(login_user: LoginUser = Depends(LoginUser.get_login_user)):
         raise HTTPException(status_code=500, detail="User information failed")
 
 
+_PORTAL_ADMIN_ROLE_NAMES = frozenset({"管理员", "系统管理员", "admin"})
+
+
+def _user_info_role_label(role, role_names: list[str] | None):
+    """AdminRole 仍返回 admin；若持有门户管理员角色名则下发该名。"""
+    if role == "admin":
+        return "admin"
+    for name in role_names or []:
+        text = str(name).strip()
+        if text in _PORTAL_ADMIN_ROLE_NAMES or text.lower() == "admin":
+            return text
+    return role
+
+
 @router.get("/user/info")
 async def get_info(login_user: LoginUser = Depends(LoginUser.get_login_user)):
     user_id = login_user.user_id
@@ -205,6 +219,8 @@ async def get_info(login_user: LoginUser = Depends(LoginUser.get_login_user)):
         db_user,
         is_department_admin=is_department_admin,
     )
+    # AdminRole 仍下发 admin；持有「管理员」等门户角色名时下发该名，供 Portal isPortalAdmin。
+    role = _user_info_role_label(role, getattr(login_user, "role_names", None))
     menu_approval_mode = await login_user.compute_menu_approval_mode(db_user)
     department_projection = await UserService.get_primary_department_name_projection(user_id)
 
@@ -855,6 +871,7 @@ async def update(*, request: Request, user: UserUpdate, login_user: LoginUser = 
         session.refresh(db_user)
     if disabled_just_now:
         await UserService.ainvalidate_jwt_after_account_disabled(db_user.user_id)
+        await UserService.on_account_disabled(db_user.user_id)
     update_user_delete_hook(request, login_user, db_user)
     return resp_200()
 

--- a/src/backend/bisheng/user/domain/services/auth.py
+++ b/src/backend/bisheng/user/domain/services/auth.py
@@ -2,70 +2,120 @@ import asyncio
 import functools
 import json
 import logging
+from collections.abc import Iterable
 from datetime import datetime, timezone
 from functools import cached_property
-from typing import List, Dict, Any, Optional, Tuple, Iterable
+from typing import Any
 
 import jwt
-from fastapi import Request, Response, Depends
+from fastapi import Depends, Request, Response
 from pydantic import BaseModel, Field
 from starlette.websockets import WebSocket
 from typing_extensions import Self
 
+from bisheng.approval.domain.services.user_menu_access_service import UserMenuAccessService
 from bisheng.common.errcode.http_error import UnAuthorizedError
 from bisheng.common.exceptions.auth import JWTDecodeError
 from bisheng.common.services.config_service import settings
-from bisheng.approval.domain.services.user_menu_access_service import UserMenuAccessService
+from bisheng.core.context.tenant import DEFAULT_TENANT_ID, get_current_tenant_id
 from bisheng.database.constants import AdminRole
-from bisheng.database.models.role import RoleDao
-from bisheng.database.models.group import GroupDao
 from bisheng.database.models.department import DepartmentDao
+from bisheng.database.models.group import GroupDao
+from bisheng.database.models.role import RoleDao
 from bisheng.database.models.role_access import AccessType, RoleAccessDao, WebMenuResource
 from bisheng.database.models.user_group import UserGroupDao
-from bisheng.core.context.tenant import DEFAULT_TENANT_ID, get_current_tenant_id
+
 from ..models.user import User, UserDao
 from ..models.user_role import UserRoleDao
 
 logger = logging.getLogger(__name__)
-PORTAL_RUNTIME_TOKEN_PURPOSE = 'portal_runtime'
+PORTAL_RUNTIME_TOKEN_PURPOSE = "portal_runtime"
 
 # 部门管理员：工作台 + 管理后台全量菜单（含路由用的 sys、仅 UI 的 log/system_config）
-_DEPARTMENT_ADMIN_WEB_MENU_FULL = frozenset({
-    'workstation', 'admin',
-    'build', 'create_app', 'knowledge', 'create_knowledge',
-    'knowledge_space', 'model', 'tool', 'mcp', 'channel',
-    'evaluation', 'dataset', 'mark_task', 'board', 'subscription',
-    'home', 'apps',
-    'frontend', 'backend', 'create_dashboard',
-    'log', 'system_config', 'sys',
-})
+_DEPARTMENT_ADMIN_WEB_MENU_FULL = frozenset(
+    {
+        "workstation",
+        "admin",
+        "build",
+        "create_app",
+        "knowledge",
+        "create_knowledge",
+        "knowledge_space",
+        "model",
+        "tool",
+        "mcp",
+        "channel",
+        "evaluation",
+        "dataset",
+        "mark_task",
+        "board",
+        "subscription",
+        "home",
+        "apps",
+        "frontend",
+        "backend",
+        "create_dashboard",
+        "log",
+        "system_config",
+        "sys",
+    }
+)
 
 # 角色管理 UI：一级「工作台 / 管理后台」关闭时，二级项仍存库但不应对用户生效（与 Roles.tsx 一致）
-_WORKBENCH_ENTRY_KEYS = frozenset({'workstation', 'frontend'})
-_ADMIN_ENTRY_KEYS = frozenset({'admin', 'backend'})
-_ROLE_UI_WORKBENCH_CHILDREN = frozenset({
-    'home', 'apps', 'subscription', 'knowledge_space',
-})
-_ROLE_UI_ADMIN_CHILDREN = frozenset({
-    'board', 'model', 'log', 'knowledge', 'create_knowledge',
-    'build', 'create_app', 'evaluation', 'mark_task',
-})
+_WORKBENCH_ENTRY_KEYS = frozenset({"workstation", "frontend"})
+_ADMIN_ENTRY_KEYS = frozenset({"admin", "backend"})
+_ROLE_UI_WORKBENCH_CHILDREN = frozenset(
+    {
+        "home",
+        "apps",
+        "subscription",
+        "knowledge_space",
+    }
+)
+_ROLE_UI_ADMIN_CHILDREN = frozenset(
+    {
+        "board",
+        "model",
+        "log",
+        "knowledge",
+        "create_knowledge",
+        "build",
+        "create_app",
+        "evaluation",
+        "mark_task",
+    }
+)
 
 # 登录校验：任一侧有「可生效」菜单即允许（含仅一级 workstation/admin，供需审批模式）
-_WEB_MENU_WORKBENCH_ALL = frozenset({
-    'workstation',
-    'frontend',
-    'home',
-    'apps',
-    'subscription',
-    'knowledge_space',
-})
-_WEB_MENU_ADMIN_ALL = frozenset({
-    'admin', 'backend',
-    'build', 'create_app', 'knowledge', 'create_knowledge',
-    'model', 'tool', 'mcp', 'channel',
-    'evaluation', 'dataset', 'mark_task', 'board', 'create_dashboard',
-})
+_WEB_MENU_WORKBENCH_ALL = frozenset(
+    {
+        "workstation",
+        "frontend",
+        "home",
+        "apps",
+        "subscription",
+        "knowledge_space",
+    }
+)
+_WEB_MENU_ADMIN_ALL = frozenset(
+    {
+        "admin",
+        "backend",
+        "build",
+        "create_app",
+        "knowledge",
+        "create_knowledge",
+        "model",
+        "tool",
+        "mcp",
+        "channel",
+        "evaluation",
+        "dataset",
+        "mark_task",
+        "board",
+        "create_dashboard",
+    }
+)
 
 
 def _effective_web_menu_strip_orphans(web_menu: list[str]) -> list[str]:
@@ -77,28 +127,29 @@ def _effective_web_menu_strip_orphans(web_menu: list[str]) -> list[str]:
         s -= _ROLE_UI_ADMIN_CHILDREN
     return list(s)
 
+
 # ── AccessType → ReBAC mapping (F008, AD-02) ────────────────
 # Maps old RBAC AccessType to one-or-more (relation, object_type) pairs for
 # ReBAC delegation. Knowledge libraries are migrating from the historical
 # knowledge_space object type to the dedicated knowledge_library type, so the
 # adapter must temporarily accept both.
-_ACCESS_TYPE_TO_REBAC: Dict[int, Tuple[Tuple[str, str], ...]] = {
+_ACCESS_TYPE_TO_REBAC: dict[int, tuple[tuple[str, str], ...]] = {
     AccessType.KNOWLEDGE: (
-        ('can_read', 'knowledge_library'),
-        ('can_read', 'knowledge_space'),
+        ("can_read", "knowledge_library"),
+        ("can_read", "knowledge_space"),
     ),
     AccessType.KNOWLEDGE_WRITE: (
-        ('can_edit', 'knowledge_library'),
-        ('can_edit', 'knowledge_space'),
+        ("can_edit", "knowledge_library"),
+        ("can_edit", "knowledge_space"),
     ),
-    AccessType.WORKFLOW: (('can_read', 'workflow'),),
-    AccessType.WORKFLOW_WRITE: (('can_edit', 'workflow'),),
-    AccessType.ASSISTANT_READ: (('can_read', 'assistant'),),
-    AccessType.ASSISTANT_WRITE: (('can_edit', 'assistant'),),
-    AccessType.GPTS_TOOL_READ: (('can_read', 'tool'),),
-    AccessType.GPTS_TOOL_WRITE: (('can_edit', 'tool'),),
-    AccessType.DASHBOARD: (('can_read', 'dashboard'),),
-    AccessType.DASHBOARD_WRITE: (('can_edit', 'dashboard'),),
+    AccessType.WORKFLOW: (("can_read", "workflow"),),
+    AccessType.WORKFLOW_WRITE: (("can_edit", "workflow"),),
+    AccessType.ASSISTANT_READ: (("can_read", "assistant"),),
+    AccessType.ASSISTANT_WRITE: (("can_edit", "assistant"),),
+    AccessType.GPTS_TOOL_READ: (("can_read", "tool"),),
+    AccessType.GPTS_TOOL_WRITE: (("can_edit", "tool"),),
+    AccessType.DASHBOARD: (("can_read", "dashboard"),),
+    AccessType.DASHBOARD_WRITE: (("can_edit", "dashboard"),),
 }
 
 
@@ -113,19 +164,19 @@ class AuthJwt:
         self._decode_algorithms = [self._encode_algorithm]
 
     def create_access_token(self, subject: dict) -> str:
-        """ create jwt token """
+        """create jwt token"""
         if isinstance(subject, dict):
             subject = json.dumps(subject)
         payload = {
-            'sub': subject,
-            'exp': int(datetime.now(timezone.utc).timestamp()) + self.cookie_conf.jwt_token_expire_time,
-            'iss': self.cookie_conf.jwt_iss
+            "sub": subject,
+            "exp": int(datetime.now(timezone.utc).timestamp()) + self.cookie_conf.jwt_token_expire_time,
+            "iss": self.cookie_conf.jwt_iss,
         }
         token = jwt.encode(payload, self.jwt_secret, algorithm=self._encode_algorithm)
         return token
 
     def set_access_token(self, token: str, response: Response = None, max_age: int = None) -> None:
-        """ set jwt token to cookie """
+        """set jwt token to cookie"""
         response = response or self.res
         response.set_cookie(
             self._access_cookie_key,
@@ -135,21 +186,16 @@ class AuthJwt:
             domain=self.cookie_conf.domain,
             secure=self.cookie_conf.secure,
             httponly=self.cookie_conf.httponly,
-            samesite=self.cookie_conf.samesite
+            samesite=self.cookie_conf.samesite,
         )
 
     def unset_access_token(self) -> None:
-        self.res.delete_cookie(
-            self._access_cookie_key,
-            path=self.cookie_conf.path,
-            domain=self.cookie_conf.domain
-        )
+        self.res.delete_cookie(self._access_cookie_key, path=self.cookie_conf.path, domain=self.cookie_conf.domain)
 
-    def get_subject(self,
-                    auth_from: str = "request",
-                    token: Optional[str] = None,
-                    websocket: Optional[WebSocket] = None) -> Dict:
-        """ decode jwt token """
+    def get_subject(
+        self, auth_from: str = "request", token: str | None = None, websocket: WebSocket | None = None
+    ) -> dict:
+        """decode jwt token"""
         if auth_from == "request":
             if not token:
                 token = self.req.cookies.get(self._access_cookie_key)
@@ -163,12 +209,13 @@ class AuthJwt:
             raise ValueError("unsupported auth_from value")
         return self.decode_jwt_token(token)
 
-    def decode_jwt_token(self, token: str) -> Dict:
-        """ decode jwt token """
+    def decode_jwt_token(self, token: str) -> dict:
+        """decode jwt token"""
         try:
-            payload = jwt.decode(token, self.jwt_secret, issuer=self.cookie_conf.jwt_iss,
-                                 algorithms=self._decode_algorithms)
-            return json.loads(payload.get('sub'))
+            payload = jwt.decode(
+                token, self.jwt_secret, issuer=self.cookie_conf.jwt_iss, algorithms=self._decode_algorithms
+            )
+            return json.loads(payload.get("sub"))
         except Exception as e:
             raise JWTDecodeError(status_code=422, message=str(e))
 
@@ -176,14 +223,19 @@ class AuthJwt:
 class LoginUser(BaseModel):
     user_id: int
     user_name: str = Field(default="")
-    user_role: List[int] = Field(default_factory=list, description="Users GroupsIDVertical")
-    group_cache: Dict[int, Any] = Field(default_factory=dict, description="User Group Cache")
+    user_role: list[int] = Field(default_factory=list, description="Users GroupsIDVertical")
+    role_names: list[str] = Field(
+        default_factory=list,
+        description="角色显示名；供专家库管理员判定对齐 Portal isPortalAdmin",
+    )
+    group_cache: dict[int, Any] = Field(default_factory=dict, description="User Group Cache")
     tenant_id: int = Field(default=1, description="Current tenant ID")
     # v2.5.1 F012: JWT invalidation counter carried from JWT payload.
     # Middleware compares this against user.token_version and rejects
     # stale tokens (AC-09). Defaults to 0 so v2.5.0 JWTs still decode.
     token_version: int = Field(
-        default=0, description='JWT invalidation counter (F012)',
+        default=0,
+        description="JWT invalidation counter (F012)",
     )
     # Pre-resolved global-super flag, populated by ``init_login_user`` from
     # ``_check_is_global_super`` (FGA tuple + RBAC AdminRole fallback). Kept
@@ -191,17 +243,19 @@ class LoginUser(BaseModel):
     # serialisation share a single source of truth, and so test fixtures
     # can set it directly without mocking helpers.
     is_global_super: bool = Field(
-        default=False, description='True iff system:global#super_admin',
+        default=False,
+        description="True iff system:global#super_admin",
     )
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.user_id = kwargs.get('user_id')
-        self.user_name = kwargs.get('user_name')
-        self.user_role = kwargs.get('user_role')
-        self.group_cache = kwargs.get('group_cache', {})
-        self.tenant_id = kwargs.get('tenant_id', DEFAULT_TENANT_ID)
-        self.is_global_super = bool(kwargs.get('is_global_super', False))
+        self.user_id = kwargs.get("user_id")
+        self.user_name = kwargs.get("user_name")
+        self.user_role = kwargs.get("user_role")
+        self.role_names = list(kwargs.get("role_names") or getattr(self, "role_names", []) or [])
+        self.group_cache = kwargs.get("group_cache", {})
+        self.tenant_id = kwargs.get("tenant_id", DEFAULT_TENANT_ID)
+        self.is_global_super = bool(kwargs.get("is_global_super", False))
         # token_version is validated by Pydantic Field(default=0) above.
 
         if not self.user_role:
@@ -260,6 +314,7 @@ class LoginUser(BaseModel):
         rebac_targets = self._rebac_targets_for_access_type(access_type)
         if rebac_targets:
             from bisheng.permission.domain.services.owner_service import _run_async_safe
+
             return any(
                 _run_async_safe(self.rebac_check(relation, object_type, str(target_id)))
                 for relation, object_type in rebac_targets
@@ -277,10 +332,9 @@ class LoginUser(BaseModel):
         """Async permission check — delegates to ReBAC for mapped types."""
         rebac_targets = self._rebac_targets_for_access_type(access_type)
         if rebac_targets:
-            results = await asyncio.gather(*[
-                self.rebac_check(relation, object_type, str(target_id))
-                for relation, object_type in rebac_targets
-            ])
+            results = await asyncio.gather(
+                *[self.rebac_check(relation, object_type, str(target_id)) for relation, object_type in rebac_targets]
+            )
             return any(results)
 
         # Legacy fallback for unmapped AccessType
@@ -292,7 +346,7 @@ class LoginUser(BaseModel):
     @wrapper_access_check
     def copiable_check(self, owner_user_id: int) -> bool:
         """
-            Check if the user has permission to copy a resource
+        Check if the user has permission to copy a resource
         """
         # Determine if it belongs to my resource
         if self.user_id == owner_user_id:
@@ -302,7 +356,7 @@ class LoginUser(BaseModel):
     @wrapper_access_check
     def check_group_admin(self, group_id: int) -> bool:
         """
-            Check if the user is an administrator of a group
+        Check if the user is an administrator of a group
         """
         # Determine if you are an administrator of a user group
         user_group = UserGroupDao.get_user_admin_group(self.user_id)
@@ -316,7 +370,7 @@ class LoginUser(BaseModel):
     @async_wrapper_access_check
     async def async_check_group_admin(self, group_id: int) -> bool:
         """
-            Asynchronously check if the user is an administrator of a group
+        Asynchronously check if the user is an administrator of a group
         """
         # Determine if you are an administrator of a user group
         user_group = await UserGroupDao.aget_user_admin_group(self.user_id, group_id)
@@ -328,7 +382,7 @@ class LoginUser(BaseModel):
         return False
 
     @wrapper_access_check
-    def check_groups_admin(self, group_ids: List[int]) -> bool:
+    def check_groups_admin(self, group_ids: list[int]) -> bool:
         """
         Check if the user is an administrator in the user group list, one of which istrue
         """
@@ -338,10 +392,10 @@ class LoginUser(BaseModel):
                 return True
         return False
 
-    async def get_user_groups(self, user_id: int) -> List[Dict]:
-        """ Query a list of roles for a user """
+    async def get_user_groups(self, user_id: int) -> list[dict]:
+        """Query a list of roles for a user"""
         user_groups = await UserGroupDao.aget_user_group(user_id)
-        user_group_ids: List[int] = [one_group.group_id for one_group in user_groups]
+        user_group_ids: list[int] = [one_group.group_id for one_group in user_groups]
         res = []
         for i in range(len(user_group_ids) - 1, -1, -1):
             if self.group_cache.get(user_group_ids[i]):
@@ -351,7 +405,7 @@ class LoginUser(BaseModel):
         if user_group_ids:
             group_list = await GroupDao.aget_group_by_ids(user_group_ids)
             for group_info in group_list:
-                self.group_cache[group_info.id] = {'id': group_info.id, 'name': group_info.group_name}
+                self.group_cache[group_info.id] = {"id": group_info.id, "name": group_info.group_name}
                 res.append(self.group_cache.get(group_info.id))
         return res
 
@@ -361,7 +415,7 @@ class LoginUser(BaseModel):
         user_groups = await UserGroupDao.aget_user_group(user_id)
         return [one_group.group_id for one_group in user_groups]
 
-    def get_user_access_resource_ids(self, access_types: List[AccessType]) -> List[str]:
+    def get_user_access_resource_ids(self, access_types: list[AccessType]) -> list[str]:
         """Query accessible resource IDs.
 
         F008 adapter: delegates to ReBAC list_accessible for mapped AccessType.
@@ -371,7 +425,7 @@ class LoginUser(BaseModel):
         if rebac_targets:
             from bisheng.permission.domain.services.owner_service import _run_async_safe
 
-            merged: Dict[str, None] = {}
+            merged: dict[str, None] = {}
             for relation, object_type in rebac_targets:
                 ids = _run_async_safe(self.rebac_list_accessible(relation, object_type)) or []
                 for rid in ids:
@@ -382,15 +436,14 @@ class LoginUser(BaseModel):
         role_access = RoleAccessDao.get_role_access_batch(self.user_role, access_types)
         return list(set([one.third_id for one in role_access]))
 
-    async def aget_user_access_resource_ids(self, access_types: List[AccessType]) -> List[str]:
+    async def aget_user_access_resource_ids(self, access_types: list[AccessType]) -> list[str]:
         """Async version — delegates to ReBAC for mapped types."""
         rebac_targets = self._rebac_targets_for_access_types(access_types)
         if rebac_targets:
-            merged: Dict[str, None] = {}
-            results = await asyncio.gather(*[
-                self.rebac_list_accessible(relation, object_type)
-                for relation, object_type in rebac_targets
-            ])
+            merged: dict[str, None] = {}
+            results = await asyncio.gather(
+                *[self.rebac_list_accessible(relation, object_type) for relation, object_type in rebac_targets]
+            )
             for ids in results:
                 for rid in ids or []:
                     merged[str(rid)] = None
@@ -400,7 +453,7 @@ class LoginUser(BaseModel):
         role_access = await RoleAccessDao.aget_role_access_batch(self.user_role, access_types)
         return list(set([one.third_id for one in role_access]))
 
-    def get_merged_rebac_app_resource_ids(self, *, for_write: bool = False) -> List[str]:
+    def get_merged_rebac_app_resource_ids(self, *, for_write: bool = False) -> list[str]:
         """合并 workflow + assistant 的 ReBAC 可见 ID（构建/工作台应用列表）。
 
         ⚠️ 仅供 async 调用方使用 sync 适配器时兜底。新代码请用
@@ -410,20 +463,22 @@ class LoginUser(BaseModel):
         """
         from bisheng.permission.domain.services.owner_service import _run_async_safe
 
-        relation = 'can_edit' if for_write else 'can_read'
-        wf_ids = _run_async_safe(self.rebac_list_accessible(relation, 'workflow'))
-        asst_ids = _run_async_safe(self.rebac_list_accessible(relation, 'assistant'))
+        relation = "can_edit" if for_write else "can_read"
+        wf_ids = _run_async_safe(self.rebac_list_accessible(relation, "workflow"))
+        asst_ids = _run_async_safe(self.rebac_list_accessible(relation, "assistant"))
         wf_ids = wf_ids or []
         asst_ids = asst_ids or []
         return list(set(wf_ids) | set(asst_ids))
 
     async def aget_merged_rebac_app_resource_ids(
-        self, *, for_write: bool = False,
-    ) -> List[str]:
+        self,
+        *,
+        for_write: bool = False,
+    ) -> list[str]:
         """async 版本：合并 workflow + assistant 的 ReBAC 可见 ID。"""
-        relation = 'can_edit' if for_write else 'can_read'
-        wf_ids = await self.rebac_list_accessible(relation, 'workflow')
-        asst_ids = await self.rebac_list_accessible(relation, 'assistant')
+        relation = "can_edit" if for_write else "can_read"
+        wf_ids = await self.rebac_list_accessible(relation, "workflow")
+        asst_ids = await self.rebac_list_accessible(relation, "assistant")
         return list(set(wf_ids or []) | set(asst_ids or []))
 
     # ── ReBAC permission methods (F004, INV-3) ─────────────────
@@ -435,6 +490,7 @@ class LoginUser(BaseModel):
         L1 admin → L2 cache → L3 OpenFGA → L4 owner fallback → L5 fail-closed.
         """
         from bisheng.permission.domain.services.permission_service import PermissionService
+
         return await PermissionService.check(
             user_id=self.user_id,
             relation=relation,
@@ -443,13 +499,14 @@ class LoginUser(BaseModel):
             login_user=self,
         )
 
-    async def rebac_list_accessible(self, relation: str, object_type: str) -> Optional[List[str]]:
+    async def rebac_list_accessible(self, relation: str, object_type: str) -> list[str] | None:
         """List accessible resource IDs via ReBAC.
 
         Returns None for admin (caller should not filter).
         Returns list of ID strings for normal users.
         """
         from bisheng.permission.domain.services.permission_service import PermissionService
+
         return await PermissionService.list_accessible_ids(
             user_id=self.user_id,
             relation=relation,
@@ -458,14 +515,15 @@ class LoginUser(BaseModel):
         )
 
     @staticmethod
-    def _rebac_targets_for_access_type(access_type: AccessType) -> Tuple[Tuple[str, str], ...]:
+    def _rebac_targets_for_access_type(access_type: AccessType) -> tuple[tuple[str, str], ...]:
         return _ACCESS_TYPE_TO_REBAC.get(access_type, ())
 
     @classmethod
     def _rebac_targets_for_access_types(
-        cls, access_types: Iterable[AccessType],
-    ) -> List[Tuple[str, str]]:
-        merged: Dict[Tuple[str, str], None] = {}
+        cls,
+        access_types: Iterable[AccessType],
+    ) -> list[tuple[str, str]]:
+        merged: dict[tuple[str, str], None] = {}
         for access_type in access_types:
             for pair in cls._rebac_targets_for_access_type(access_type):
                 merged[pair] = None
@@ -479,7 +537,7 @@ class LoginUser(BaseModel):
         auth_jwt: AuthJwt,
         tenant_id: int = None,
         token_version: int = None,
-        token_purpose: str = '',
+        token_purpose: str = "",
     ) -> str:
         """Create access token for user with tenant_id + token_version.
 
@@ -489,21 +547,21 @@ class LoginUser(BaseModel):
         the JWT so the middleware can invalidate stale tokens.
         """
         if token_version is None:
-            token_version = int(getattr(user, 'token_version', 0) or 0)
+            token_version = int(getattr(user, "token_version", 0) or 0)
         payload = {
-            'user_id': user.user_id,
-            'user_name': user.user_name,
-            'tenant_id': tenant_id or DEFAULT_TENANT_ID,
-            'token_version': token_version,
+            "user_id": user.user_id,
+            "user_name": user.user_name,
+            "tenant_id": tenant_id or DEFAULT_TENANT_ID,
+            "token_version": token_version,
         }
         if token_purpose:
-            payload['token_purpose'] = token_purpose
+            payload["token_purpose"] = token_purpose
         token = auth_jwt.create_access_token(subject=payload)
         return token
 
     @classmethod
     def set_access_cookies(cls, token: str, auth_jwt: AuthJwt, **kwargs) -> None:
-        """ set access token into cookie """
+        """set access token into cookie"""
         auth_jwt.set_access_token(token, **kwargs)
 
     @classmethod
@@ -527,15 +585,22 @@ class LoginUser(BaseModel):
         # this, hotfix-3's tenant-aware UserRole table trips
         # NoTenantContextError before tenant resolution finishes.
         from bisheng.core.context.tenant import bypass_tenant_filter
+        from bisheng.database.models.role import RoleDao
         from bisheng.utils.http_middleware import _check_is_global_super
+
         with bypass_tenant_filter():
             user_roles, is_global_super = await asyncio.gather(
                 UserRoleDao.aget_user_roles(user_id),
                 _check_is_global_super(user_id),
             )
-        role_ids = [user_role.role_id for user_role in user_roles]
+            role_ids = [user_role.role_id for user_role in user_roles]
+            db_roles = await RoleDao.aget_role_by_ids(role_ids) if role_ids else []
+        role_names = [str(r.role_name).strip() for r in db_roles if getattr(r, "role_name", None)]
         login_user = cls(
-            user_id=user_id, user_name=user_name, user_role=role_ids,
+            user_id=user_id,
+            user_name=user_name,
+            user_role=role_ids,
+            role_names=role_names,
             tenant_id=tenant_id or DEFAULT_TENANT_ID,
             token_version=token_version,
             is_global_super=is_global_super,
@@ -553,11 +618,18 @@ class LoginUser(BaseModel):
         # See ``init_login_user`` — bypass is required because UserRole is
         # tenant-aware and login-time has no tenant context yet.
         from bisheng.core.context.tenant import bypass_tenant_filter
+        from bisheng.database.models.role import RoleDao
+
         with bypass_tenant_filter():
             user_roles = UserRoleDao.get_user_roles(user_id)
-        role_ids = [user_role.role_id for user_role in user_roles]
+            role_ids = [user_role.role_id for user_role in user_roles]
+            db_roles = RoleDao.get_role_by_ids(role_ids) if role_ids else []
+        role_names = [str(r.role_name).strip() for r in db_roles if getattr(r, "role_name", None)]
         login_user = cls(
-            user_id=user_id, user_name=user_name, user_role=role_ids,
+            user_id=user_id,
+            user_name=user_name,
+            user_role=role_ids,
+            role_names=role_names,
             tenant_id=tenant_id or DEFAULT_TENANT_ID,
             token_version=token_version,
         )
@@ -567,10 +639,10 @@ class LoginUser(BaseModel):
     async def get_login_user(cls, auth_jwt: AuthJwt = Depends()) -> Self:
         subject = auth_jwt.get_subject()
         return await cls.init_login_user(
-            user_id=subject['user_id'],
-            user_name=subject['user_name'],
-            tenant_id=subject.get('tenant_id', DEFAULT_TENANT_ID),
-            token_version=int(subject.get('token_version', 0) or 0),
+            user_id=subject["user_id"],
+            user_name=subject["user_name"],
+            tenant_id=subject.get("tenant_id", DEFAULT_TENANT_ID),
+            token_version=int(subject.get("token_version", 0) or 0),
         )
 
     @classmethod
@@ -586,17 +658,17 @@ class LoginUser(BaseModel):
         login_user = await cls.get_login_user(auth_jwt)
         if login_user.is_admin():
             return login_user
-        await cls.assert_effective_web_menu_contains(login_user.user_id, 'model')
+        await cls.assert_effective_web_menu_contains(login_user.user_id, "model")
         return login_user
 
     @classmethod
     async def get_login_user_from_ws(cls, websocket: WebSocket, auth_jwt: AuthJwt = Depends(), t: str = None) -> Self:
         subject = auth_jwt.get_subject(auth_from="websocket", websocket=websocket, token=t)
         return await cls.init_login_user(
-            user_id=subject['user_id'],
-            user_name=subject['user_name'],
-            tenant_id=subject.get('tenant_id', DEFAULT_TENANT_ID),
-            token_version=int(subject.get('token_version', 0) or 0),
+            user_id=subject["user_id"],
+            user_name=subject["user_name"],
+            tenant_id=subject.get("tenant_id", DEFAULT_TENANT_ID),
+            token_version=int(subject.get("token_version", 0) or 0),
         )
 
     @classmethod
@@ -612,7 +684,7 @@ class LoginUser(BaseModel):
         user: User,
         *,
         is_department_admin: bool = False,
-    ) -> (List[int] | str, List[str]):
+    ) -> (list[int] | str, list[str]):
         """Resolve role key(s) and web_menu.
 
         - AC-13: multi-role web_menu is the **union** of each role's WEB_MENU entries.
@@ -621,14 +693,14 @@ class LoginUser(BaseModel):
           stripped for other users even if legacy role_access rows exist.
         """
         db_user_role = await UserRoleDao.aget_user_roles(user.user_id)
-        role = ''
+        role = ""
         role_ids = []
         for user_role in db_user_role:
             if user_role.role_id == AdminRole:
-                role = 'admin'
+                role = "admin"
             else:
                 role_ids.append(user_role.role_id)
-        if role != 'admin':
+        if role != "admin":
             role = role_ids
             # AC-13: union of all roles' menu permissions
             web_menu = await RoleAccessDao.aget_role_access(role_ids, AccessType.WEB_MENU)
@@ -641,7 +713,7 @@ class LoginUser(BaseModel):
             if is_department_admin:
                 web_menu = list(set(web_menu) | set(_DEPARTMENT_ADMIN_WEB_MENU_FULL))
             else:
-                web_menu = [m for m in web_menu if m not in ('system_config', 'sys')]
+                web_menu = [m for m in web_menu if m not in ("system_config", "sys")]
             web_menu = _effective_web_menu_strip_orphans(web_menu)
         else:
             # AC-14: admin returns all WebMenuResource values (including deprecated for compat)
@@ -649,7 +721,7 @@ class LoginUser(BaseModel):
         return role, web_menu
 
     @classmethod
-    async def effective_workbench_admin_flags(cls, user: User) -> Tuple[bool, bool]:
+    async def effective_workbench_admin_flags(cls, user: User) -> tuple[bool, bool]:
         """Effective (has_workbench, has_admin_console) after orphan strip and dept-admin merge."""
         db_user_role = await UserRoleDao.aget_user_roles(user.user_id)
         if any(ur.role_id == AdminRole for ur in db_user_role):
@@ -671,18 +743,18 @@ class LoginUser(BaseModel):
     def default_web_entry(cls, has_workbench: bool, has_admin_console: bool) -> str:
         """First app after login: ``platform`` (管理后台) or ``workspace`` (工作台). Both open → platform."""
         if has_admin_console:
-            return 'platform'
+            return "platform"
         if has_workbench:
-            return 'workspace'
-        return 'platform'
+            return "workspace"
+        return "platform"
 
     @classmethod
     async def user_entry_payload_for_read(cls, user: User) -> dict:
         hw, ha = await cls.effective_workbench_admin_flags(user)
         return {
-            'has_workbench': hw,
-            'has_admin_console': ha,
-            'default_entry': cls.default_web_entry(hw, ha),
+            "has_workbench": hw,
+            "has_admin_console": ha,
+            "default_entry": cls.default_web_entry(hw, ha),
         }
 
     @classmethod
@@ -695,8 +767,8 @@ class LoginUser(BaseModel):
         roles = await RoleDao.aget_role_by_ids(role_ids)
         for r in roles or []:
             qc = r.quota_config or {}
-            v = qc.get('menu_approval_mode')
-            if v is True or v == 1 or str(v).lower() in ('true', '1'):
+            v = qc.get("menu_approval_mode")
+            if v is True or v == 1 or str(v).lower() in ("true", "1"):
                 return True
         return False
 

--- a/src/backend/bisheng/user/domain/services/user.py
+++ b/src/backend/bisheng/user/domain/services/user.py
@@ -1,29 +1,29 @@
 from base64 import b64decode
 from datetime import datetime
-from typing import List, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 from urllib.parse import unquote, urlsplit
 
 import rsa
-from fastapi import Request, Depends, UploadFile, HTTPException
+from fastapi import Depends, HTTPException, Request, UploadFile
 from loguru import logger
 
 from bisheng.common.constants.enums.telemetry import BaseTelemetryTypeEnum
 from bisheng.common.errcode.user import (
     CaptchaError,
     UserForbiddenError,
-    UserValidateError,
-    UserPasswordMaxTryError,
-    UserPasswordExpireError,
+    UserMultiLoginConflictError,
     UserNameTooLongError,
     UserNoRoleForLoginError,
     UserNoWebMenuForLoginError,
-    UserMultiLoginConflictError,
+    UserPasswordExpireError,
+    UserPasswordMaxTryError,
+    UserValidateError,
 )
 from bisheng.common.schemas.api import UnifiedResponseModel, resp_200
 from bisheng.common.schemas.telemetry.event_data_schema import UserLoginEventData
 from bisheng.common.services import telemetry_service
 from bisheng.common.services.config_service import settings
-from bisheng.core.cache.redis_manager import get_redis_client_sync, get_redis_client
+from bisheng.core.cache.redis_manager import get_redis_client, get_redis_client_sync
 from bisheng.core.context.tenant import (
     DEFAULT_TENANT_ID,
     bypass_tenant_filter,
@@ -37,26 +37,27 @@ from bisheng.database.constants import AdminRole, DefaultRole
 from bisheng.database.models.department import DepartmentDao
 from bisheng.database.models.user_group import UserGroupDao
 from bisheng.permission.domain.services.legacy_rbac_sync_service import LegacyRBACSyncService
-from bisheng.user.domain.models.user import User, UserDao, UserLogin, UserRead, UserCreate
+from bisheng.user.domain.models.user import User, UserCreate, UserDao, UserLogin, UserRead
 from bisheng.user.domain.models.user_role import UserRoleDao
-from bisheng.utils import md5_hash, get_request_ip, generate_uuid
+from bisheng.utils import generate_uuid, get_request_ip, md5_hash
 from bisheng.utils.constants import RSA_KEY
-from .auth import LoginUser, AuthJwt, PORTAL_RUNTIME_TOKEN_PURPOSE
+
+from ..const import USER_CURRENT_SESSION, USER_PASSWORD_ERROR
+from .auth import PORTAL_RUNTIME_TOKEN_PURPOSE, AuthJwt, LoginUser
 from .captcha import verify_captcha
-from ..const import USER_PASSWORD_ERROR, USER_CURRENT_SESSION
 
 if TYPE_CHECKING:
     from bisheng.api.v1.schemas import CreateUserReq
 
 # Allowed avatar file types and their MIME types
 ALLOWED_AVATAR_TYPES = {
-    'image/jpeg': '.jpg',
-    'image/png': '.png',
-    'image/webp': '.webp',
-    'image/gif': '.gif',
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/webp": ".webp",
+    "image/gif": ".gif",
 }
 MAX_AVATAR_SIZE = 10 * 1024 * 1024  # 10MB
-AVATAR_OBJECT_PREFIX = 'avatar/'
+AVATAR_OBJECT_PREFIX = "avatar/"
 
 
 class UserService:
@@ -65,19 +66,39 @@ class UserService:
         """禁用账号后立刻让已签发的 JWT 失效（F012 ``token_version``），并清理管理端 scope 缓存。"""
         try:
             await UserDao.aincrement_token_version(user_id)
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             logger.warning(
-                'aincrement_token_version failed after account disabled user_id=%s: %s',
-                user_id, exc,
+                "aincrement_token_version failed after account disabled user_id=%s: %s",
+                user_id,
+                exc,
             )
             return
         try:
             from bisheng.admin.domain.services.tenant_scope import TenantScopeService
+
             await TenantScopeService.clear_on_token_version_bump(user_id)
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             logger.debug(
-                'clear_on_token_version_bump failed after account disabled user_id=%s: %s',
-                user_id, exc,
+                "clear_on_token_version_bump failed after account disabled user_id=%s: %s",
+                user_id,
+                exc,
+            )
+
+    @classmethod
+    async def on_account_disabled(cls, user_id: int) -> None:
+        """账号停用后结束该用户作为提问者的进行中转公开申请。"""
+        try:
+            from bisheng.qa_expert.domain.publish_service import PublishService
+
+            svc = PublishService()
+            rows = await svc.request_repo.list_pending_for_asker(int(user_id))
+            for row in rows:
+                await svc.on_asker_disabled(int(row.question_id))
+        except Exception as exc:
+            logger.warning(
+                "on_account_disabled qa publish hook failed user_id=%s: %s",
+                user_id,
+                exc,
             )
 
     @classmethod
@@ -86,11 +107,11 @@ class UserService:
             return avatar
 
         avatar = avatar.strip()
-        path = urlsplit(avatar).path if '://' in avatar or avatar.startswith('/') else avatar.split('?', 1)[0]
-        path = unquote(path).lstrip('/')
+        path = urlsplit(avatar).path if "://" in avatar or avatar.startswith("/") else avatar.split("?", 1)[0]
+        path = unquote(path).lstrip("/")
 
-        if bucket and path.startswith(f'{bucket}/'):
-            path = path[len(bucket) + 1:]
+        if bucket and path.startswith(f"{bucket}/"):
+            path = path[len(bucket) + 1 :]
 
         if path.startswith(AVATAR_OBJECT_PREFIX):
             return path
@@ -122,7 +143,7 @@ class UserService:
     async def build_user_read(cls, user: User, **kwargs) -> UserRead:
         user_data = user.model_dump()
         user_data.update(kwargs)
-        user_data['avatar'] = await cls.get_avatar_share_link(user_data.get('avatar'))
+        user_data["avatar"] = await cls.get_avatar_share_link(user_data.get("avatar"))
         return UserRead(**user_data)
 
     @classmethod
@@ -149,7 +170,7 @@ class UserService:
     def build_user_read_sync(cls, user: User, **kwargs) -> UserRead:
         user_data = user.model_dump()
         user_data.update(kwargs)
-        user_data['avatar'] = cls.get_avatar_share_link_sync(user_data.get('avatar'))
+        user_data["avatar"] = cls.get_avatar_share_link_sync(user_data.get("avatar"))
         return UserRead(**user_data)
 
     @classmethod
@@ -157,7 +178,7 @@ class UserService:
         """RSA 解密得到明文密码（未做 MD5）；无 RSA 配置时视为明文开发模式。"""
         if value := get_redis_client_sync().get(RSA_KEY):
             private_key = value[1]
-            return rsa.decrypt(b64decode(password), private_key).decode('utf-8')
+            return rsa.decrypt(b64decode(password), private_key).decode("utf-8")
         return password
 
     @classmethod
@@ -166,14 +187,14 @@ class UserService:
         return md5_hash(plain)
 
     @classmethod
-    def create_user(cls, request: Request, login_user: LoginUser, req_data: 'CreateUserReq'):
+    def create_user(cls, request: Request, login_user: LoginUser, req_data: "CreateUserReq"):
         """
         Create User
         """
         user = User(
             user_name=req_data.user_name,
             password=cls.decrypt_md5_password(req_data.password),
-            source='local',
+            source="local",
             # Default external_id to user_name so password login (which queries
             # external_id only since 94323e3ec) works out of the box. SSO-synced
             # users set their own external_id via org_sync, not through here.
@@ -235,17 +256,17 @@ class UserService:
     @classmethod
     async def user_register(cls, user: UserCreate):
         # Captcha Verification
-        if settings.get_from_db('use_captcha'):
+        if settings.get_from_db("use_captcha"):
             if not user.captcha_key or not await verify_captcha(user.captcha, user.captcha_key):
                 raise CaptchaError()
 
         db_user = User.model_validate(user)
         person_id = (db_user.external_id or "").strip()
         if not person_id:
-            raise UserValidateError(msg='Person ID is required')
+            raise UserValidateError(msg="Person ID is required")
         existing_pid = await UserDao.aget_by_external_id(person_id)
         if existing_pid:
-            raise UserValidateError(msg='Person ID already exists')
+            raise UserValidateError(msg="Person ID already exists")
         db_user.external_id = person_id
 
         # 允许用户名重复；人员唯一性由 external_id / user_id 等保证
@@ -287,16 +308,17 @@ class UserService:
     @classmethod
     async def _ensure_user_guest_department_membership(cls, user_id: int) -> None:
         """注册完成后自动加入“临时访客”部门（主部门）。"""
-        from bisheng.database.models.department import Department, UserDepartment
         from sqlmodel import select
 
-        guest_dept_id = 'BS@guest'
+        from bisheng.database.models.department import Department, UserDepartment
+
+        guest_dept_id = "BS@guest"
         async with get_async_db_session() as session:
             dept = (
                 await session.exec(
                     select(Department).where(
                         Department.dept_id == guest_dept_id,
-                        Department.status == 'active',
+                        Department.status == "active",
                     )
                 )
             ).first()
@@ -312,16 +334,19 @@ class UserService:
             ).first()
             if exists:
                 return
-            session.add(UserDepartment(
-                user_id=user_id,
-                department_id=dept.id,
-                is_primary=1,
-                source='local',
-            ))
+            session.add(
+                UserDepartment(
+                    user_id=user_id,
+                    department_id=dept.id,
+                    is_primary=1,
+                    source="local",
+                )
+            )
             await session.commit()
             from bisheng.department.domain.services.department_change_handler import (
                 DepartmentChangeHandler,
             )
+
             ops = DepartmentChangeHandler.on_members_added(dept.id, [user_id])
             await DepartmentChangeHandler.execute_async(ops)
 
@@ -330,14 +355,16 @@ class UserService:
         """Resolve the tenant_id used for anonymous self-registration."""
         from bisheng.database.models.tenant import TenantDao
 
-        code = (settings.multi_tenant.default_tenant_code or 'default').strip() or 'default'
+        code = (settings.multi_tenant.default_tenant_code or "default").strip() or "default"
         with bypass_tenant_filter():
             tenant = await TenantDao.aget_by_code(code)
         return int(tenant.id) if tenant else DEFAULT_TENANT_ID
 
     @classmethod
     async def _ensure_user_default_tenant_association(
-        cls, user_id: int, tenant_id: Optional[int] = None,
+        cls,
+        user_id: int,
+        tenant_id: int | None = None,
     ) -> int:
         """Ensure a user has a default tenant row and return its tenant_id."""
         from bisheng.database.models.tenant import UserTenantDao
@@ -345,7 +372,7 @@ class UserService:
         existing = await UserTenantDao.aget_user_tenants(user_id)
         if existing:
             for row in existing:
-                if getattr(row, 'is_default', 0) == 1:
+                if getattr(row, "is_default", 0) == 1:
                     return int(row.tenant_id)
             return int(existing[0].tenant_id)
         if tenant_id is None:
@@ -355,8 +382,9 @@ class UserService:
 
     @classmethod
     async def _reject_login_if_user_has_no_usable_access(
-        cls, db_user: User,
-    ) -> Optional[UnifiedResponseModel]:
+        cls,
+        db_user: User,
+    ) -> UnifiedResponseModel | None:
         """无角色且非部门/用户组管理员时拒绝登录；有角色但生效菜单既不包含工作台也不包含管理后台时拒绝登录。
 
         需审批模式下角色可仅勾选一级菜单（workstation/admin）而无二级项，仍视为有菜单权限，允许登录。
@@ -366,6 +394,7 @@ class UserService:
         # NoTenantContextError because do_orm_execute can't infer a tenant for
         # tenant-aware tables (userrole/department/usergroup/roleaccess).
         from bisheng.core.context.tenant import bypass_tenant_filter
+
         with bypass_tenant_filter():
             roles = await UserRoleDao.aget_user_roles(db_user.user_id)
             if not roles:
@@ -389,8 +418,8 @@ class UserService:
     async def has_other_active_session(cls, user_id: int, request_token: str = "") -> bool:
         try:
             login_method = await settings.aget_system_login_method()
-        except Exception as exc:  # noqa: BLE001
-            logger.debug('allow_multi_login lookup failed for user %s: %s', user_id, exc)
+        except Exception as exc:
+            logger.debug("allow_multi_login lookup failed for user %s: %s", user_id, exc)
             return False
         if login_method.allow_multi_login:
             return False
@@ -398,8 +427,8 @@ class UserService:
         try:
             redis_client = await get_redis_client()
             current_token = await redis_client.aget(USER_CURRENT_SESSION.format(user_id))
-        except Exception as exc:  # noqa: BLE001
-            logger.debug('current session lookup failed for user %s: %s', user_id, exc)
+        except Exception as exc:
+            logger.debug("current session lookup failed for user %s: %s", user_id, exc)
             return False
 
         if not current_token:
@@ -415,19 +444,19 @@ class UserService:
 
     @staticmethod
     def _extract_request_access_token(request: Request) -> str:
-        token = (request.cookies.get('access_token_cookie') or '').strip()
+        token = (request.cookies.get("access_token_cookie") or "").strip()
         if token:
             return token
-        auth = (request.headers.get('Authorization') or '').strip()
-        if auth.lower().startswith('bearer '):
+        auth = (request.headers.get("Authorization") or "").strip()
+        if auth.lower().startswith("bearer "):
             return auth[7:].strip()
-        return ''
+        return ""
 
     @classmethod
     async def user_login(cls, request: Request, user: UserLogin, auth_jwt: AuthJwt = Depends()):
         from bisheng.api.services.audit_log import AuditLogService
 
-        if await settings.aget_from_db('use_captcha'):
+        if await settings.aget_from_db("use_captcha"):
             if not user.captcha_key or not await verify_captcha(user.captcha, user.captcha_key):
                 raise CaptchaError()
 
@@ -482,9 +511,9 @@ class UserService:
         tenants_list = None
 
         if settings.multi_tenant.enabled:
-            from bisheng.database.models.tenant import UserTenantDao, TenantDao
             from bisheng.common.errcode.tenant import (
-                NoTenantsAvailableError, TenantDisabledError,
+                NoTenantsAvailableError,
+                TenantDisabledError,
             )
             from bisheng.core.context.tenant import DEFAULT_TENANT_ID, bypass_tenant_filter
 
@@ -496,8 +525,11 @@ class UserService:
             # of a disabled tenant would get fallback-routed to Root and log
             # in normally, which contradicts the operator's intent.
             from bisheng.database.models.department import (
-                DepartmentDao, UserDepartmentDao,
+                DepartmentDao,
+                UserDepartmentDao,
             )
+            from bisheng.database.models.tenant import TenantDao, UserTenantDao
+
             with bypass_tenant_filter():
                 primary_dept = await UserDepartmentDao.aget_user_primary_department(
                     db_user.user_id,
@@ -510,31 +542,31 @@ class UserService:
                         mount_tenant = await TenantDao.aget_by_id(
                             mount_dept.mounted_tenant_id,
                         )
-                        if mount_tenant is not None and mount_tenant.status == 'disabled':
+                        if mount_tenant is not None and mount_tenant.status == "disabled":
                             raise TenantDisabledError()
 
             user_tenants = await UserTenantDao.aget_user_tenants_with_details(db_user.user_id)
-            active_tenants = [t for t in user_tenants if t.get('status') == 'active']
+            active_tenants = [t for t in user_tenants if t.get("status") == "active"]
 
             if len(active_tenants) == 0:
                 # 注册/历史数据可能未写入 user_tenant；若默认租户存在则自动挂接，避免无法登录
-                code = (settings.multi_tenant.default_tenant_code or 'default').strip() or 'default'
+                code = (settings.multi_tenant.default_tenant_code or "default").strip() or "default"
                 with bypass_tenant_filter():
                     default_tenant = await TenantDao.aget_by_code(code)
                     if default_tenant is None:
                         default_tenant = await TenantDao.aget_by_id(DEFAULT_TENANT_ID)
-                if default_tenant and default_tenant.status == 'active':
+                if default_tenant and default_tenant.status == "active":
                     await UserTenantDao.aadd_user_to_tenant(
                         user_id=db_user.user_id,
                         tenant_id=default_tenant.id,
                         is_default=1,
                     )
                     user_tenants = await UserTenantDao.aget_user_tenants_with_details(db_user.user_id)
-                    active_tenants = [t for t in user_tenants if t.get('status') == 'active']
+                    active_tenants = [t for t in user_tenants if t.get("status") == "active"]
                 if len(active_tenants) == 0:
                     raise NoTenantsAvailableError()
             elif len(active_tenants) == 1:
-                tenant_id = active_tenants[0]['tenant_id']
+                tenant_id = active_tenants[0]["tenant_id"]
                 await UserTenantDao.aupdate_last_access_time(db_user.user_id, tenant_id)
             else:
                 # Multiple tenants: issue temporary JWT with tenant_id=0
@@ -553,18 +585,20 @@ class UserService:
             from bisheng.tenant.domain.services.user_tenant_sync_service import (
                 UserTenantSyncService,
             )
+
             leaf = await UserTenantSyncService.sync_user(
-                db_user.user_id, trigger=UserTenantSyncTrigger.LOGIN,
+                db_user.user_id,
+                trigger=UserTenantSyncTrigger.LOGIN,
             )
             # Override tenant_id for JWT payload — the resolver is the
             # authoritative source for leaf tenancy in v2.5.1.
-            if leaf is not None and getattr(leaf, 'id', None):
+            if leaf is not None and getattr(leaf, "id", None):
                 tenant_id = leaf.id
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             logger.warning(
-                'F012 login-time tenant sync failed for user %d: %s — '
-                'falling back to legacy tenant resolution',
-                db_user.user_id, exc,
+                "F012 login-time tenant sync failed for user %d: %s — falling back to legacy tenant resolution",
+                db_user.user_id,
+                exc,
             )
 
         # Block login when the resolved leaf tenant is disabled/archived.
@@ -573,24 +607,27 @@ class UserService:
         # immediately kicked out" instead of a clear error on the login form.
         # DB.status is authoritative; Redis blacklist is a defensive cross-check.
         if settings.multi_tenant.enabled and tenant_id and tenant_id > 0:
-            from bisheng.database.models.tenant import TenantDao
             from bisheng.common.errcode.tenant import TenantDisabledError
             from bisheng.core.context.tenant import bypass_tenant_filter
+            from bisheng.database.models.tenant import TenantDao
+
             with bypass_tenant_filter():
                 tenant_obj = await TenantDao.aget_by_id(tenant_id)
-            if not tenant_obj or tenant_obj.status != 'active':
+            if not tenant_obj or tenant_obj.status != "active":
                 raise TenantDisabledError()
             try:
                 from bisheng.tenant.domain.services.tenant_service import DISABLED_TENANT_KEY
+
                 redis_client = await get_redis_client()
                 if await redis_client.aget(DISABLED_TENANT_KEY.format(tenant_id)):
                     raise TenantDisabledError()
             except TenantDisabledError:
                 raise
-            except Exception as exc:  # noqa: BLE001
+            except Exception as exc:
                 logger.debug(
-                    'tenant blacklist check skipped for tenant %s: %s',
-                    tenant_id, exc,
+                    "tenant blacklist check skipped for tenant %s: %s",
+                    tenant_id,
+                    exc,
                 )
 
         # Fetch fresh token_version (sync_user may have just bumped it) and
@@ -598,14 +635,16 @@ class UserService:
         fresh_token_version = 0
         try:
             fresh_token_version = await UserDao.aget_token_version(db_user.user_id)
-        except Exception as exc:  # noqa: BLE001
-            logger.debug('aget_token_version failed for %d: %s', db_user.user_id, exc)
+        except Exception as exc:
+            logger.debug("aget_token_version failed for %d: %s", db_user.user_id, exc)
 
         # gen jwt token
         access_token = LoginUser.create_access_token(
-            user=db_user, auth_jwt=auth_jwt, tenant_id=tenant_id,
+            user=db_user,
+            auth_jwt=auth_jwt,
+            tenant_id=tenant_id,
             token_version=fresh_token_version,
-            token_purpose=PORTAL_RUNTIME_TOKEN_PURPOSE if is_portal_runtime_login else '',
+            token_purpose=PORTAL_RUNTIME_TOKEN_PURPOSE if is_portal_runtime_login else "",
         )
 
         # set cookies
@@ -614,17 +653,23 @@ class UserService:
         if not is_portal_runtime_login:
             # Set the logged in user's currentcookie, .jwtValid for an additional hour
             redis_client = await get_redis_client()
-            await redis_client.aset(USER_CURRENT_SESSION.format(db_user.user_id), access_token,
-                                    auth_jwt.cookie_conf.jwt_token_expire_time + 3600)
+            await redis_client.aset(
+                USER_CURRENT_SESSION.format(db_user.user_id),
+                access_token,
+                auth_jwt.cookie_conf.jwt_token_expire_time + 3600,
+            )
 
         # Log Audit Logs
         login_user = await LoginUser.init_login_user(db_user.user_id, db_user.user_name)
         AuditLogService.user_login(login_user, get_request_ip(request))
 
         # RecordTelemetryJournal
-        await telemetry_service.log_event(user_id=db_user.user_id, event_type=BaseTelemetryTypeEnum.USER_LOGIN,
-                                          trace_id=trace_id_var.get(),
-                                          event_data=UserLoginEventData(method="password"))
+        await telemetry_service.log_event(
+            user_id=db_user.user_id,
+            event_type=BaseTelemetryTypeEnum.USER_LOGIN,
+            trace_id=trace_id_var.get(),
+            event_data=UserLoginEventData(method="password"),
+        )
         try:
             from bisheng.telemetry.domain.mid_table.daily_participation import (
                 DailyParticipationFact,
@@ -646,41 +691,50 @@ class UserService:
         # frontend can render admin menus without a /user/info round-trip.
         entry = await LoginUser.user_entry_payload_for_read(db_user)
         extra_fields = {
-            'access_token': access_token,
-            'is_global_super': login_user.is_global_super,
+            "access_token": access_token,
+            "is_global_super": login_user.is_global_super,
             **entry,
         }
         if requires_tenant_selection:
-            extra_fields['requires_tenant_selection'] = True
-            extra_fields['tenants'] = tenants_list
+            extra_fields["requires_tenant_selection"] = True
+            extra_fields["tenants"] = tenants_list
         if tenant_id and tenant_id > 0:
-            extra_fields['tenant_id'] = tenant_id
-            tenant_info = next((t for t in (tenants_list or []) if t.get('tenant_id') == tenant_id), None)
+            extra_fields["tenant_id"] = tenant_id
+            tenant_info = next((t for t in (tenants_list or []) if t.get("tenant_id") == tenant_id), None)
             if not tenant_info and settings.multi_tenant.enabled:
-                from bisheng.database.models.tenant import TenantDao
                 from bisheng.core.context.tenant import bypass_tenant_filter
+                from bisheng.database.models.tenant import TenantDao
+
                 with bypass_tenant_filter():
                     t_obj = await TenantDao.aget_by_id(tenant_id)
                 if t_obj:
-                    extra_fields['tenant_name'] = t_obj.tenant_name
+                    extra_fields["tenant_name"] = t_obj.tenant_name
 
         return resp_200(await cls.build_user_read(db_user, **extra_fields))
 
     @classmethod
-    def get_user_all_info(cls, *, start_time: datetime = None, end_time: datetime = None, user_ids: List[int] = None,
-                          page: int = 1, page_size: int = 100) -> List[User]:
-        """ Get user information, including user group and role information """
-        return UserDao.get_user_with_group_role(page=page, page_size=page_size, user_ids=user_ids,
-                                                start_time=start_time, end_time=end_time)
+    def get_user_all_info(
+        cls,
+        *,
+        start_time: datetime = None,
+        end_time: datetime = None,
+        user_ids: list[int] = None,
+        page: int = 1,
+        page_size: int = 100,
+    ) -> list[User]:
+        """Get user information, including user group and role information"""
+        return UserDao.get_user_with_group_role(
+            page=page, page_size=page_size, user_ids=user_ids, start_time=start_time, end_time=end_time
+        )
 
     @classmethod
     def get_first_user(cls) -> User | None:
-        """ Get the first user """
+        """Get the first user"""
         return UserDao.get_first_user()
 
     @classmethod
     async def get_user_by_id(cls, user_id: int) -> User | None:
-        """ Get user by username """
+        """Get user by username"""
         return await UserDao.aget_user(user_id)
 
     @classmethod
@@ -693,22 +747,16 @@ class UserService:
         """
         # Validate file type
         if file.content_type not in ALLOWED_AVATAR_TYPES:
-            raise HTTPException(
-                status_code=400,
-                detail=f'Invalid file type. Allowed types: jpg, png, webp, gif'
-            )
+            raise HTTPException(status_code=400, detail="Invalid file type. Allowed types: jpg, png, webp, gif")
 
         # Read file content to check size
         content = await file.read()
         if len(content) > MAX_AVATAR_SIZE:
-            raise HTTPException(
-                status_code=400,
-                detail='File size exceeds limit. Maximum size: 10MB'
-            )
+            raise HTTPException(status_code=400, detail="File size exceeds limit. Maximum size: 10MB")
 
         # Generate object name for MinIO
         file_ext = ALLOWED_AVATAR_TYPES[file.content_type]
-        object_name = f'avatar/{user_id}/{generate_uuid()}{file_ext}'
+        object_name = f"avatar/{user_id}/{generate_uuid()}{file_ext}"
 
         # Upload to MinIO
         minio_client = await get_minio_storage()

--- a/src/backend/bisheng/worker/__init__.py
+++ b/src/backend/bisheng/worker/__init__.py
@@ -1,10 +1,10 @@
 # ruff: noqa: F401
 # register tasks
-from bisheng.worker.admin_scope.tasks import admin_scope_cleanup
 from bisheng.open_endpoints.worker.filelib_sync_worker import (
     fanout_automotive_sheet_intro_sync,
     run_automotive_sheet_intro_sync,
 )
+from bisheng.worker.admin_scope.tasks import admin_scope_cleanup
 from bisheng.worker.approval.notification_tasks import (
     consume_approval_notification,
     dispatch_approval_notifications,
@@ -24,16 +24,6 @@ from bisheng.worker.knowledge.file_migration import (
     preflight_knowledge_migration,
     reconcile_knowledge_migrations,
 )
-from bisheng.worker.knowledge.fulltext_index import (
-    consume_knowledge_fulltext_outbox,
-    dispatch_knowledge_fulltext_outbox,
-    repair_knowledge_fulltext_source,
-)
-from bisheng.worker.knowledge.fulltext_engagement import (
-    rebuild_knowledge_fulltext_engagement,
-    reconcile_knowledge_fulltext_engagement,
-    sync_knowledge_fulltext_engagement,
-)
 from bisheng.worker.knowledge.file_title_worker import (
     extract_knowledge_file_title_celery,
 )
@@ -42,6 +32,16 @@ from bisheng.worker.knowledge.file_worker import (
     parse_knowledge_file_celery,
     refresh_file_similarity_candidates_celery,
     retry_knowledge_file_celery,
+)
+from bisheng.worker.knowledge.fulltext_engagement import (
+    rebuild_knowledge_fulltext_engagement,
+    reconcile_knowledge_fulltext_engagement,
+    sync_knowledge_fulltext_engagement,
+)
+from bisheng.worker.knowledge.fulltext_index import (
+    consume_knowledge_fulltext_outbox,
+    dispatch_knowledge_fulltext_outbox,
+    repair_knowledge_fulltext_source,
 )
 from bisheng.worker.knowledge.pdf_artifact_worker import (
     generate_knowledge_file_pdf_celery,
@@ -93,6 +93,7 @@ from bisheng.worker.portal_course.tasks import (
     process_portal_course_media_cleanup,
     scan_portal_course_media_cleanup,
 )
+from bisheng.worker.qa_expert.tasks import expire_publish_requests
 from bisheng.worker.telemetry.derived_mid_table import (
     sync_mid_active_user,
     sync_mid_doc_parse_dtl,

--- a/src/backend/bisheng/worker/qa_expert/__init__.py
+++ b/src/backend/bisheng/worker/qa_expert/__init__.py
@@ -1,0 +1,1 @@
+"""qa_expert celery package."""

--- a/src/backend/bisheng/worker/qa_expert/tasks.py
+++ b/src/backend/bisheng/worker/qa_expert/tasks.py
@@ -1,0 +1,51 @@
+# ruff: noqa: RUF002
+"""专家问答 Celery 任务：转公开到期扫描。"""
+
+from __future__ import annotations
+
+import logging
+
+from bisheng.worker._asyncio_utils import run_async_task
+from bisheng.worker.main import bisheng_celery
+
+logger = logging.getLogger(__name__)
+
+EXPIRE_PUBLISH_TASK = "bisheng.worker.qa_expert.tasks.expire_publish_requests"
+EXPIRE_PUBLISH_INTERVAL_SECONDS = 60
+
+
+def register_qa_expert_beat_schedule() -> None:
+    """注册转公开过期 Beat。"""
+    schedule = dict(bisheng_celery.conf.beat_schedule or {})
+    schedule.setdefault(
+        "qa_expert_expire_publish_requests",
+        {
+            "task": EXPIRE_PUBLISH_TASK,
+            "schedule": EXPIRE_PUBLISH_INTERVAL_SECONDS,
+        },
+    )
+    bisheng_celery.conf.beat_schedule = schedule
+
+
+register_qa_expert_beat_schedule()
+
+
+@bisheng_celery.task(
+    acks_late=True,
+    time_limit=120,
+    soft_time_limit=90,
+    name=EXPIRE_PUBLISH_TASK,
+)
+def expire_publish_requests(tenant_id: int = 1) -> int:
+    """扫描 pending 且 expire_at<=now 的转公开申请。执行前恢复租户上下文。"""
+    return run_async_task(lambda: _expire_async(int(tenant_id)))
+
+
+async def _expire_async(tenant_id: int) -> int:
+    from bisheng.core.context.tenant import set_current_tenant_id
+    from bisheng.qa_expert.domain.publish_service import PublishService
+
+    set_current_tenant_id(tenant_id)
+    count = await PublishService().expire_pending(tenant_id=tenant_id)
+    logger.info("qa_expert.publish.expire tenant_id=%s count=%s", tenant_id, count)
+    return count

--- a/src/backend/test/approval/test_approval_gate.py
+++ b/src/backend/test/approval/test_approval_gate.py
@@ -503,9 +503,7 @@ async def test_gate_auto_approves_when_applicant_is_only_approver(
                 enabled=True,
             )
         ),
-        list_route_rules=AsyncMock(
-            return_value=[SimpleNamespace(id=31, route_type="flow", flow_definition_id=9)]
-        ),
+        list_route_rules=AsyncMock(return_value=[SimpleNamespace(id=31, route_type="flow", flow_definition_id=9)]),
         get_active_flow_version=AsyncMock(return_value=SimpleNamespace(id=21)),
         list_node_definitions=AsyncMock(return_value=[node]),
     )
@@ -513,9 +511,7 @@ async def test_gate_auto_approves_when_applicant_is_only_approver(
     instance_repository = SimpleNamespace(
         find_duplicate_active_instance=AsyncMock(return_value=None),
         create_instance=AsyncMock(side_effect=lambda row: row.model_copy(update={"id": 300})),
-        create_tasks=AsyncMock(
-            side_effect=lambda rows: [rows[0].model_copy(update={"id": 301})]
-        ),
+        create_tasks=AsyncMock(side_effect=lambda rows: [rows[0].model_copy(update={"id": 301})]),
         create_action_log=AsyncMock(),
         get_instance=AsyncMock(return_value=approved_instance),
     )
@@ -539,17 +535,14 @@ async def test_gate_auto_approves_when_applicant_is_only_approver(
         assert comment == SELF_APPROVAL_COMMENT
 
     monkeypatch.setattr(
-        "bisheng.approval.domain.services.approval_center_service."
-        "ApprovalCenterService.decide_task",
+        "bisheng.approval.domain.services.approval_center_service.ApprovalCenterService.decide_task",
         decide_self_task,
     )
     gate = ApprovalGate(
         registry=SimpleNamespace(get_handler=AsyncMock(return_value=handler)),
         scenario_repository=scenario_repository,
         instance_repository=instance_repository,
-        route_matcher=AsyncMock(
-            return_value=SimpleNamespace(id=31, route_type="flow", flow_definition_id=9)
-        ),
+        route_matcher=AsyncMock(return_value=SimpleNamespace(id=31, route_type="flow", flow_definition_id=9)),
     )
 
     result = await gate.request_or_pass(
@@ -1428,6 +1421,8 @@ def test_registry_exposes_default_presets():
         "knowledge_space_subscribe_request",
         "knowledge_space_create_request",
         "knowledge_space_file_publish_request",
+        "knowledge_space_file_share_request",
         "department_file_view_request",
+        "qa_question_publish",
     }
     assert presets["menu_access_request"].handler_key == "menu_access_request"

--- a/src/backend/test/qa_expert/conftest.py
+++ b/src/backend/test/qa_expert/conftest.py
@@ -1,0 +1,278 @@
+# ruff: noqa: RUF002
+"""qa_expert 流转夹具：真实 MySQL（config.yaml / 171），每次新连接。"""
+
+from __future__ import annotations
+
+import os
+import re
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+import yaml
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from bisheng.common.dependencies.user_deps import UserPayload
+from bisheng.common.errcode.base import BaseErrorCode
+from bisheng.core.context.tenant import set_current_tenant_id
+from bisheng.core.database.connection import _patch_aiomysql_pre_ping
+from bisheng.database.models.qa_expert import Expert
+from bisheng.qa_expert.api.router import router
+from bisheng.qa_expert.domain.publish_service import PublishService
+from bisheng.qa_expert.domain.services import AnswerService, CommentService, ExpertService, QuestionService
+
+FLOW_PREFIX = "df-flow-"
+_USER_ID_BASE = 88_000_000
+
+
+def _mysql_async_url() -> str:
+    """从 config.yaml 解密 database_url，转为 aiomysql；可用环境变量覆盖。不打印口令。"""
+    override = os.environ.get("QA_EXPERT_FLOW_DATABASE_URL")
+    if override:
+        return override.replace("pymysql", "aiomysql")
+    from bisheng.core.config.settings import decrypt_token
+
+    cfg_name = os.environ.get("config", "config.yaml")
+    cfg_path = Path(__file__).resolve().parents[2] / "bisheng" / Path(cfg_name).name
+    loaded = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    url = loaded["database_url"]
+    if not isinstance(url, str):
+        raise RuntimeError("config.yaml database_url 不是字符串")
+    match = re.search(r"(?<=:)[^:]+(?=@)", url)
+    if match:
+        url = re.sub(r"(?<=:)[^:]+(?=@)", decrypt_token(match.group(0)), url)
+    if "171" not in url and not os.environ.get("QA_EXPERT_FLOW_DATABASE_URL"):
+        # 本 Feature 验收库约定 171；覆盖 URL 时跳过该检查
+        raise RuntimeError("流转测试默认打 192.168.106.171，请确认 config.yaml 或设置 QA_EXPERT_FLOW_DATABASE_URL")
+    return url.replace("pymysql", "aiomysql")
+
+
+def make_user(
+    user_id: int,
+    *,
+    admin: bool = False,
+    super_admin: bool = False,
+    role: str | None = None,
+    name: str | None = None,
+):
+    """构造接口依赖用的登录身份（不写 user 表）。"""
+    return SimpleNamespace(
+        user_id=user_id,
+        user_name=name or f"u{user_id}",
+        tenant_id=1,
+        is_admin=lambda: admin,
+        role=role,
+        is_global_super=super_admin,
+    )
+
+
+def _flow_app(auth: dict):
+    """挂 qa_expert 路由；身份从 auth['user'] 读取。"""
+    app = FastAPI()
+
+    @app.exception_handler(BaseErrorCode)
+    async def _biz(_req, exc: BaseErrorCode):
+        return JSONResponse(
+            {"status_code": exc.code, "status_message": exc.message, "data": None},
+            status_code=200,
+        )
+
+    app.include_router(router, prefix="/api/v1")
+    app.dependency_overrides[UserPayload.get_login_user] = lambda: auth["user"]
+    return app
+
+
+async def _cleanup_prefix(engine, prefix: str) -> None:
+    """按标题/专家名前缀删除本夹具写入的 qa_* 行。"""
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        q_rows = (
+            await session.execute(text("SELECT id FROM qa_question WHERE title LIKE :p"), {"p": f"{prefix}%"})
+        ).fetchall()
+        qids = [int(row[0]) for row in q_rows]
+        if qids:
+            ids = ",".join(str(i) for i in qids)
+            for stmt in (
+                f"DELETE FROM qa_publish_approver WHERE request_id IN (SELECT id FROM qa_publish_request WHERE question_id IN ({ids}))",
+                f"DELETE FROM qa_publish_request WHERE question_id IN ({ids})",
+                f"DELETE FROM qa_answer_eligibility WHERE question_id IN ({ids})",
+                f"DELETE FROM qa_anonymous_alias WHERE question_id IN ({ids})",
+                f"DELETE FROM qa_answer_adopt WHERE question_id IN ({ids})",
+                f"DELETE FROM qa_comment WHERE question_id IN ({ids})",
+                f"DELETE FROM qa_answer WHERE question_id IN ({ids})",
+                f"DELETE FROM qa_question_invite WHERE question_id IN ({ids})",
+                f"DELETE FROM qa_question WHERE id IN ({ids})",
+            ):
+                await session.execute(text(stmt))
+        await session.execute(
+            text(
+                "DELETE FROM approval_action_log WHERE instance_id IN "
+                "(SELECT id FROM approval_instance WHERE scenario_code = 'qa_question_publish' AND business_name LIKE :p)"
+            ),
+            {"p": f"{prefix}%"},
+        )
+        await session.execute(
+            text(
+                "DELETE FROM approval_task WHERE instance_id IN "
+                "(SELECT id FROM approval_instance WHERE scenario_code = 'qa_question_publish' AND business_name LIKE :p)"
+            ),
+            {"p": f"{prefix}%"},
+        )
+        await session.execute(
+            text("DELETE FROM approval_instance WHERE scenario_code = 'qa_question_publish' AND business_name LIKE :p"),
+            {"p": f"{prefix}%"},
+        )
+        await session.execute(text("DELETE FROM qa_expert WHERE expert_name LIKE :p"), {"p": f"{prefix}%"})
+        await session.execute(
+            text(
+                "DELETE FROM inbox_message_read WHERE message_id IN "
+                "(SELECT id FROM (SELECT id FROM inbox_message WHERE CAST(content AS CHAR) LIKE :p) t)"
+            ),
+            {"p": f"%{prefix}%"},
+        )
+        await session.execute(
+            text("DELETE FROM inbox_message WHERE CAST(content AS CHAR) LIKE :p"),
+            {"p": f"%{prefix}%"},
+        )
+        await session.commit()
+
+
+def _flow_engine():
+    _patch_aiomysql_pre_ping()
+    return create_async_engine(
+        _mysql_async_url(),
+        pool_pre_ping=True,
+        pool_size=8,
+        max_overflow=4,
+        pool_recycle=3600,
+    )
+
+
+@pytest.fixture
+async def flow_env(monkeypatch):
+    """
+    真实 MySQL：每次仓储调用新 session，才能验 FOR UPDATE / 行锁。
+    通知/积分/遥测静音。数据前缀 df-flow-<uuid>- 。
+    """
+    set_current_tenant_id(1)
+    prefix = f"{FLOW_PREFIX}{uuid.uuid4().hex[:8]}-"
+    uid_start = _USER_ID_BASE + (uuid.uuid4().int % 40_000) * 20
+    uid_cursor = {"n": uid_start}
+    uid_map: dict[int, int] = {}
+
+    def next_uid() -> int:
+        uid_cursor["n"] += 1
+        return uid_cursor["n"]
+
+    def uid(logical: int) -> int:
+        if logical not in uid_map:
+            uid_map[logical] = next_uid()
+        return uid_map[logical]
+
+    engine = _flow_engine()
+    await _cleanup_prefix(engine, FLOW_PREFIX)
+    await _cleanup_prefix(engine, prefix)
+
+    @asynccontextmanager
+    async def patched_session():
+        session = AsyncSession(bind=engine, expire_on_commit=False)
+        try:
+            yield session
+        finally:
+            await session.close()
+
+    monkeypatch.setattr("bisheng.qa_expert.domain.repositories.get_async_db_session", patched_session)
+    monkeypatch.setattr("bisheng.qa_expert.domain.services.get_async_db_session", patched_session)
+    monkeypatch.setattr("bisheng.core.database.get_async_db_session", patched_session)
+    monkeypatch.setattr("bisheng.core.database.manager.get_async_db_session", patched_session)
+    monkeypatch.setattr(
+        "bisheng.approval.domain.repositories.approval_instance_repository.get_async_db_session",
+        patched_session,
+    )
+    monkeypatch.setattr(
+        "bisheng.approval.domain.repositories.approval_scenario_repository.get_async_db_session",
+        patched_session,
+    )
+    monkeypatch.setattr(QuestionService, "_send_expert_invitation_inbox_notice", AsyncMock())
+    monkeypatch.setattr(QuestionService, "_send_adoption_notification", AsyncMock())
+    monkeypatch.setattr(AnswerService, "_send_answer_notification", AsyncMock())
+    monkeypatch.setattr(CommentService, "_send_comment_notification", AsyncMock())
+    monkeypatch.setattr(PublishService, "_notify", AsyncMock())
+    monkeypatch.setattr("bisheng.qa_expert.domain.services.RealtimeQaQuestionFact.record_success", AsyncMock())
+    monkeypatch.setattr("bisheng.qa_expert.api.endpoints.check_question_content", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "bisheng.points.domain.services.points_award_hooks.notify_answer_adopted",
+        AsyncMock(),
+    )
+
+    async def _related_access(_user, _space_id, _file_id):
+        return False
+
+    monkeypatch.setattr(
+        "bisheng.qa_expert.domain.related_docs_access.check_related_doc_access",
+        _related_access,
+    )
+
+    def mapped_user(logical_id: int, **kwargs):
+        real_id = logical_id if logical_id >= _USER_ID_BASE else uid(logical_id)
+        return make_user(real_id, **kwargs)
+
+    asker = mapped_user(101, name="asker")
+    auth = {"user": asker}
+    app = _flow_app(auth)
+    client = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+    async def seed_expert(*, user_id: int, name: str, status: int = 1) -> Expert:
+        repo = ExpertService().repository
+        return await repo.create(
+            Expert(user_id=uid(user_id), expert_name=f"{prefix}{name}", status=status, tenant_id=1)
+        )
+
+    async def reload_row(model, **eq):
+        table = model.__table__
+        stmt = select(table)
+        for key, value in eq.items():
+            stmt = stmt.where(table.c[key] == value)
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            mapping = (await session.execute(stmt)).mappings().first()
+            return SimpleNamespace(**dict(mapping)) if mapping else None
+
+    async def reload_all(model, **eq):
+        table = model.__table__
+        stmt = select(table)
+        for key, value in eq.items():
+            stmt = stmt.where(table.c[key] == value)
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            mappings = (await session.execute(stmt)).mappings().all()
+            return [SimpleNamespace(**dict(item)) for item in mappings]
+
+    env = SimpleNamespace(
+        client=client,
+        engine=engine,
+        prefix=prefix,
+        uid=uid,
+        auth=auth,
+        as_user=lambda user: auth.__setitem__("user", user),
+        user=mapped_user,
+        seed_expert=seed_expert,
+        reload_row=reload_row,
+        reload_all=reload_all,
+        asker=asker,
+        stranger=mapped_user(301, name="stranger"),
+        portal_admin=mapped_user(401, name="portal-admin", admin=True, role="管理员"),
+        t=lambda title: title if title.startswith(prefix) else prefix + title,
+    )
+    try:
+        yield env
+    finally:
+        await client.aclose()
+        await _cleanup_prefix(engine, prefix)
+        await engine.dispose()

--- a/src/backend/test/qa_expert/test_adopt.py
+++ b/src/backend/test/qa_expert/test_adopt.py
@@ -1,0 +1,236 @@
+# ruff: noqa: RUF002
+"""T012：采纳槽位、首次已解决、公开题资格快照（仓储全 mock）。"""
+
+import inspect
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bisheng.common.errcode.qa_expert import QaExpertAdoptLimitError, QaExpertAnswerNotAllowedError
+from bisheng.database.models.qa_expert import Answer, AnswerAdopt, AnswerEligibility, Question
+from bisheng.qa_expert.domain.capability import DISPLAY_SOLVED
+from bisheng.qa_expert.domain.schemas import AnswerCreateRequest
+from bisheng.qa_expert.domain.services import (
+    MAX_ADOPTED_ANSWERS_PER_QUESTION,
+    AnswerService,
+    QuestionService,
+)
+
+
+def _question(**kwargs) -> SimpleNamespace:
+    data = {
+        "id": 100,
+        "user_id": 1,
+        "title": "炼钢",
+        "question_type": "public",
+        "adopt_count": 0,
+        "answer_count": 2,
+        "status": 0,
+        "resolved_at": None,
+        "adopted_answer_id": None,
+        "tenant_id": 1,
+        "display_status": None,
+    }
+    data.update(kwargs)
+    return SimpleNamespace(**data)
+
+
+def _answer(**kwargs) -> SimpleNamespace:
+    data = {
+        "id": 11,
+        "question_id": 100,
+        "expert_id": 5,
+        "user_id": 55,
+        "adopted": False,
+        "status": 1,
+    }
+    data.update(kwargs)
+    return SimpleNamespace(**data)
+
+
+def _service() -> QuestionService:
+    svc = QuestionService()
+    svc.repository = MagicMock()
+    svc.answer_repo = MagicMock()
+    svc.expert_repo = MagicMock()
+    svc.invite_repo = MagicMock()
+    svc.adopt_repo = MagicMock()
+    svc.eligibility_repo = MagicMock()
+    svc.adopt_repo.create = AsyncMock()
+    svc.eligibility_repo.create_many = AsyncMock()
+    svc.invite_repo.list_user_ids_by_question_ids = AsyncMock(return_value={})
+    svc.answer_repo.list_all_by_question_id = AsyncMock(return_value=[])
+    svc.answer_repo.update = AsyncMock()
+    svc.repository.update = AsyncMock()
+    svc.expert_repo.increment_adoption_count = AsyncMock()
+    svc.expert_repo.get_by_id = AsyncMock(return_value=SimpleNamespace(id=5, user_id=55))
+    svc._send_adoption_notification = AsyncMock()
+
+    async def fake_apply(question_id: int, **kwargs):
+        q = await svc.repository.get_by_id_for_update(question_id)
+        current = int(getattr(q, "adopt_count", 0) or 0)
+        is_first = current == 0
+        q.adopt_count = current + 1
+        q.status = 1
+        q.adopted_answer_id = kwargs["answer_id"]
+        if is_first:
+            q.resolved_at = datetime.utcnow()
+        await svc.adopt_repo.create(
+            AnswerAdopt(
+                tenant_id=kwargs.get("tenant_id") or 1,
+                question_id=question_id,
+                answer_id=kwargs["answer_id"],
+                expert_user_id=kwargs["expert_user_id"],
+                adopted_by=kwargs["adopted_by"],
+            )
+        )
+        await svc.repository.update(
+            question_id,
+            adopted_answer_id=q.adopted_answer_id,
+            status=1,
+            adopt_count=q.adopt_count,
+            resolved_at=q.resolved_at,
+        )
+        await svc.answer_repo.update(kwargs["answer_id"], status=1, adopted=True)
+        return SimpleNamespace(question=q, status="ok", is_first=is_first)
+
+    svc.repository.apply_adopt_count_locked = AsyncMock(side_effect=fake_apply)
+    return svc
+
+
+async def test_first_adopt_marks_resolved_and_writes_slot():
+    svc = _service()
+    question = _question()
+    svc.repository.get_by_id_for_update = AsyncMock(return_value=question)
+    svc.answer_repo.get_by_id = AsyncMock(return_value=_answer())
+    with patch(
+        "bisheng.points.domain.services.points_award_hooks.notify_answer_adopted",
+        new_callable=AsyncMock,
+    ) as notify:
+        result = await svc.adopt_answer(100, 11, operator_id=1)
+    assert result.adopt_count == 1
+    assert result.status == 1
+    assert result.resolved_at is not None
+    assert result.display_status == DISPLAY_SOLVED
+    slot: AnswerAdopt = svc.adopt_repo.create.await_args.args[0]
+    assert slot.answer_id == 11
+    assert slot.question_id == 100
+    assert slot.expert_user_id == 55
+    assert slot.adopted_by == 1
+    notify.assert_awaited_once()
+    source = inspect.getsource(QuestionService.adopt_answer)
+    assert "user_point_log" not in source
+    assert "notify_answer_adopted" in source
+
+
+async def test_fourth_adopt_raises_18304():
+    svc = _service()
+    svc.repository.get_by_id_for_update = AsyncMock(
+        return_value=_question(adopt_count=MAX_ADOPTED_ANSWERS_PER_QUESTION)
+    )
+    svc.answer_repo.get_by_id = AsyncMock(return_value=_answer(id=14))
+    with pytest.raises(QaExpertAdoptLimitError) as exc:
+        await svc.adopt_answer(100, 14, operator_id=1)
+    assert exc.value.Code == 18304
+    svc.adopt_repo.create.assert_not_awaited()
+    svc.repository.update.assert_not_awaited()
+
+
+async def test_same_expert_multiple_answers_fill_multiple_slots():
+    svc = _service()
+    question = _question(adopt_count=0)
+    svc.repository.get_by_id_for_update = AsyncMock(return_value=question)
+    with patch(
+        "bisheng.points.domain.services.points_award_hooks.notify_answer_adopted",
+        new_callable=AsyncMock,
+    ) as notify:
+        svc.answer_repo.get_by_id = AsyncMock(return_value=_answer(id=11, expert_id=5, user_id=55))
+        await svc.adopt_answer(100, 11, operator_id=1)
+        svc.answer_repo.get_by_id = AsyncMock(return_value=_answer(id=12, expert_id=5, user_id=55))
+        await svc.adopt_answer(100, 12, operator_id=1)
+    answer_ids = [call.args[0].answer_id for call in svc.adopt_repo.create.await_args_list]
+    assert answer_ids == [11, 12]
+    assert [call.args[0].expert_user_id for call in svc.adopt_repo.create.await_args_list] == [55, 55]
+    assert notify.await_count == 2
+    assert question.adopt_count == 2
+
+
+async def test_public_first_adopt_writes_eligibility_including_deleted_author():
+    svc = _service()
+    question = _question(question_type="public", adopt_count=0)
+    svc.repository.get_by_id_for_update = AsyncMock(return_value=question)
+    svc.answer_repo.get_by_id = AsyncMock(return_value=_answer(id=11, user_id=55))
+    svc.invite_repo.list_user_ids_by_question_ids = AsyncMock(return_value={100: {70}})
+    svc.answer_repo.list_all_by_question_id = AsyncMock(
+        return_value=[
+            _answer(id=11, user_id=55, status=1),
+            _answer(id=99, user_id=80, expert_id=9, status=3, adopted=False),
+        ]
+    )
+    with patch(
+        "bisheng.points.domain.services.points_award_hooks.notify_answer_adopted",
+        new_callable=AsyncMock,
+    ):
+        await svc.adopt_answer(100, 11, operator_id=1)
+    rows: list[AnswerEligibility] = svc.eligibility_repo.create_many.await_args.args[0]
+    by_user = {int(row.user_id): row.source for row in rows}
+    assert by_user[70] == "invited"
+    assert by_user[55] == "pre_adopt_answer"
+    assert by_user[80] == "pre_adopt_answer"
+
+
+async def test_directed_first_adopt_skips_eligibility():
+    svc = _service()
+    question = _question(question_type="directed", adopt_count=0)
+    svc.repository.get_by_id_for_update = AsyncMock(return_value=question)
+    svc.answer_repo.get_by_id = AsyncMock(return_value=_answer())
+    with patch(
+        "bisheng.points.domain.services.points_award_hooks.notify_answer_adopted",
+        new_callable=AsyncMock,
+    ):
+        await svc.adopt_answer(100, 11, operator_id=1)
+    svc.eligibility_repo.create_many.assert_not_awaited()
+
+
+async def test_public_after_adopt_only_snapshot_experts_can_answer():
+    svc = AnswerService()
+    svc.repository = MagicMock()
+    svc.question_repo = MagicMock()
+    svc.expert_repo = MagicMock()
+    svc.invite_repo = MagicMock()
+    svc.eligibility_repo = MagicMock()
+    svc.question_repo.try_lock_content = AsyncMock(return_value=False)
+    svc.question_repo.update = AsyncMock()
+    svc.question_repo.increment_answer_count = AsyncMock()
+    svc.invite_repo.list_user_ids_by_question_ids = AsyncMock(return_value={})
+    svc.eligibility_repo.list_user_ids = AsyncMock(return_value={55})
+    svc.expert_repo.increment_answer_count = AsyncMock()
+    svc._send_answer_notification = AsyncMock()
+    svc._resolve_answer = AsyncMock(side_effect=lambda answer: answer)
+    question = Question(
+        id=100,
+        user_id=1,
+        title="t",
+        description="d",
+        business_domain="steel",
+        question_type="public",
+        adopt_count=1,
+        answer_count=1,
+    )
+    svc.question_repo.get_by_id = AsyncMock(return_value=question)
+    outsider = SimpleNamespace(id=9, user_id=99, status=1, expert_name="外人")
+    insider = SimpleNamespace(id=5, user_id=55, status=1, expert_name="快照内")
+    svc.expert_repo.get_by_user_id = AsyncMock(return_value=outsider)
+    with pytest.raises(QaExpertAnswerNotAllowedError):
+        await svc.create_answer(99, AnswerCreateRequest(question_id=100, content="不可答"), tenant_id=1)
+    svc.expert_repo.get_by_user_id = AsyncMock(return_value=insider)
+
+    async def fake_create(answer: Answer) -> Answer:
+        answer.id = 30
+        return answer
+
+    svc.repository.create = AsyncMock(side_effect=fake_create)
+    allowed = await svc.create_answer(55, AnswerCreateRequest(question_id=100, content="可答"), tenant_id=1)
+    assert allowed.id == 30

--- a/src/backend/test/qa_expert/test_adopt_answer_limit.py
+++ b/src/backend/test/qa_expert/test_adopt_answer_limit.py
@@ -1,23 +1,31 @@
+# ruff: noqa: RUF002
 """同题最多 3 个最佳答案：上限拦截、已采纳幂等、软删不计上限。"""
 
+from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from bisheng.qa_expert.domain.services import (
-    AdoptLimitExceededError,
     MAX_ADOPTED_ANSWERS_PER_QUESTION,
+    AdoptLimitExceededError,
     QuestionService,
 )
 
 
-def _question(*, question_id: int = 100, user_id: int = 1) -> SimpleNamespace:
+def _question(*, question_id: int = 100, user_id: int = 1, adopt_count: int = 0) -> SimpleNamespace:
     return SimpleNamespace(
         id=question_id,
         user_id=user_id,
         adopted_answer_id=None,
         status=0,
+        adopt_count=adopt_count,
+        answer_count=1,
+        question_type="public",
+        resolved_at=None,
+        tenant_id=1,
+        display_status=None,
     )
 
 
@@ -33,6 +41,7 @@ def _answer(
         id=answer_id,
         question_id=question_id,
         expert_id=expert_id,
+        user_id=55,
         adopted=adopted,
         status=status,
     )
@@ -43,7 +52,36 @@ def _service() -> QuestionService:
     svc.repository = MagicMock()
     svc.answer_repo = MagicMock()
     svc.expert_repo = MagicMock()
+    svc.invite_repo = MagicMock()
+    svc.adopt_repo = MagicMock()
+    svc.eligibility_repo = MagicMock()
+    svc.adopt_repo.create = AsyncMock()
+    svc.eligibility_repo.create_many = AsyncMock()
+    svc.invite_repo.list_user_ids_by_question_ids = AsyncMock(return_value={})
+    svc.answer_repo.list_all_by_question_id = AsyncMock(return_value=[])
+    svc.answer_repo.update = AsyncMock()
     svc._send_adoption_notification = AsyncMock()
+
+    async def fake_apply(question_id: int, **kwargs):
+        q = await svc.repository.get_by_id_for_update(question_id)
+        current = int(getattr(q, "adopt_count", 0) or 0)
+        is_first = current == 0
+        q.adopt_count = current + 1
+        q.status = 1
+        q.adopted_answer_id = kwargs["answer_id"]
+        if is_first:
+            q.resolved_at = datetime.utcnow()
+        await svc.repository.update(
+            question_id,
+            adopted_answer_id=q.adopted_answer_id,
+            status=1,
+            adopt_count=q.adopt_count,
+            resolved_at=q.resolved_at,
+        )
+        await svc.answer_repo.update(kwargs["answer_id"], status=1, adopted=True)
+        return SimpleNamespace(question=q, status="ok", is_first=is_first)
+
+    svc.repository.apply_adopt_count_locked = AsyncMock(side_effect=fake_apply)
     return svc
 
 
@@ -51,7 +89,7 @@ def _service() -> QuestionService:
 async def test_adopt_first_three_succeeds():
     svc = _service()
     q = _question()
-    svc.repository.get_by_id = AsyncMock(return_value=q)
+    svc.repository.get_by_id_for_update = AsyncMock(return_value=q)
     svc.repository.update = AsyncMock(return_value=q)
     svc.answer_repo.update = AsyncMock()
     svc.expert_repo.increment_adoption_count = AsyncMock()
@@ -61,11 +99,8 @@ async def test_adopt_first_three_succeeds():
         "bisheng.points.domain.services.points_award_hooks.notify_answer_adopted",
         new_callable=AsyncMock,
     ) as notify:
-        for idx, answer_id in enumerate((11, 12, 13), start=0):
-            svc.answer_repo.get_by_id = AsyncMock(
-                return_value=_answer(answer_id=answer_id, adopted=False)
-            )
-            svc.answer_repo.count_adopted_by_question_id = AsyncMock(return_value=idx)
+        for answer_id in (11, 12, 13):
+            svc.answer_repo.get_by_id = AsyncMock(return_value=_answer(answer_id=answer_id, adopted=False))
             result = await svc.adopt_answer(100, answer_id, operator_id=1)
             assert result is q
 
@@ -76,11 +111,10 @@ async def test_adopt_first_three_succeeds():
 @pytest.mark.asyncio
 async def test_adopt_fourth_raises_limit():
     svc = _service()
-    svc.repository.get_by_id = AsyncMock(return_value=_question())
-    svc.answer_repo.get_by_id = AsyncMock(return_value=_answer(answer_id=14, adopted=False))
-    svc.answer_repo.count_adopted_by_question_id = AsyncMock(
-        return_value=MAX_ADOPTED_ANSWERS_PER_QUESTION
+    svc.repository.get_by_id_for_update = AsyncMock(
+        return_value=_question(adopt_count=MAX_ADOPTED_ANSWERS_PER_QUESTION)
     )
+    svc.answer_repo.get_by_id = AsyncMock(return_value=_answer(answer_id=14, adopted=False))
     svc.repository.update = AsyncMock()
     svc.answer_repo.update = AsyncMock()
     svc.expert_repo.increment_adoption_count = AsyncMock()
@@ -96,10 +130,8 @@ async def test_adopt_fourth_raises_limit():
 async def test_already_adopted_is_idempotent():
     svc = _service()
     q = _question(question_id=100)
-    svc.repository.get_by_id = AsyncMock(return_value=q)
-    svc.answer_repo.get_by_id = AsyncMock(
-        return_value=_answer(answer_id=11, adopted=True, status=1)
-    )
+    svc.repository.get_by_id_for_update = AsyncMock(return_value=q)
+    svc.answer_repo.get_by_id = AsyncMock(return_value=_answer(answer_id=11, adopted=True, status=1))
     svc.answer_repo.count_adopted_by_question_id = AsyncMock()
     svc.repository.update = AsyncMock()
     svc.answer_repo.update = AsyncMock()
@@ -122,12 +154,10 @@ async def test_already_adopted_is_idempotent():
 async def test_soft_deleted_adopted_not_counted_in_limit_path():
     """软删回答不计上限：count 由仓储过滤；此处验证 count=2 时仍可采纳第 3 条。"""
     svc = _service()
-    q = _question()
-    svc.repository.get_by_id = AsyncMock(return_value=q)
+    q = _question(adopt_count=2)
+    svc.repository.get_by_id_for_update = AsyncMock(return_value=q)
     svc.repository.update = AsyncMock(return_value=q)
     svc.answer_repo.get_by_id = AsyncMock(return_value=_answer(answer_id=20, adopted=False))
-    # 仓储已排除 status=3，故返回 2（含 1 条软删场景下真实未删除已采纳数）
-    svc.answer_repo.count_adopted_by_question_id = AsyncMock(return_value=2)
     svc.answer_repo.update = AsyncMock()
     svc.expert_repo.increment_adoption_count = AsyncMock()
     svc.expert_repo.get_by_id = AsyncMock(return_value=SimpleNamespace(id=5, user_id=55))

--- a/src/backend/test/qa_expert/test_anonymous_alias.py
+++ b/src/backend/test/qa_expert/test_anonymous_alias.py
@@ -1,0 +1,175 @@
+# ruff: noqa: RUF002
+"""T014：匿名别名时间序、删内容不重排、管理员破匿名、转公开用预存 reveal。"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from bisheng.database.models.qa_expert import AnonymousAlias
+from bisheng.qa_expert.domain.identity import (
+    IdentityService,
+    alias_label_for_ord,
+    persist_anonymous_choice,
+    should_reveal_name,
+)
+
+
+def _viewer(*, user_id: int = 9, admin: bool = False, role: str | None = None) -> SimpleNamespace:
+    return SimpleNamespace(
+        user_id=user_id,
+        user_name=f"u{user_id}",
+        is_admin=lambda: admin,
+        role=role,
+        is_global_super=False,
+    )
+
+
+def _service() -> IdentityService:
+    svc = IdentityService()
+    svc.alias_repo = MagicMock()
+    svc.alias_repo.get_by_question_user = AsyncMock(return_value=None)
+    svc.alias_repo.next_alias_ord = AsyncMock(return_value=1)
+    svc.alias_repo.create = AsyncMock(side_effect=lambda row: row)
+    svc.alias_repo.list_by_question_ids = AsyncMock(return_value=[])
+    return svc
+
+
+async def test_alias_assigned_in_time_order_a_then_b():
+    svc = _service()
+    first = await svc.get_or_assign_alias(question_id=10, user_id=2, tenant_id=1)
+    assert first.alias_ord == 1
+    assert first.alias_label == "匿名同事A"
+
+    svc.alias_repo.get_by_question_user = AsyncMock(return_value=None)
+    svc.alias_repo.next_alias_ord = AsyncMock(return_value=2)
+    second = await svc.get_or_assign_alias(question_id=10, user_id=3, tenant_id=1)
+    assert second.alias_ord == 2
+    assert second.alias_label == "匿名同事B"
+    assert alias_label_for_ord(27).endswith("AA")
+
+
+async def test_deleted_content_does_not_reuse_alias_ord():
+    svc = _service()
+    existing = AnonymousAlias(
+        id=1,
+        question_id=10,
+        user_id=2,
+        alias_ord=1,
+        alias_label="匿名同事A",
+        tenant_id=1,
+    )
+    svc.alias_repo.get_by_question_user = AsyncMock(return_value=existing)
+    again = await svc.get_or_assign_alias(question_id=10, user_id=2)
+    assert again.alias_ord == 1
+    assert again.alias_label == "匿名同事A"
+    svc.alias_repo.next_alias_ord.assert_not_awaited()
+    svc.alias_repo.create.assert_not_awaited()
+
+    svc.alias_repo.get_by_question_user = AsyncMock(return_value=None)
+    svc.alias_repo.next_alias_ord = AsyncMock(return_value=3)
+    later = await svc.get_or_assign_alias(question_id=10, user_id=8)
+    assert later.alias_ord == 3
+    assert later.alias_label == "匿名同事C"
+
+
+async def test_non_admin_response_has_no_real_name_fields():
+    svc = _service()
+    svc.alias_repo.get_by_question_user = AsyncMock(return_value=None)
+    svc.alias_repo.next_alias_ord = AsyncMock(return_value=1)
+    view = await svc.mask_identity(
+        _viewer(admin=False),
+        question_id=10,
+        user_id=2,
+        real_name="张三",
+        anonymous=True,
+        question_type="directed",
+        reveal_on_public=0,
+    )
+    payload = view.to_dict(can_view_real_identity=False)
+    assert payload["display_name"] == "匿名同事A"
+    assert payload["anonymous"] is True
+    assert "real_name" not in payload
+    assert "real_user_id" not in payload
+    assert view.real_name is None
+    assert view.real_user_id is None
+
+
+async def test_expert_library_admin_can_read_real_name():
+    svc = _service()
+    svc.alias_repo.get_by_question_user = AsyncMock(
+        return_value=AnonymousAlias(
+            question_id=10,
+            user_id=2,
+            alias_ord=1,
+            alias_label="匿名同事A",
+            tenant_id=1,
+        )
+    )
+    view = await svc.mask_identity(
+        _viewer(admin=False, role="管理员"),
+        question_id=10,
+        user_id=2,
+        real_name="张三",
+        anonymous=True,
+        question_type="directed",
+        reveal_on_public=0,
+    )
+    payload = view.to_dict(can_view_real_identity=True)
+    assert payload["display_name"] == "匿名同事A"
+    assert payload["real_name"] == "张三"
+    assert payload["real_user_id"] == 2
+
+
+def test_publish_uses_stored_reveal_without_asking_again():
+    assert should_reveal_name(anonymous=True, question_type="public", reveal_on_public=1) is True
+    assert should_reveal_name(anonymous=True, question_type="public", reveal_on_public=0) is False
+    assert should_reveal_name(anonymous=True, question_type="directed", reveal_on_public=1) is False
+    assert should_reveal_name(anonymous=False, question_type="public", reveal_on_public=0) is True
+
+
+async def test_after_publish_revealed_name_uses_preset():
+    svc = _service()
+    view = await svc.mask_identity(
+        _viewer(),
+        question_id=10,
+        user_id=2,
+        real_name="张三",
+        anonymous=True,
+        question_type="public",
+        reveal_on_public=1,
+    )
+    assert view.display_name == "张三"
+    assert view.anonymous is False
+    svc.alias_repo.create.assert_not_awaited()
+
+
+def test_persist_anonymous_choice_requires_reveal_when_directed():
+    import pytest
+
+    from bisheng.common.errcode.qa_expert import QaExpertAnonymousRevealRequiredError
+
+    assert persist_anonymous_choice(anonymous=False, reveal_on_public=True, question_type="directed") == (0, None)
+    assert persist_anonymous_choice(anonymous=True, reveal_on_public=None, question_type="public") == (1, None)
+    assert persist_anonymous_choice(anonymous=True, reveal_on_public=False, question_type="directed") == (1, 0)
+    with pytest.raises(QaExpertAnonymousRevealRequiredError):
+        persist_anonymous_choice(anonymous=True, reveal_on_public=None, question_type="directed")
+
+
+async def test_preload_reuses_aliases_without_per_user_lookup():
+    """列表预加载后，同页 mask 不得再按人 get_by_question_user。"""
+    existing = AnonymousAlias(
+        id=1,
+        question_id=10,
+        user_id=2,
+        alias_ord=1,
+        alias_label="匿名同事A",
+        tenant_id=1,
+    )
+    svc = _service()
+    svc.alias_repo.list_by_question_ids = AsyncMock(return_value=[existing])
+    await svc.preload_for_questions([10])
+    again = await svc.get_or_assign_alias(question_id=10, user_id=2)
+    assert again.alias_label == "匿名同事A"
+    svc.alias_repo.get_by_question_user.assert_not_awaited()
+    svc.alias_repo.next_alias_ord.assert_not_awaited()
+    svc.alias_repo.create.assert_not_awaited()
+    svc.alias_repo.list_by_question_ids.assert_awaited_once()

--- a/src/backend/test/qa_expert/test_answer_comment_api.py
+++ b/src/backend/test/qa_expert/test_answer_comment_api.py
@@ -1,0 +1,74 @@
+# ruff: noqa: RUF002
+"""T025：回答/采纳/评论 API。"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from bisheng.common.dependencies.user_deps import UserPayload
+from bisheng.common.errcode.base import BaseErrorCode
+from bisheng.common.errcode.qa_expert import QaExpertAdoptLimitError, QaExpertCommentNotAllowedError
+from bisheng.qa_expert.api import endpoints
+from bisheng.qa_expert.api.router import router
+
+
+def _user():
+    return SimpleNamespace(
+        user_id=8,
+        user_name="expert",
+        tenant_id=1,
+        is_admin=lambda: False,
+        role=None,
+        is_global_super=False,
+    )
+
+
+def _app(*, answer=None, question=None, comment=None):
+    app = FastAPI()
+
+    @app.exception_handler(BaseErrorCode)
+    async def _biz(_req, exc: BaseErrorCode):
+        from fastapi.responses import JSONResponse
+
+        return JSONResponse({"status_code": exc.code, "status_message": exc.message, "data": None})
+
+    app.include_router(router, prefix="/api/v1")
+    app.dependency_overrides[UserPayload.get_login_user] = _user
+    if answer is not None:
+        app.dependency_overrides[endpoints.get_answer_service] = lambda: answer
+    if question is not None:
+        app.dependency_overrides[endpoints.get_question_service] = lambda: question
+    if comment is not None:
+        app.dependency_overrides[endpoints.get_comment_service] = lambda: comment
+    return app
+
+
+def test_create_answer_and_adopt():
+    answer_svc = SimpleNamespace(create_answer=AsyncMock(return_value={"id": 2, "question_id": 1}))
+    question_svc = SimpleNamespace(
+        adopt_answer=AsyncMock(return_value={"id": 1, "adopt_count": 1, "display_status": "solved"})
+    )
+    client = TestClient(_app(answer=answer_svc, question=question_svc))
+    resp = client.post("/api/v1/qa_experts/answers", json={"question_id": 1, "content": "答"})
+    assert resp.json()["status_code"] == 200
+    adopted = client.post("/api/v1/qa_experts/questions/1/adopt", json={"answer_id": 2})
+    assert adopted.json()["status_code"] == 200
+
+
+def test_fourth_adopt_returns_18304():
+    question_svc = SimpleNamespace(adopt_answer=AsyncMock(side_effect=QaExpertAdoptLimitError()))
+    client = TestClient(_app(question=question_svc))
+    resp = client.post("/api/v1/qa_experts/questions/1/adopt", json={"answer_id": 9})
+    assert resp.json()["status_code"] == 18304
+
+
+def test_comment_without_answer_returns_18309():
+    comment_svc = SimpleNamespace(create_comment=AsyncMock(side_effect=QaExpertCommentNotAllowedError()))
+    client = TestClient(_app(comment=comment_svc))
+    resp = client.post(
+        "/api/v1/qa_experts/comments",
+        json={"answer_id": 2, "content": "评", "question_id": 1},
+    )
+    assert resp.json()["status_code"] == 18309

--- a/src/backend/test/qa_expert/test_answer_lock.py
+++ b/src/backend/test/qa_expert/test_answer_lock.py
@@ -1,0 +1,170 @@
+# ruff: noqa: RUF002
+"""T008：首答锁（仓储全 mock）。"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from bisheng.common.errcode.qa_expert import QaExpertAnonymousRevealRequiredError, QaExpertContentLockedError
+from bisheng.database.models.qa_expert import Answer, Expert, Question
+from bisheng.qa_expert.domain.schemas import AnswerCreateRequest, QuestionUpdateRequest
+from bisheng.qa_expert.domain.services import AnswerService, QuestionService
+
+
+def _question(**kwargs) -> Question:
+    data = {
+        "id": 9,
+        "user_id": 1,
+        "title": "炼钢",
+        "description": "描述",
+        "business_domain": "steel",
+        "question_type": "public",
+        "content_locked": 0,
+        "answer_count": 0,
+        "adopt_count": 0,
+    }
+    data.update(kwargs)
+    return Question(**data)
+
+
+def _expert(*, expert_id: int = 3, user_id: int = 8, status: int = 1) -> Expert:
+    return Expert(id=expert_id, user_id=user_id, expert_name=f"专家{expert_id}", status=status)
+
+
+def _answer_service() -> AnswerService:
+    svc = AnswerService()
+    svc.repository = MagicMock()
+    svc.question_repo = MagicMock()
+    svc.expert_repo = MagicMock()
+    svc.invite_repo = MagicMock()
+    svc.question_repo.try_lock_content = AsyncMock(return_value=True)
+    svc.question_repo.update = AsyncMock()
+    svc.question_repo.increment_answer_count = AsyncMock()
+    svc.invite_repo.list_user_ids_by_question_ids = AsyncMock(return_value={})
+    svc.expert_repo.increment_answer_count = AsyncMock()
+    svc.expert_repo.get_by_id = AsyncMock(return_value=_expert())
+    svc._send_answer_notification = AsyncMock()
+    svc._resolve_answer = AsyncMock(side_effect=lambda answer: answer)
+    return svc
+
+
+async def _submit(svc: AnswerService, *, user_id: int = 8, question_id: int = 9) -> Answer:
+    next_id = {"n": 10}
+
+    async def fake_create(answer: Answer) -> Answer:
+        next_id["n"] += 1
+        answer.id = next_id["n"]
+        return answer
+
+    svc.repository.create = AsyncMock(side_effect=fake_create)
+    return await svc.create_answer(
+        user_id,
+        AnswerCreateRequest(question_id=question_id, content="有效回答"),
+        tenant_id=1,
+    )
+
+
+async def test_first_valid_answer_locks_content():
+    svc = _answer_service()
+    svc.question_repo.get_by_id = AsyncMock(return_value=_question())
+    svc.expert_repo.get_by_user_id = AsyncMock(return_value=_expert())
+    answer = await _submit(svc)
+    assert answer.id is not None
+    persisted: Answer = svc.repository.create.await_args.args[0]
+    assert persisted.user_id == 8
+    svc.question_repo.try_lock_content.assert_awaited_once_with(9)
+    svc.question_repo.increment_answer_count.assert_awaited_once_with(9)
+
+
+async def test_concurrent_first_answers_both_succeed_lock_once():
+    svc = _answer_service()
+    svc.question_repo.get_by_id = AsyncMock(return_value=_question())
+    experts = {
+        8: _expert(expert_id=3, user_id=8),
+        9: _expert(expert_id=4, user_id=9),
+    }
+    svc.expert_repo.get_by_user_id = AsyncMock(side_effect=lambda uid: experts[uid])
+    locked = {"v": 0}
+
+    async def fake_lock(_question_id: int) -> bool:
+        if locked["v"] == 0:
+            locked["v"] = 1
+            return True
+        return False
+
+    svc.question_repo.try_lock_content = AsyncMock(side_effect=fake_lock)
+    next_id = {"n": 10}
+
+    async def fake_create(answer: Answer) -> Answer:
+        next_id["n"] += 1
+        answer.id = next_id["n"]
+        return answer
+
+    svc.repository.create = AsyncMock(side_effect=fake_create)
+    request = AnswerCreateRequest(question_id=9, content="有效回答")
+    first = await svc.create_answer(8, request, tenant_id=1)
+    second = await svc.create_answer(9, request, tenant_id=1)
+    assert first.id != second.id
+    assert svc.question_repo.try_lock_content.await_count == 2
+    assert locked["v"] == 1
+
+
+async def test_delete_all_unadopted_does_not_unlock():
+    svc = _answer_service()
+    question = SimpleNamespace(id=9, user_id=1, content_locked=1, answer_count=1)
+    answer = SimpleNamespace(id=11, question_id=9, user_id=8, expert_id=3, status=1)
+    svc.repository.get_by_id = AsyncMock(return_value=answer)
+    svc.repository.delete = AsyncMock(return_value=True)
+    svc.question_repo.get_by_id = AsyncMock(return_value=question)
+    assert await svc.delete_answer(11, 8) is True
+    svc.question_repo.update.assert_awaited()
+    kwargs = svc.question_repo.update.await_args.kwargs
+    assert kwargs.get("answer_count") == 0
+    assert "content_locked" not in kwargs
+
+
+async def test_update_question_rejected_when_locked():
+    svc = QuestionService()
+    svc.repository = MagicMock()
+    svc.repository.get_by_id = AsyncMock(return_value=_question(content_locked=1))
+    with pytest.raises(QaExpertContentLockedError):
+        await svc.update_question(9, QuestionUpdateRequest(title="改标题"))
+    svc.repository.update.assert_not_called()
+
+
+async def test_submit_answer_persists_anonymous_choice():
+    """专家回答可选择匿名；未匿名不落 reveal。"""
+    svc = _answer_service()
+    svc.question_repo.get_by_id = AsyncMock(return_value=_question())
+    svc.expert_repo.get_by_user_id = AsyncMock(return_value=_expert())
+
+    async def fake_create(answer: Answer) -> Answer:
+        answer.id = 11
+        return answer
+
+    svc.repository.create = AsyncMock(side_effect=fake_create)
+    await svc.create_answer(
+        8,
+        AnswerCreateRequest(question_id=9, content="匿名答", anonymous=True),
+        tenant_id=1,
+    )
+    persisted: Answer = svc.repository.create.await_args.args[0]
+    assert persisted.anonymous == 1
+    assert persisted.reveal_on_public is None
+
+
+async def test_directed_anonymous_answer_requires_reveal():
+    """定向匿名回答未选转公开姓名则拒绝，不写 qa_answer。"""
+    svc = _answer_service()
+    svc.question_repo.get_by_id = AsyncMock(return_value=_question(question_type="directed"))
+    svc.expert_repo.get_by_user_id = AsyncMock(return_value=_expert())
+    svc.invite_repo.list_user_ids_by_question_ids = AsyncMock(return_value={9: {8}})
+    svc.repository.create = AsyncMock()
+    with pytest.raises(QaExpertAnonymousRevealRequiredError):
+        await svc.create_answer(
+            8,
+            AnswerCreateRequest(question_id=9, content="定向匿名答", anonymous=True),
+            tenant_id=1,
+        )
+    svc.repository.create.assert_not_awaited()

--- a/src/backend/test/qa_expert/test_asset_persistence.py
+++ b/src/backend/test/qa_expert/test_asset_persistence.py
@@ -454,6 +454,8 @@ async def test_answer_create_compensates_when_database_insert_fails() -> None:
     )
     service.expert_repo = AsyncMock()
     service.expert_repo.get_by_user_id.return_value = Expert(id=3, user_id=8, expert_name="expert")
+    service.invite_repo = AsyncMock()
+    service.invite_repo.list_user_ids_by_question_ids.return_value = {}
     service.repository = AsyncMock()
     service.repository.create.side_effect = RuntimeError("db failed")
 

--- a/src/backend/test/qa_expert/test_capability_resolver.py
+++ b/src/backend/test/qa_expert/test_capability_resolver.py
@@ -1,0 +1,228 @@
+# ruff: noqa: RUF002
+"""T004：CapabilityResolver 资格引擎单测（不查库）。"""
+
+from types import SimpleNamespace
+
+from bisheng.common.errcode.qa_expert import (
+    QaExpertPublishDurationInvalidError,
+    QaExpertQuestionAccessDeniedError,
+)
+from bisheng.qa_expert.domain.capability import (
+    DISPLAY_PENDING_ADOPT,
+    DISPLAY_SOLVED,
+    DISPLAY_UNANSWERED,
+    CapabilityResolver,
+    CapabilitySnapshot,
+    derive_display_status,
+    is_expert_library_admin,
+    is_unresolved,
+)
+
+
+def _user(*, user_id: int, admin: bool = False, role: str | None = None, user_name: str = "u") -> SimpleNamespace:
+    return SimpleNamespace(
+        user_id=user_id,
+        user_name=user_name,
+        role=role,
+        is_admin=lambda: admin,
+    )
+
+
+def _question(
+    *,
+    user_id: int = 1,
+    question_type: str = "public",
+    content_locked: int = 0,
+    adopt_count: int = 0,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=10,
+        user_id=user_id,
+        question_type=question_type,
+        content_locked=content_locked,
+        adopt_count=adopt_count,
+    )
+
+
+def _expert(*, status: int = 1) -> SimpleNamespace:
+    return SimpleNamespace(id=99, user_id=20, status=status)
+
+
+def _resolve(user, question, **snapshot_kwargs):
+    return CapabilityResolver().resolve(user, question, CapabilitySnapshot(**snapshot_kwargs))
+
+
+def test_error_codes_module_183():
+    assert QaExpertQuestionAccessDeniedError.Code == 18301
+    assert QaExpertPublishDurationInvalidError.Code == 18310
+
+
+def test_display_status_unanswered_pending_solved():
+    assert derive_display_status(effective_answer_count=0, adopt_count=0) == DISPLAY_UNANSWERED
+    assert derive_display_status(effective_answer_count=2, adopt_count=0) == DISPLAY_PENDING_ADOPT
+    assert derive_display_status(effective_answer_count=2, adopt_count=1) == DISPLAY_SOLVED
+    unanswered = _resolve(_user(user_id=1), _question(), effective_answer_count=0)
+    pending = _resolve(_user(user_id=1), _question(), effective_answer_count=1)
+    solved = _resolve(_user(user_id=1), _question(adopt_count=1), effective_answer_count=1)
+    assert unanswered.display_status == DISPLAY_UNANSWERED
+    assert pending.display_status == DISPLAY_PENDING_ADOPT
+    assert solved.display_status == DISPLAY_SOLVED
+    assert "已关闭" not in {unanswered.display_status, pending.display_status, solved.display_status}
+
+
+def test_unresolved_filter_set():
+    assert is_unresolved(DISPLAY_UNANSWERED)
+    assert is_unresolved(DISPLAY_PENDING_ADOPT)
+    assert not is_unresolved(DISPLAY_SOLVED)
+
+
+def test_directed_hidden_from_stranger():
+    question = _question(user_id=1, question_type="directed")
+    result = _resolve(
+        _user(user_id=99),
+        question,
+        invited_user_ids=frozenset({20}),
+        expert=_expert(),
+    )
+    assert result.capabilities.visible is False
+    assert result.capabilities.can_answer is False
+    assert result.capabilities.can_comment is False
+    assert result.capabilities.can_edit is False
+
+
+def test_directed_visible_to_invited_and_admin():
+    question = _question(user_id=1, question_type="directed")
+    invited = _resolve(
+        _user(user_id=20),
+        question,
+        invited_user_ids=frozenset({20}),
+        expert=_expert(),
+    )
+    admin = _resolve(
+        _user(user_id=8, admin=True),
+        question,
+        invited_user_ids=frozenset({20}),
+    )
+    role_admin = _resolve(
+        _user(user_id=9, role="管理员"),
+        question,
+        invited_user_ids=frozenset({20}),
+    )
+    assert invited.capabilities.visible is True
+    assert invited.capabilities.can_answer is True
+    assert admin.capabilities.visible is True
+    assert admin.capabilities.can_view_real_identity is True
+    assert role_admin.capabilities.visible is True
+    assert is_expert_library_admin(_user(user_id=9, role="管理员"))
+    names_only = SimpleNamespace(
+        user_id=9,
+        user_name="gzx03",
+        is_admin=lambda: False,
+        role_names=["管理员"],
+    )
+    assert is_expert_library_admin(names_only)
+
+
+def test_public_expert_can_answer_before_first_adopt():
+    result = _resolve(
+        _user(user_id=20),
+        _question(user_id=1, question_type="public", adopt_count=0),
+        expert=_expert(),
+    )
+    assert result.capabilities.visible is True
+    assert result.capabilities.can_answer is True
+
+
+def test_public_expert_cannot_answer_after_first_adopt_if_not_eligible():
+    result = _resolve(
+        _user(user_id=20),
+        _question(user_id=1, question_type="public", adopt_count=1),
+        expert=_expert(),
+        eligibility_user_ids=frozenset({30}),
+        effective_answer_count=1,
+    )
+    assert result.capabilities.can_answer is False
+    eligible = _resolve(
+        _user(user_id=20),
+        _question(user_id=1, question_type="public", adopt_count=1),
+        expert=_expert(),
+        eligibility_user_ids=frozenset({20}),
+        effective_answer_count=1,
+    )
+    assert eligible.capabilities.can_answer is True
+
+
+def test_disabled_expert_cannot_answer():
+    result = _resolve(
+        _user(user_id=20),
+        _question(user_id=1, question_type="public"),
+        expert=_expert(status=0),
+    )
+    assert result.capabilities.can_answer is False
+
+
+def test_asker_cannot_answer_and_lock_blocks_edit():
+    asker = _user(user_id=1)
+    unlocked = _resolve(asker, _question(user_id=1, content_locked=0), expert=_expert())
+    locked = _resolve(asker, _question(user_id=1, content_locked=1), expert=_expert())
+    assert unlocked.capabilities.can_answer is False
+    assert unlocked.capabilities.can_edit is True
+    assert locked.capabilities.can_edit is False
+    assert locked.capabilities.can_delete_question is False
+
+
+def test_directed_comment_requires_effective_answer_except_asker():
+    question = _question(user_id=1, question_type="directed")
+    invited = _resolve(
+        _user(user_id=20),
+        question,
+        invited_user_ids=frozenset({20}),
+        expert=_expert(),
+        user_has_effective_answer=False,
+    )
+    invited_answered = _resolve(
+        _user(user_id=20),
+        question,
+        invited_user_ids=frozenset({20}),
+        expert=_expert(),
+        user_has_effective_answer=True,
+    )
+    asker = _resolve(_user(user_id=1), question, invited_user_ids=frozenset({20}))
+    assert invited.capabilities.can_comment is False
+    assert invited_answered.capabilities.can_comment is True
+    assert asker.capabilities.can_comment is True
+
+
+def test_ended_publish_blocks_restart():
+    question = _question(user_id=1, question_type="directed", adopt_count=1)
+    allowed = _resolve(
+        _user(user_id=1),
+        question,
+        user_has_effective_answer=False,
+        effective_answer_count=1,
+    )
+    ended = _resolve(
+        _user(user_id=1),
+        question,
+        user_has_effective_answer=False,
+        effective_answer_count=1,
+        latest_publish_status="ended",
+    )
+    pending = _resolve(
+        _user(user_id=1),
+        question,
+        user_has_effective_answer=False,
+        effective_answer_count=1,
+        has_pending_publish=True,
+    )
+    rejected = _resolve(
+        _user(user_id=1),
+        question,
+        user_has_effective_answer=False,
+        effective_answer_count=1,
+        latest_publish_status="rejected",
+    )
+    assert allowed.capabilities.can_start_publish is True
+    assert ended.capabilities.can_start_publish is False
+    assert pending.capabilities.can_start_publish is False
+    assert rejected.capabilities.can_start_publish is True

--- a/src/backend/test/qa_expert/test_capability_resolver.py
+++ b/src/backend/test/qa_expert/test_capability_resolver.py
@@ -226,3 +226,27 @@ def test_ended_publish_blocks_restart():
     assert ended.capabilities.can_start_publish is False
     assert pending.capabilities.can_start_publish is False
     assert rejected.capabilities.can_start_publish is True
+
+
+def test_initiator_already_agreed_cannot_decide_again():
+    """发起人默认同意后不在 pending 审批人集合里，详情不再给同意/拒绝。"""
+    question = _question(user_id=1, question_type="directed", adopt_count=1)
+    initiator = _resolve(
+        _user(user_id=1),
+        question,
+        has_pending_publish=True,
+        effective_answer_count=1,
+        approver_user_ids=frozenset({50}),
+    )
+    pending_expert = _resolve(
+        _user(user_id=50),
+        question,
+        invited_user_ids=frozenset({50}),
+        expert=_expert(),
+        user_has_effective_answer=True,
+        has_pending_publish=True,
+        effective_answer_count=1,
+        approver_user_ids=frozenset({50}),
+    )
+    assert initiator.capabilities.can_decide_publish is False
+    assert pending_expert.capabilities.can_decide_publish is True

--- a/src/backend/test/qa_expert/test_comment_gate.py
+++ b/src/backend/test/qa_expert/test_comment_gate.py
@@ -1,0 +1,173 @@
+# ruff: noqa: RUF002
+"""T010：定向评论资格与追问豁免（仓储全 mock）。"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from bisheng.common.errcode.qa_expert import QaExpertAnonymousRevealRequiredError, QaExpertCommentNotAllowedError
+from bisheng.database.models.qa_expert import Comment, Question
+from bisheng.qa_expert.domain.schemas import CommentCreateRequest
+from bisheng.qa_expert.domain.services import CommentService
+
+
+def _question(**kwargs) -> Question:
+    data = {
+        "id": 9,
+        "user_id": 1,
+        "title": "炼钢",
+        "description": "描述",
+        "business_domain": "steel",
+        "question_type": "directed",
+        "answer_count": 0,
+        "adopt_count": 0,
+        "comment_count": 0,
+    }
+    data.update(kwargs)
+    return Question(**data)
+
+
+def _service() -> CommentService:
+    svc = CommentService()
+    svc.repository = MagicMock()
+    svc.answer_repo = MagicMock()
+    svc.question_repo = MagicMock()
+    svc.expert_repo = MagicMock()
+    svc.invite_repo = MagicMock()
+    svc.invite_repo.list_user_ids_by_question_ids = AsyncMock(return_value={9: {50}})
+    svc.expert_repo.get_by_user_id = AsyncMock(return_value=SimpleNamespace(id=3, user_id=50, status=1))
+    svc.answer_repo.has_effective_answer = AsyncMock(return_value=False)
+    svc.answer_repo.update = AsyncMock()
+    svc.question_repo.update = AsyncMock()
+    svc._send_comment_notification = AsyncMock()
+
+    async def fake_create(comment: Comment) -> Comment:
+        comment.id = 21
+        return comment
+
+    svc.repository.create = AsyncMock(side_effect=fake_create)
+    return svc
+
+
+async def test_directed_invited_cannot_comment_before_answer():
+    svc = _service()
+    answer = SimpleNamespace(id=11, question_id=9, comment_count=0)
+    svc.answer_repo.get_by_id = AsyncMock(return_value=answer)
+    svc.question_repo.get_by_id = AsyncMock(return_value=_question())
+    with pytest.raises(QaExpertCommentNotAllowedError):
+        await svc.create_comment(50, "专家", CommentCreateRequest(answer_id=11, content="先评一句"))
+    svc.repository.create.assert_not_awaited()
+
+
+async def test_directed_invited_can_comment_after_answer():
+    svc = _service()
+    svc.answer_repo.has_effective_answer = AsyncMock(return_value=True)
+    answer = SimpleNamespace(id=11, question_id=9, comment_count=0)
+    svc.answer_repo.get_by_id = AsyncMock(return_value=answer)
+    svc.question_repo.get_by_id = AsyncMock(return_value=_question(answer_count=1))
+    comment = await svc.create_comment(
+        50,
+        "专家",
+        CommentCreateRequest(answer_id=11, content="补充", anonymous=True, reveal_on_public=False),
+    )
+    assert comment.id == 21
+    persisted: Comment = svc.repository.create.await_args.args[0]
+    assert persisted.anonymous == 1
+    assert persisted.reveal_on_public == 0
+
+
+async def test_public_logged_in_can_comment():
+    svc = _service()
+    svc.invite_repo.list_user_ids_by_question_ids = AsyncMock(return_value={})
+    answer = SimpleNamespace(id=11, question_id=9, comment_count=0)
+    svc.answer_repo.get_by_id = AsyncMock(return_value=answer)
+    svc.question_repo.get_by_id = AsyncMock(return_value=_question(question_type="public"))
+    comment = await svc.create_comment(99, "同事", CommentCreateRequest(answer_id=11, content="公开可评"))
+    assert comment.content == "公开可评"
+
+
+async def test_follow_up_skips_expert_answer_gate():
+    svc = _service()
+    svc.question_repo.get_by_id = AsyncMock(return_value=_question())
+    comment = await svc.create_comment(
+        50,
+        "专家",
+        CommentCreateRequest(answer_id=0, question_id=9, content="追问", is_follow_up=True),
+    )
+    assert comment.is_follow_up is True
+    svc.repository.create.assert_awaited()
+
+
+async def test_asker_follow_up_inherits_question_anonymous_ignoring_client():
+    """提问者追问继承问题匿名；请求体匿名=false 也不能改成实名。"""
+    svc = _service()
+    svc.question_repo.get_by_id = AsyncMock(
+        return_value=_question(user_id=1, asker_anonymous=1, asker_reveal_on_public=0)
+    )
+    comment = await svc.create_comment(
+        1,
+        "提问者",
+        CommentCreateRequest(
+            answer_id=0,
+            question_id=9,
+            content="追问一句",
+            is_follow_up=True,
+            anonymous=False,
+            reveal_on_public=True,
+        ),
+    )
+    assert comment.is_follow_up is True
+    persisted: Comment = svc.repository.create.await_args.args[0]
+    assert persisted.anonymous == 1
+    assert persisted.reveal_on_public == 0
+
+
+async def test_self_comment_inherits_answer_anonymous():
+    """专家评论自己的回答时继承该回答匿名，忽略请求体。"""
+    svc = _service()
+    svc.answer_repo.has_effective_answer = AsyncMock(return_value=True)
+    answer = SimpleNamespace(id=11, question_id=9, comment_count=0, user_id=50, anonymous=1, reveal_on_public=0)
+    svc.answer_repo.get_by_id = AsyncMock(return_value=answer)
+    svc.question_repo.get_by_id = AsyncMock(return_value=_question(question_type="public", answer_count=1))
+    await svc.create_comment(
+        50,
+        "专家",
+        CommentCreateRequest(answer_id=11, content="自评补充", anonymous=False, reveal_on_public=True),
+    )
+    persisted: Comment = svc.repository.create.await_args.args[0]
+    assert persisted.anonymous == 1
+    assert persisted.reveal_on_public == 0
+
+
+async def test_other_comment_uses_request_anonymous():
+    """评论他人回答时用请求体独立选择匿名。"""
+    svc = _service()
+    svc.invite_repo.list_user_ids_by_question_ids = AsyncMock(return_value={})
+    answer = SimpleNamespace(id=11, question_id=9, comment_count=0, user_id=50, anonymous=0, reveal_on_public=None)
+    svc.answer_repo.get_by_id = AsyncMock(return_value=answer)
+    svc.question_repo.get_by_id = AsyncMock(return_value=_question(question_type="public"))
+    await svc.create_comment(
+        99,
+        "同事",
+        CommentCreateRequest(answer_id=11, content="路人评", anonymous=True),
+    )
+    persisted: Comment = svc.repository.create.await_args.args[0]
+    assert persisted.anonymous == 1
+    assert persisted.reveal_on_public is None
+
+
+async def test_directed_anonymous_comment_requires_reveal():
+    """定向题评他人且匿名时必须预选转公开姓名，拒绝后不写库。"""
+    svc = _service()
+    svc.answer_repo.has_effective_answer = AsyncMock(return_value=True)
+    answer = SimpleNamespace(id=11, question_id=9, comment_count=0, user_id=88)
+    svc.answer_repo.get_by_id = AsyncMock(return_value=answer)
+    svc.question_repo.get_by_id = AsyncMock(return_value=_question(answer_count=1))
+    with pytest.raises(QaExpertAnonymousRevealRequiredError):
+        await svc.create_comment(
+            50,
+            "专家",
+            CommentCreateRequest(answer_id=11, content="定向匿名评", anonymous=True),
+        )
+    svc.repository.create.assert_not_awaited()

--- a/src/backend/test/qa_expert/test_data_flow.py
+++ b/src/backend/test/qa_expert/test_data_flow.py
@@ -454,13 +454,27 @@ async def test_df13_publish_approve_keeps_invites_and_blocks_outsider(flow_env):
     pending_detail = _ok(await env.client.get(f"{PREFIX}/questions/{qid}"))
     pending_pub = (pending_detail.get("data") or {}).get("latest_publish_request") or {}
     assert pending_pub.get("status") == "pending"
+    assert pending_pub.get("viewer_decision") == "approved"
     assert (pending_detail.get("data") or {}).get("active_publish_request", {}).get("status") == "pending"
+    assert (pending_detail.get("data") or {}).get("capabilities", {}).get("can_decide_publish") is False
     request_id = int((created.get("data") or {}).get("id") or 0)
     if not request_id:
         req = await env.reload_row(PublishRequest, question_id=qid)
         request_id = int(req.id)
-    invites_before = await env.reload_all(QuestionInvite, question_id=qid)
+    approvers_pending = await env.reload_all(PublishApprover, request_id=request_id)
+    asker_row = next(row for row in approvers_pending if int(row.user_id) == int(env.asker.user_id))
+    expert_row = next(row for row in approvers_pending if int(row.user_id) == int(env.uid(201)))
+    assert asker_row.decision == "approved"
+    assert expert_row.decision == "pending"
+    # 再读确认发起人仍是已同意且不能改口
+    again = _ok(await env.client.get(f"{PREFIX}/questions/{qid}"))
+    assert (again.get("data") or {}).get("latest_publish_request", {}).get("viewer_decision") == "approved"
+    assert (again.get("data") or {}).get("capabilities", {}).get("can_decide_publish") is False
     env.as_user(env.user(201, name="专家甲"))
+    expert_detail = _ok(await env.client.get(f"{PREFIX}/questions/{qid}"))
+    assert (expert_detail.get("data") or {}).get("latest_publish_request", {}).get("viewer_decision") == "pending"
+    assert (expert_detail.get("data") or {}).get("capabilities", {}).get("can_decide_publish") is True
+    invites_before = await env.reload_all(QuestionInvite, question_id=qid)
     approved = _ok(await env.client.post(f"{PREFIX}/publish-requests/{request_id}/approve"))
     assert approved["status_code"] == 200
     question = await env.reload_row(Question, id=qid)
@@ -938,3 +952,51 @@ async def test_df21_publish_todo_and_late_answerer_joins(flow_env, monkeypatch):
     assert env.uid(202) in _receiver_ids(added_msgs[-1]["receiver"])
     still_tasks = await env.reload_all(ApprovalTask, instance_id=instance.id)
     assert {int(row.approver_user_id) for row in still_tasks if row.status == "pending"} == pending_after
+
+
+async def test_df13_reject_keeps_viewer_decision_on_latest(flow_env):
+    """任一拒绝后申请 ended 为 rejected；详情仍返回本人 viewer_decision，供右上角展示已拒绝。"""
+    env = flow_env
+    invited = await env.seed_expert(user_id=201, name="专家甲")
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df13拒绝决策",
+            "description": "定向",
+            "business_domain": "steel",
+            "question_type": "directed",
+            "invited_expert_ids": [invited.id],
+            "asker_reveal_on_public": True,
+        },
+    )
+    env.as_user(env.user(201, name="专家甲"))
+    aid = await _create_answer(env, qid, "甲的回答")
+    env.as_user(env.asker)
+    _ok(await env.client.post(f"{PREFIX}/questions/{qid}/adopt", json={"answer_id": aid}))
+    created = _ok(await env.client.post(f"{PREFIX}/questions/{qid}/publish-requests", json={"duration_days": 3}))
+    request_id = int((created.get("data") or {}).get("id") or 0)
+    if not request_id:
+        req = await env.reload_row(PublishRequest, question_id=qid)
+        request_id = int(req.id)
+    env.as_user(env.user(201, name="专家甲"))
+    denied = _ok(await env.client.post(f"{PREFIX}/publish-requests/{request_id}/reject"))
+    assert denied["status_code"] == 200
+    request = await env.reload_row(PublishRequest, id=request_id)
+    assert request.status == "rejected"
+    expert_row = next(
+        row for row in await env.reload_all(PublishApprover, request_id=request_id) if int(row.user_id) == env.uid(201)
+    )
+    assert expert_row.decision == "rejected"
+    detail = _ok(await env.client.get(f"{PREFIX}/questions/{qid}"))
+    latest = (detail.get("data") or {}).get("latest_publish_request") or {}
+    assert latest.get("status") == "rejected"
+    assert latest.get("viewer_decision") == "rejected"
+    assert (detail.get("data") or {}).get("question_type") == "directed"
+    assert (detail.get("data") or {}).get("capabilities", {}).get("can_decide_publish") is False
+    env.as_user(env.asker)
+    asker_detail = _ok(await env.client.get(f"{PREFIX}/questions/{qid}"))
+    asker_latest = (asker_detail.get("data") or {}).get("latest_publish_request") or {}
+    assert asker_latest.get("status") == "rejected"
+    assert asker_latest.get("viewer_decision") == "approved"
+    assert (asker_detail.get("data") or {}).get("capabilities", {}).get("can_start_publish") is True

--- a/src/backend/test/qa_expert/test_data_flow.py
+++ b/src/backend/test/qa_expert/test_data_flow.py
@@ -1,0 +1,940 @@
+# ruff: noqa: RUF002
+"""F083 接口+落库流转：对照 api-data-flow-matrix.md P0。仓储不 mock。"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from bisheng.database.models.qa_expert import (
+    AnonymousAlias,
+    Answer,
+    AnswerAdopt,
+    AnswerEligibility,
+    Comment,
+    Expert,
+    PublishApprover,
+    PublishRequest,
+    Question,
+    QuestionInvite,
+)
+
+PREFIX = "/api/v1/qa_experts"
+
+
+def _ok(resp) -> dict:
+    body = resp.json()
+    assert resp.status_code == 200, body
+    return body
+
+
+async def _create_question(env, payload: dict) -> int:
+    payload = {**payload, "title": env.t(payload["title"])}
+    resp = await env.client.post(f"{PREFIX}/questions", json=payload)
+    body = _ok(resp)
+    assert body.get("status_code") == 200, body
+    data = body.get("data") or {}
+    qid = data.get("id")
+    if qid:
+        return int(qid)
+    row = await env.reload_row(Question, title=payload["title"])
+    assert row is not None
+    return int(row.id)
+
+
+async def _create_answer(env, question_id: int, content: str) -> int:
+    resp = await env.client.post(
+        f"{PREFIX}/answers",
+        json={"question_id": question_id, "content": content, "reveal_on_public": True},
+    )
+    body = _ok(resp)
+    assert body.get("status_code") == 200, body
+    data = body.get("data") or {}
+    aid = data.get("id")
+    if aid:
+        return int(aid)
+    rows = await env.reload_all(Answer, question_id=question_id)
+    assert rows
+    return int(max(rows, key=lambda r: r.id).id)
+
+
+async def _create_answer_anonymous(env, question_id: int, content: str) -> int:
+    resp = await env.client.post(
+        f"{PREFIX}/answers",
+        json={"question_id": question_id, "content": content, "anonymous": True},
+    )
+    body = _ok(resp)
+    assert body.get("status_code") == 200, body
+    data = body.get("data") or {}
+    aid = data.get("id")
+    if aid:
+        return int(aid)
+    rows = await env.reload_all(Answer, question_id=question_id)
+    assert rows
+    return int(max(rows, key=lambda r: r.id).id)
+
+
+async def test_df01_directed_persists_question_and_invite(flow_env):
+    env = flow_env
+    expert = await env.seed_expert(user_id=201, name="专家甲")
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df01定向题",
+            "description": "定向正文",
+            "business_domain": "steel",
+            "question_type": "directed",
+            "invited_expert_ids": [expert.id],
+            "asker_reveal_on_public": True,
+        },
+    )
+    question = await env.reload_row(Question, id=qid)
+    invites = await env.reload_all(QuestionInvite, question_id=qid)
+    assert question.question_type == "directed"
+    assert question.content_locked == 0
+    assert len(invites) == 1
+    assert invites[0].user_id == env.uid(201)
+    assert invites[0].expert_id == expert.id
+    assert question.experts_names == expert.expert_name
+    assert question.experts_names != str(expert.id)
+    detail = _ok(await env.client.get(f"{PREFIX}/questions/{qid}"))
+    assert detail["status_code"] == 200
+    data = detail.get("data") or {}
+    assert data.get("experts_names") == expert.expert_name
+    assert data.get("experts_names") != str(expert.id)
+    assert "定向正文" in str(data)
+    again = _ok(await env.client.get(f"{PREFIX}/questions/{qid}"))
+    assert (again.get("data") or {}).get("experts_names") == expert.expert_name
+
+
+async def test_df02_public_visible_to_stranger(flow_env):
+    env = flow_env
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {"title": "df02公开题", "description": "公开正文", "business_domain": "steel", "question_type": "public"},
+    )
+    question = await env.reload_row(Question, id=qid)
+    invites = await env.reload_all(QuestionInvite, question_id=qid)
+    assert question.question_type == "public"
+    assert invites == []
+    env.as_user(env.stranger)
+    detail = _ok(await env.client.get(f"{PREFIX}/questions/{qid}"))
+    assert detail["status_code"] == 200
+    assert "公开正文" in str(detail.get("data"))
+
+
+async def test_df03_directed_denied_no_leak_and_absent_from_list(flow_env):
+    env = flow_env
+    expert = await env.seed_expert(user_id=201, name="专家甲")
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df03机密标题",
+            "description": "机密正文",
+            "business_domain": "steel",
+            "question_type": "directed",
+            "invited_expert_ids": [expert.id],
+            "asker_reveal_on_public": False,
+        },
+    )
+    env.as_user(env.stranger)
+    detail = _ok(await env.client.get(f"{PREFIX}/questions/{qid}"))
+    assert detail["status_code"] == 18301
+    dumped = str(detail)
+    assert "机密标题" not in dumped
+    assert "机密正文" not in dumped
+    listed = _ok(
+        await env.client.get(
+            f"{PREFIX}/questions",
+            params={"page": 1, "page_size": 50, "keyword": env.t("df03机密标题")},
+        )
+    )
+    assert listed["status_code"] == 200
+    questions = (listed.get("data") or {}).get("questions") or []
+    ids = {int(item["id"]) for item in questions if isinstance(item, dict) and item.get("id")}
+    assert qid not in ids
+    assert await env.reload_row(Question, id=qid) is not None
+
+
+async def test_df04_related_docs_persisted_as_space_file_id(flow_env):
+    env = flow_env
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df04关联文档",
+            "description": "正文仍在",
+            "business_domain": "steel",
+            "question_type": "public",
+            "related_doc_ids": ["3-8"],
+        },
+    )
+    question = await env.reload_row(Question, id=qid)
+    assert question.related_docs
+    assert "3-8" in question.related_docs
+    detail = _ok(await env.client.get(f"{PREFIX}/questions/{qid}"))
+    assert detail["status_code"] == 200
+    data = detail.get("data") or {}
+    views = data.get("related_doc_views") or data.get("related_docs") or []
+    if isinstance(views, list) and views and isinstance(views[0], dict):
+        assert views[0].get("unavailable_reason") == "forbidden"
+        assert views[0].get("unavailable_reason") != "not_found"
+    assert "正文仍在" in str(data)
+
+
+async def test_df05_first_answer_locks_content(flow_env):
+    env = flow_env
+    expert = await env.seed_expert(user_id=201, name="专家甲")
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df05首答锁",
+            "description": "原正文",
+            "business_domain": "steel",
+            "question_type": "directed",
+            "invited_expert_ids": [expert.id],
+            "asker_reveal_on_public": True,
+        },
+    )
+    env.as_user(env.user(201, name="专家甲"))
+    await _create_answer(env, qid, "首答内容")
+    question = await env.reload_row(Question, id=qid)
+    answers = await env.reload_all(Answer, question_id=qid)
+    assert question.content_locked == 1
+    assert question.answer_count == 1
+    assert len(answers) == 1
+    env.as_user(env.asker)
+    locked_resp = _ok(
+        await env.client.put(
+            f"{PREFIX}/questions/{qid}",
+            json={"title": "改标题", "description": "改正文"},
+        )
+    )
+    assert locked_resp["status_code"] != 200
+    locked = await env.reload_row(Question, id=qid)
+    assert locked.title == env.t("df05首答锁")
+    assert locked.content_locked == 1
+
+
+async def test_df06_non_invited_answer_does_not_insert(flow_env):
+    env = flow_env
+    invited = await env.seed_expert(user_id=201, name="专家甲")
+    await env.seed_expert(user_id=203, name="专家丙")
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df06未受邀",
+            "description": "定向",
+            "business_domain": "steel",
+            "question_type": "directed",
+            "invited_expert_ids": [invited.id],
+            "asker_reveal_on_public": True,
+        },
+    )
+    env.as_user(env.user(203, name="专家丙"))
+    before = await env.reload_all(Answer, question_id=qid)
+    resp = await env.client.post(
+        f"{PREFIX}/answers",
+        json={"question_id": qid, "content": "不该写入", "reveal_on_public": True},
+    )
+    body = _ok(resp)
+    assert body["status_code"] != 200
+    after = await env.reload_all(Answer, question_id=qid)
+    assert len(after) == len(before)
+
+
+async def test_df07_delete_last_answer_keeps_lock(flow_env):
+    env = flow_env
+
+    expert = await env.seed_expert(user_id=201, name="专家甲")
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df07锁不解除",
+            "description": "正文",
+            "business_domain": "steel",
+            "question_type": "directed",
+            "invited_expert_ids": [expert.id],
+            "asker_reveal_on_public": True,
+        },
+    )
+    env.as_user(env.user(201, name="专家甲"))
+    aid = await _create_answer(env, qid, "将删除的回答")
+    resp = await env.client.delete(f"{PREFIX}/answers/{aid}")
+    body = _ok(resp)
+    assert body["status_code"] == 200
+    question = await env.reload_row(Question, id=qid)
+    answer = await env.reload_row(Answer, id=aid)
+    assert question.content_locked == 1
+    assert question.answer_count == 0
+    assert answer.status == 3
+
+
+async def test_df08_public_adopt_writes_eligibility_snapshot(flow_env):
+    env = flow_env
+    expert_a = await env.seed_expert(user_id=201, name="专家A")
+    await env.seed_expert(user_id=202, name="专家B")
+    await env.seed_expert(user_id=203, name="专家C")
+    await env.seed_expert(user_id=204, name="专家D")
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df08公开快照",
+            "description": "公开",
+            "business_domain": "steel",
+            "question_type": "public",
+            "invited_expert_ids": [expert_a.id],
+        },
+    )
+    env.as_user(env.user(202, name="专家B"))
+    bid = await _create_answer(env, qid, "B的回答")
+    await env.client.delete(f"{PREFIX}/answers/{bid}")
+    env.as_user(env.user(203, name="专家C"))
+    cid = await _create_answer(env, qid, "C的回答")
+    env.as_user(env.asker)
+    adopt = _ok(await env.client.post(f"{PREFIX}/questions/{qid}/adopt", json={"answer_id": cid}))
+    assert adopt["status_code"] == 200
+    question = await env.reload_row(Question, id=qid)
+    adopts = await env.reload_all(AnswerAdopt, question_id=qid)
+    elig = await env.reload_all(AnswerEligibility, question_id=qid)
+    elig_users = {int(row.user_id) for row in elig}
+    assert question.adopt_count == 1
+    assert question.resolved_at is not None
+    assert len(adopts) == 1
+    assert elig_users == {env.uid(201), env.uid(202), env.uid(203)}
+    env.as_user(env.user(204, name="专家D"))
+    before = await env.reload_all(Answer, question_id=qid)
+    denied = _ok(
+        await env.client.post(
+            f"{PREFIX}/answers",
+            json={"question_id": qid, "content": "圈外不应写入", "reveal_on_public": True},
+        )
+    )
+    assert denied["status_code"] != 200
+    after = await env.reload_all(Answer, question_id=qid)
+    assert len(after) == len(before)
+
+
+async def test_df09_fourth_adopt_does_not_write_slot(flow_env):
+    env = flow_env
+    experts = []
+    for i in range(4):
+        experts.append(await env.seed_expert(user_id=210 + i, name=f"专家{i}"))
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {"title": "df09四次采纳", "description": "公开", "business_domain": "steel", "question_type": "public"},
+    )
+    answer_ids = []
+    for i, expert in enumerate(experts):
+        env.as_user(env.user(expert.user_id, name=expert.expert_name))
+        answer_ids.append(await _create_answer(env, qid, f"回答{i}"))
+    env.as_user(env.asker)
+    for aid in answer_ids[:3]:
+        body = _ok(await env.client.post(f"{PREFIX}/questions/{qid}/adopt", json={"answer_id": aid}))
+        assert body["status_code"] == 200
+    fourth = _ok(await env.client.post(f"{PREFIX}/questions/{qid}/adopt", json={"answer_id": answer_ids[3]}))
+    assert fourth["status_code"] != 200
+    question = await env.reload_row(Question, id=qid)
+    adopts = await env.reload_all(AnswerAdopt, question_id=qid)
+    assert question.adopt_count == 3
+    assert len(adopts) == 3
+
+
+async def test_df10_directed_comment_requires_effective_answer(flow_env):
+    env = flow_env
+    expert_a = await env.seed_expert(user_id=201, name="专家甲")
+    expert_b = await env.seed_expert(user_id=202, name="专家乙")
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df10评论门禁",
+            "description": "定向",
+            "business_domain": "steel",
+            "question_type": "directed",
+            "invited_expert_ids": [expert_a.id, expert_b.id],
+            "asker_reveal_on_public": True,
+        },
+    )
+    env.as_user(env.user(201, name="专家甲"))
+    aid = await _create_answer(env, qid, "甲先答")
+    env.as_user(env.user(202, name="专家乙"))
+    before = await env.reload_all(Comment, question_id=qid)
+    denied = _ok(
+        await env.client.post(
+            f"{PREFIX}/comments",
+            json={"answer_id": aid, "content": "未答不能评", "reveal_on_public": True},
+        )
+    )
+    assert denied["status_code"] != 200
+    assert len(await env.reload_all(Comment, question_id=qid)) == len(before)
+    await _create_answer(env, qid, "乙后答")
+    allowed = _ok(
+        await env.client.post(
+            f"{PREFIX}/comments",
+            json={"answer_id": aid, "content": "已答可评", "reveal_on_public": True},
+        )
+    )
+    assert allowed["status_code"] == 200
+    comments = await env.reload_all(Comment, question_id=qid)
+    assert len(comments) == 1
+    assert comments[0].content == "已答可评"
+
+
+async def test_df11_disable_expert_blocks_new_answer(flow_env):
+    env = flow_env
+    expert = await env.seed_expert(user_id=201, name="专家甲")
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {"title": "df11停用", "description": "公开", "business_domain": "steel", "question_type": "public"},
+    )
+    env.as_user(env.portal_admin)
+    disabled = _ok(await env.client.post(f"{PREFIX}/experts/{expert.id}/disable"))
+    assert disabled["status_code"] == 200
+    row = await env.reload_row(Expert, id=expert.id)
+    assert row is not None
+    assert row.status == 0
+    env.as_user(env.user(201, name="专家甲"))
+    before = await env.reload_all(Answer, question_id=qid)
+    denied = _ok(
+        await env.client.post(
+            f"{PREFIX}/answers",
+            json={"question_id": qid, "content": "停用后不能答"},
+        )
+    )
+    assert denied["status_code"] != 200
+    assert len(await env.reload_all(Answer, question_id=qid)) == len(before)
+
+
+async def test_df12_non_admin_cannot_disable_expert(flow_env):
+    env = flow_env
+    expert = await env.seed_expert(user_id=201, name="专家甲")
+    env.as_user(env.asker)
+    denied = _ok(await env.client.post(f"{PREFIX}/experts/{expert.id}/disable"))
+    assert denied["status_code"] != 200
+    row = await env.reload_row(Expert, id=expert.id)
+    assert row.status == 1
+
+
+async def test_df13_publish_approve_keeps_invites_and_blocks_outsider(flow_env):
+    env = flow_env
+    invited = await env.seed_expert(user_id=201, name="专家甲")
+    await env.seed_expert(user_id=203, name="专家丙")
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df13转公开",
+            "description": "定向",
+            "business_domain": "steel",
+            "question_type": "directed",
+            "invited_expert_ids": [invited.id],
+            "asker_reveal_on_public": True,
+        },
+    )
+    env.as_user(env.user(201, name="专家甲"))
+    aid = await _create_answer(env, qid, "甲的回答")
+    env.as_user(env.asker)
+    _ok(await env.client.post(f"{PREFIX}/questions/{qid}/adopt", json={"answer_id": aid}))
+    created = _ok(await env.client.post(f"{PREFIX}/questions/{qid}/publish-requests", json={"duration_days": 3}))
+    assert created["status_code"] == 200
+    pending_detail = _ok(await env.client.get(f"{PREFIX}/questions/{qid}"))
+    pending_pub = (pending_detail.get("data") or {}).get("latest_publish_request") or {}
+    assert pending_pub.get("status") == "pending"
+    assert (pending_detail.get("data") or {}).get("active_publish_request", {}).get("status") == "pending"
+    request_id = int((created.get("data") or {}).get("id") or 0)
+    if not request_id:
+        req = await env.reload_row(PublishRequest, question_id=qid)
+        request_id = int(req.id)
+    invites_before = await env.reload_all(QuestionInvite, question_id=qid)
+    env.as_user(env.user(201, name="专家甲"))
+    approved = _ok(await env.client.post(f"{PREFIX}/publish-requests/{request_id}/approve"))
+    assert approved["status_code"] == 200
+    question = await env.reload_row(Question, id=qid)
+    request = await env.reload_row(PublishRequest, id=request_id)
+    invites_after = await env.reload_all(QuestionInvite, question_id=qid)
+    assert question.question_type == "public"
+    assert request.status == "approved"
+    approved_detail = _ok(await env.client.get(f"{PREFIX}/questions/{qid}"))
+    latest = (approved_detail.get("data") or {}).get("latest_publish_request") or {}
+    assert latest.get("status") == "approved"
+    assert (approved_detail.get("data") or {}).get("question_type") == "public"
+    assert (approved_detail.get("data") or {}).get("active_publish_request") in (None, {})
+    assert len(invites_after) == len(invites_before) == 1
+    env.as_user(env.user(203, name="专家丙"))
+    before = await env.reload_all(Answer, question_id=qid)
+    denied = _ok(
+        await env.client.post(
+            f"{PREFIX}/answers",
+            json={"question_id": qid, "content": "非原受邀不能答"},
+        )
+    )
+    assert denied["status_code"] != 200
+    assert len(await env.reload_all(Answer, question_id=qid)) == len(before)
+    approvers = await env.reload_all(PublishApprover, request_id=request_id)
+    assert approvers
+
+
+async def _post_as(user, method: str, path: str, json: dict | None = None):
+    """独立 ASGI 客户端，避免并发时抢共享 auth。"""
+    from test.qa_expert.conftest import _flow_app
+
+    auth = {"user": user}
+    app = _flow_app(auth)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        return await getattr(client, method)(path, json=json)
+
+
+async def test_df14_concurrent_first_answers_lock_once(flow_env):
+    env = flow_env
+    await env.seed_expert(user_id=201, name="专家甲")
+    await env.seed_expert(user_id=202, name="专家乙")
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {"title": "df14并发首答", "description": "公开", "business_domain": "steel", "question_type": "public"},
+    )
+    r1, r2 = await asyncio.gather(
+        _post_as(
+            env.user(201, name="专家甲"),
+            "post",
+            f"{PREFIX}/answers",
+            {"question_id": qid, "content": "甲并发答", "reveal_on_public": True},
+        ),
+        _post_as(
+            env.user(202, name="专家乙"),
+            "post",
+            f"{PREFIX}/answers",
+            {"question_id": qid, "content": "乙并发答", "reveal_on_public": True},
+        ),
+    )
+    b1, b2 = _ok(r1), _ok(r2)
+    assert b1["status_code"] == 200
+    assert b2["status_code"] == 200
+    answers = await env.reload_all(Answer, question_id=qid)
+    question = await env.reload_row(Question, id=qid)
+    assert len(answers) == 2
+    assert question.content_locked == 1
+    assert question.answer_count == 2
+
+
+async def test_df15_concurrent_adopt_uses_row_lock(flow_env):
+    env = flow_env
+    await env.seed_expert(user_id=201, name="专家甲")
+    await env.seed_expert(user_id=202, name="专家乙")
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {"title": "df15并发采纳", "description": "公开", "business_domain": "steel", "question_type": "public"},
+    )
+    env.as_user(env.user(201, name="专家甲"))
+    a1 = await _create_answer(env, qid, "甲答")
+    env.as_user(env.user(202, name="专家乙"))
+    a2 = await _create_answer(env, qid, "乙答")
+    r1, r2 = await asyncio.gather(
+        _post_as(env.asker, "post", f"{PREFIX}/questions/{qid}/adopt", {"answer_id": a1}),
+        _post_as(env.asker, "post", f"{PREFIX}/questions/{qid}/adopt", {"answer_id": a2}),
+    )
+    codes = {_ok(r1)["status_code"], _ok(r2)["status_code"]}
+    assert codes == {200}
+    question = await env.reload_row(Question, id=qid)
+    adopts = await env.reload_all(AnswerAdopt, question_id=qid)
+    assert len(adopts) == 2
+    assert int(question.adopt_count) == 2
+    assert question.content_locked == 1
+
+
+async def test_df16_list_hides_anonymous_asker_name(flow_env):
+    """匿名公开题：库内 created_by 仍是真名；列表接口对路人只给别名。"""
+    env = flow_env
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df16匿名公开",
+            "description": "匿名正文",
+            "business_domain": "营销",
+            "question_type": "public",
+            "asker_anonymous": True,
+        },
+    )
+    stored = await env.reload_row(Question, id=qid)
+    assert int(stored.asker_anonymous) == 1
+    assert stored.created_by == "asker"
+
+    env.as_user(env.stranger)
+    resp = await env.client.get(
+        f"{PREFIX}/questions",
+        params={"page": 1, "page_size": 50, "keyword": env.t("df16匿名公开")},
+    )
+    body = _ok(resp)
+    assert body["status_code"] == 200
+    items = (body.get("data") or {}).get("questions") or []
+    hit = next((item for item in items if int(item.get("id")) == qid), None)
+    assert hit is not None
+    asker = hit.get("asker") or {}
+    assert asker.get("anonymous") is True
+    assert asker.get("display_name", "").startswith("匿名同事")
+    assert "real_name" not in asker
+    assert hit.get("created_by") == asker.get("display_name")
+    assert hit.get("created_by") != "asker"
+    aliases = await env.reload_all(AnonymousAlias, question_id=qid)
+    assert len(aliases) == 1
+    stored_again = await env.reload_row(Question, id=qid)
+    assert stored_again.created_by == "asker"
+
+
+async def test_df17_directed_anonymous_masks_invited_viewer(flow_env):
+    """定向匿名：库内仍是真名；受邀专家详情只见别名，且须预存转公开选项。"""
+    env = flow_env
+    expert = await env.seed_expert(user_id=201, name="专家甲")
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df17定向匿名",
+            "description": "定向匿名正文",
+            "business_domain": "营销",
+            "question_type": "directed",
+            "invited_expert_ids": [expert.id],
+            "asker_anonymous": True,
+            "asker_reveal_on_public": False,
+        },
+    )
+    stored = await env.reload_row(Question, id=qid)
+    assert int(stored.asker_anonymous) == 1
+    assert int(stored.asker_reveal_on_public) == 0
+    assert stored.created_by == "asker"
+
+    env.as_user(env.user(201, name="专家甲"))
+    detail = _ok(await env.client.get(f"{PREFIX}/questions/{qid}"))
+    assert detail["status_code"] == 200
+    data = detail.get("data") or {}
+    asker = data.get("asker") or {}
+    assert asker.get("anonymous") is True
+    assert str(asker.get("display_name") or "").startswith("匿名同事")
+    assert "real_name" not in asker
+    assert data.get("created_by") == asker.get("display_name")
+    aliases = await env.reload_all(AnonymousAlias, question_id=qid)
+    assert len(aliases) == 1
+
+    again = _ok(await env.client.get(f"{PREFIX}/questions/{qid}"))
+    assert (again.get("data") or {}).get("created_by") == asker.get("display_name")
+    stored_again = await env.reload_row(Question, id=qid)
+    assert stored_again.created_by == "asker"
+    assert len(await env.reload_all(AnonymousAlias, question_id=qid)) == 1
+
+
+async def test_df18_list_shows_latest_answer_preview(flow_env):
+    """有回答的列表卡片带最新一条；后写的覆盖先写的；采纳后 preview.adopted 与 qa_answer 一致。"""
+    env = flow_env
+    expert = await env.seed_expert(user_id=201, name="专家甲")
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df18列表最新答",
+            "description": "公开正文",
+            "business_domain": "营销",
+            "question_type": "public",
+        },
+    )
+
+    async def _list_hit():
+        env.as_user(env.stranger)
+        resp = await env.client.get(
+            f"{PREFIX}/questions",
+            params={"page": 1, "page_size": 50, "keyword": env.t("df18列表最新答")},
+        )
+        body = _ok(resp)
+        assert body["status_code"] == 200
+        items = (body.get("data") or {}).get("questions") or []
+        hit = next((item for item in items if int(item.get("id")) == qid), None)
+        assert hit is not None
+        return hit
+
+    empty = await _list_hit()
+    assert not empty.get("latest_answer")
+
+    env.as_user(env.user(201, name="专家甲"))
+    first = await _create_answer(env, qid, "第一答")
+    second = await _create_answer(env, qid, "第二答")
+    preview = (await _list_hit()).get("latest_answer") or {}
+    assert preview.get("id") == second
+    assert "第二答" in str(preview.get("excerpt") or "")
+    assert "第一答" not in str(preview.get("excerpt") or "")
+    assert preview.get("adopted") is False
+    assert "专家甲" in str(preview.get("expert_name") or "")
+    rows = await env.reload_all(Answer, question_id=qid)
+    latest = max(rows, key=lambda row: int(row.id))
+    assert int(latest.id) == second
+    assert int(latest.status) != 3
+
+    env.as_user(env.asker)
+    adopt = _ok(await env.client.post(f"{PREFIX}/questions/{qid}/adopt", json={"answer_id": second}))
+    assert adopt["status_code"] == 200
+    adopted_preview = (await _list_hit()).get("latest_answer") or {}
+    assert adopted_preview.get("id") == second
+    assert adopted_preview.get("adopted") is True
+    stored = await env.reload_row(Answer, id=second)
+    assert stored.adopted in (1, True)
+    assert first != second
+
+
+async def test_df19_followup_and_comment_anonymous_inheritance(flow_env):
+    """追问继承提问匿名；自评继承回答匿名；评他人独立选择。接口+落库+再读。"""
+    env = flow_env
+    expert = await env.seed_expert(user_id=201, name="专家甲")
+    other = await env.seed_expert(user_id=202, name="专家乙")
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df19匿名追问",
+            "description": "匿名正文",
+            "business_domain": "营销",
+            "question_type": "public",
+            "asker_anonymous": True,
+        },
+    )
+    stored_q = await env.reload_row(Question, id=qid)
+    assert int(stored_q.asker_anonymous) == 1
+
+    follow = _ok(
+        await env.client.post(
+            f"{PREFIX}/comments",
+            json={
+                "answer_id": 0,
+                "question_id": qid,
+                "content": "追问一句",
+                "is_follow_up": True,
+                "anonymous": False,
+            },
+        )
+    )
+    assert follow["status_code"] == 200
+    follow_id = int((follow.get("data") or {}).get("id") or 0)
+    follow_row = await env.reload_row(Comment, id=follow_id)
+    assert int(follow_row.anonymous) == 1
+    assert follow_row.user_name == "asker"
+
+    env.as_user(env.stranger)
+    listed = _ok(
+        await env.client.post(
+            f"{PREFIX}/allcomments",
+            json={"answer_id": 0, "question_id": qid, "page": 1, "page_size": 20},
+        )
+    )
+    assert listed["status_code"] == 200
+    comments = (listed.get("data") or {}).get("comments") or []
+    hit = next((item for item in comments if int(item.get("id")) == follow_id), None)
+    assert hit is not None
+    assert str(hit.get("user_name") or "").startswith("匿名同事")
+    assert hit.get("user_name") != "asker"
+    assert (hit.get("author") or {}).get("anonymous") is True
+    follow_again = await env.reload_row(Comment, id=follow_id)
+    assert follow_again.user_name == "asker"
+
+    env.as_user(env.user(201, name=expert.expert_name))
+    aid = await _create_answer_anonymous(env, qid, "匿名首答")
+    answer_row = await env.reload_row(Answer, id=aid)
+    assert int(answer_row.anonymous) == 1
+    assert answer_row.expert_name == expert.expert_name
+
+    env.as_user(env.stranger)
+    answers_body = _ok(await env.client.get(f"{PREFIX}/answers/{qid}"))
+    assert answers_body["status_code"] == 200
+    answers = (answers_body.get("data") or {}).get("answers") or []
+    ans_hit = next((item for item in answers if int(item.get("id")) == aid), None)
+    assert ans_hit is not None
+    assert str(ans_hit.get("expert_name") or "").startswith("匿名同事")
+    assert ans_hit.get("expert_name") != expert.expert_name
+    assert (ans_hit.get("author") or {}).get("anonymous") is True
+    answer_again = await env.reload_row(Answer, id=aid)
+    assert answer_again.expert_name == expert.expert_name
+
+    env.as_user(env.user(201, name=expert.expert_name))
+    self_comment = _ok(
+        await env.client.post(
+            f"{PREFIX}/comments",
+            json={"answer_id": aid, "content": "自评补充", "anonymous": False},
+        )
+    )
+    assert self_comment["status_code"] == 200
+    self_id = int((self_comment.get("data") or {}).get("id") or 0)
+    self_row = await env.reload_row(Comment, id=self_id)
+    assert int(self_row.anonymous) == 1
+
+    env.as_user(env.user(202, name=other.expert_name))
+    other_comment = _ok(
+        await env.client.post(
+            f"{PREFIX}/comments",
+            json={"answer_id": aid, "content": "他人匿名评", "anonymous": True},
+        )
+    )
+    assert other_comment["status_code"] == 200
+    other_id = int((other_comment.get("data") or {}).get("id") or 0)
+    other_row = await env.reload_row(Comment, id=other_id)
+    assert int(other_row.anonymous) == 1
+
+    env.as_user(env.stranger)
+    listed_again = _ok(
+        await env.client.post(
+            f"{PREFIX}/allcomments",
+            json={"answer_id": aid, "question_id": qid, "page": 1, "page_size": 20},
+        )
+    )
+    assert listed_again["status_code"] == 200
+    thread = (listed_again.get("data") or {}).get("comments") or []
+    self_hit = next((item for item in thread if int(item.get("id")) == self_id), None)
+    other_hit = next((item for item in thread if int(item.get("id")) == other_id), None)
+    assert self_hit is not None and str(self_hit.get("user_name") or "").startswith("匿名同事")
+    assert other_hit is not None and str(other_hit.get("user_name") or "").startswith("匿名同事")
+    assert self_hit.get("user_name") != expert.expert_name
+    stored_self = await env.reload_row(Comment, id=self_id)
+    stored_other = await env.reload_row(Comment, id=other_id)
+    assert stored_self.user_name == expert.expert_name
+    assert stored_other.user_name == other.expert_name
+
+
+async def test_df20_directed_anonymous_answer_without_reveal_rejected(flow_env):
+    """定向匿名回答未选转公开姓名：18311，qa_answer 无脏行。"""
+    env = flow_env
+    expert = await env.seed_expert(user_id=201, name="专家甲")
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df20定向匿名答",
+            "description": "定向正文",
+            "business_domain": "营销",
+            "question_type": "directed",
+            "invited_expert_ids": [expert.id],
+            "asker_anonymous": True,
+            "asker_reveal_on_public": False,
+        },
+    )
+    before = await env.reload_all(Answer, question_id=qid)
+    env.as_user(env.user(201, name=expert.expert_name))
+    resp = await env.client.post(
+        f"{PREFIX}/answers",
+        json={"question_id": qid, "content": "不该写入", "anonymous": True},
+    )
+    body = _ok(resp)
+    assert body["status_code"] == 18311
+    after = await env.reload_all(Answer, question_id=qid)
+    assert len(after) == len(before)
+
+
+async def _inbox_rows(env, title: str) -> list[dict]:
+    """按站内信正文标题查 inbox_message，核转公开通知是否带 instance_id。"""
+    async with AsyncSession(env.engine, expire_on_commit=False) as session:
+        rows = (
+            (
+                await session.execute(
+                    text(
+                        "SELECT id, action_code, receiver, content FROM inbox_message "
+                        "WHERE CAST(content AS CHAR) LIKE :p ORDER BY id"
+                    ),
+                    {"p": f"%{title}%"},
+                )
+            )
+            .mappings()
+            .all()
+        )
+        return [dict(row) for row in rows]
+
+
+def _receiver_ids(raw) -> set[int]:
+    if isinstance(raw, list):
+        return {int(uid) for uid in raw}
+    if isinstance(raw, str):
+        parsed = json.loads(raw)
+        return {int(uid) for uid in parsed}
+    return set()
+
+
+async def test_df21_publish_todo_and_late_answerer_joins(flow_env, monkeypatch):
+    """转公开先通知相关人，待我处理有 pending task；后回答的受邀专家加入会签。"""
+    from bisheng.approval.domain.models.approval_instance import ApprovalInstance, ApprovalTask
+    from bisheng.qa_expert.domain.publish_service import PublishService
+
+    async def live_notify(self, event, question, extra=None):
+        await self._send_inbox(event, question, extra or {})
+
+    monkeypatch.setattr(PublishService, "_notify", live_notify)
+    env = flow_env
+    first = await env.seed_expert(user_id=201, name="专家甲")
+    second = await env.seed_expert(user_id=202, name="专家乙")
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df21转公开待办",
+            "description": "定向",
+            "business_domain": "steel",
+            "question_type": "directed",
+            "invited_expert_ids": [first.id, second.id],
+            "asker_reveal_on_public": True,
+        },
+    )
+    env.as_user(env.user(201, name="专家甲"))
+    aid = await _create_answer(env, qid, "甲先答")
+    env.as_user(env.asker)
+    _ok(await env.client.post(f"{PREFIX}/questions/{qid}/adopt", json={"answer_id": aid}))
+    created = _ok(await env.client.post(f"{PREFIX}/questions/{qid}/publish-requests", json={"duration_days": 3}))
+    assert created["status_code"] == 200
+    request = await env.reload_row(PublishRequest, question_id=qid)
+    assert request is not None
+    assert request.status == "pending"
+    approvers = await env.reload_all(PublishApprover, request_id=request.id)
+    assert any(int(row.user_id) == env.uid(201) and row.decision == "pending" for row in approvers)
+    assert not any(int(row.user_id) == env.uid(202) for row in approvers)
+    instance = await env.reload_row(
+        ApprovalInstance,
+        business_key=f"qa_publish:{request.id}",
+        scenario_code="qa_question_publish",
+    )
+    assert instance is not None
+    tasks = await env.reload_all(ApprovalTask, instance_id=instance.id)
+    pending_users = {int(row.approver_user_id) for row in tasks if row.status == "pending"}
+    assert env.uid(201) in pending_users
+    assert env.uid(202) not in pending_users
+    title = env.t("df21转公开待办")
+    started_msgs = [
+        row for row in await _inbox_rows(env, title) if "publish_started" in str(row.get("action_code") or "")
+    ]
+    assert started_msgs
+    started = started_msgs[-1]
+    assert env.uid(201) in _receiver_ids(started["receiver"])
+    assert env.uid(202) not in _receiver_ids(started["receiver"])
+    assert str(instance.id) in str(started["content"])
+
+    env.as_user(env.user(202, name="专家乙"))
+    later = await _create_answer(env, qid, "乙后答")
+    assert later
+    approvers_after = await env.reload_all(PublishApprover, request_id=request.id)
+    assert any(int(row.user_id) == env.uid(202) and row.decision == "pending" for row in approvers_after)
+    tasks_after = await env.reload_all(ApprovalTask, instance_id=instance.id)
+    pending_after = {int(row.approver_user_id) for row in tasks_after if row.status == "pending"}
+    assert env.uid(202) in pending_after
+    still_pending = await env.reload_row(PublishRequest, id=request.id)
+    assert still_pending.status == "pending"
+    added_msgs = [row for row in await _inbox_rows(env, title) if "approver_added" in str(row.get("action_code") or "")]
+    assert added_msgs
+    assert env.uid(202) in _receiver_ids(added_msgs[-1]["receiver"])
+    still_tasks = await env.reload_all(ApprovalTask, instance_id=instance.id)
+    assert {int(row.approver_user_id) for row in still_tasks if row.status == "pending"} == pending_after

--- a/src/backend/test/qa_expert/test_expert_admin_api.py
+++ b/src/backend/test/qa_expert/test_expert_admin_api.py
@@ -1,0 +1,74 @@
+# ruff: noqa: RUF002
+"""T029：专家写接口鉴权 API。"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from bisheng.common.dependencies.user_deps import UserPayload
+from bisheng.common.errcode.base import BaseErrorCode
+from bisheng.common.errcode.qa_expert import QaExpertAdminRequiredError
+from bisheng.qa_expert.api import endpoints
+from bisheng.qa_expert.api.router import router
+
+
+def _portal_admin():
+    return SimpleNamespace(
+        user_id=9,
+        user_name="admin",
+        tenant_id=1,
+        is_admin=lambda: False,
+        role="管理员",
+        is_global_super=False,
+    )
+
+
+def _staff():
+    return SimpleNamespace(
+        user_id=2,
+        user_name="staff",
+        tenant_id=1,
+        is_admin=lambda: False,
+        role="员工",
+        is_global_super=False,
+    )
+
+
+def _app(service, user):
+    app = FastAPI()
+
+    @app.exception_handler(BaseErrorCode)
+    async def _biz(_req, exc: BaseErrorCode):
+        from fastapi.responses import JSONResponse
+
+        return JSONResponse({"status_code": exc.code, "status_message": exc.message, "data": None})
+
+    app.include_router(router, prefix="/api/v1")
+    app.dependency_overrides[UserPayload.get_login_user] = lambda: user
+    app.dependency_overrides[endpoints.get_expert_service] = lambda: service
+    return app
+
+
+def test_disable_enable_ok_for_portal_admin():
+    svc = SimpleNamespace(
+        disable_expert=AsyncMock(return_value={"id": 5, "status": 0}),
+        enable_expert=AsyncMock(return_value={"id": 5, "status": 1}),
+        delete_expert=AsyncMock(return_value=True),
+    )
+    client = TestClient(_app(svc, _portal_admin()))
+    disabled = client.post("/api/v1/qa_experts/experts/5/disable")
+    assert disabled.json()["status_code"] == 200
+    enabled = client.post("/api/v1/qa_experts/experts/5/enable")
+    assert enabled.json()["data"]["status"] == 1
+    deleted = client.delete("/api/v1/qa_experts/experts/5")
+    assert deleted.json()["status_code"] == 200
+    svc.delete_expert.assert_awaited()
+
+
+def test_staff_disable_returns_18307():
+    svc = SimpleNamespace(disable_expert=AsyncMock(side_effect=QaExpertAdminRequiredError()))
+    client = TestClient(_app(svc, _staff()))
+    resp = client.post("/api/v1/qa_experts/experts/5/disable")
+    assert resp.json()["status_code"] == 18307

--- a/src/backend/test/qa_expert/test_expert_status.py
+++ b/src/backend/test/qa_expert/test_expert_status.py
@@ -1,0 +1,93 @@
+# ruff: noqa: RUF002
+"""T018：专家停用/恢复、非管理员 18307、DELETE 映射为停用。"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from bisheng.common.errcode.qa_expert import QaExpertAdminRequiredError, QaExpertDisabledError
+from bisheng.qa_expert.domain.schemas import ExpertCreateRequest, QuestionCreateRequest
+from bisheng.qa_expert.domain.services import ExpertService, QuestionService
+
+
+def _admin() -> SimpleNamespace:
+    return SimpleNamespace(user_id=9, user_name="admin", is_admin=lambda: False, role="管理员", is_global_super=False)
+
+
+def _staff() -> SimpleNamespace:
+    return SimpleNamespace(user_id=2, user_name="staff", is_admin=lambda: False, role="员工", is_global_super=False)
+
+
+def _expert_service() -> ExpertService:
+    svc = ExpertService()
+    svc.repository = MagicMock()
+    svc.publish_service = MagicMock()
+    svc.publish_service.on_expert_disabled = AsyncMock(return_value=[])
+    svc.repository.get_by_id = AsyncMock(return_value=SimpleNamespace(id=5, user_id=50, status=1, expert_name="专家"))
+    svc.repository.update = AsyncMock(
+        side_effect=lambda eid, **kw: SimpleNamespace(id=eid, user_id=50, expert_name="专家", **kw)
+    )
+    svc.repository.delete = AsyncMock()
+    svc.repository.get_by_user_name = AsyncMock(return_value=None)
+    svc.repository.create = AsyncMock(
+        return_value=SimpleNamespace(id=8, user_id=80, expert_name="新专家", depart_ment=None, status=1)
+    )
+    svc._sync_wechat_user_id = AsyncMock()
+    return svc
+
+
+async def test_non_admin_write_raises_18307():
+    svc = _expert_service()
+    with pytest.raises(QaExpertAdminRequiredError) as exc:
+        await svc.disable_expert(5, _staff())
+    assert exc.value.Code == 18307
+    svc.repository.update.assert_not_awaited()
+
+
+async def test_disable_sets_status_zero_and_notifies_publish():
+    svc = _expert_service()
+    row = await svc.disable_expert(5, _admin())
+    assert int(row.status) == 0
+    svc.publish_service.on_expert_disabled.assert_awaited_once_with(50)
+    svc.repository.delete.assert_not_awaited()
+
+
+async def test_delete_maps_to_disable_not_hard_delete():
+    svc = _expert_service()
+    await svc.delete_expert(5, user=_admin())
+    svc.repository.delete.assert_not_awaited()
+    svc.repository.update.assert_awaited()
+    assert svc.repository.update.await_args.kwargs.get("status") == 0
+
+
+async def test_enable_does_not_rejoin_ended_publish():
+    svc = _expert_service()
+    svc.repository.get_by_id = AsyncMock(return_value=SimpleNamespace(id=5, user_id=50, status=0, expert_name="专家"))
+    row = await svc.enable_expert(5, _admin())
+    assert int(row.status) == 1
+    svc.publish_service.on_expert_disabled.assert_not_awaited()
+
+
+async def test_disabled_expert_cannot_be_invited():
+    qsvc = QuestionService()
+    qsvc.expert_repo = MagicMock()
+    qsvc.expert_repo.get_by_id = AsyncMock(return_value=SimpleNamespace(id=5, user_id=50, status=0, expert_name="专家"))
+    with pytest.raises(QaExpertDisabledError):
+        await qsvc._validate_invites(
+            1,
+            "directed",
+            [5],
+            QuestionCreateRequest(
+                title="题",
+                description="描",
+                business_domain="steel",
+                asker_reveal_on_public=True,
+            ),
+        )
+
+
+async def test_create_expert_requires_admin():
+    svc = _expert_service()
+    with pytest.raises(QaExpertAdminRequiredError):
+        await svc.create_expert(ExpertCreateRequest(expert_name="x", user_id=3), user=_staff())

--- a/src/backend/test/qa_expert/test_inbox_notify.py
+++ b/src/backend/test/qa_expert/test_inbox_notify.py
@@ -1,0 +1,75 @@
+# ruff: noqa: RUF002
+"""T021：邀请/回答/采纳/转公开走 inbox；匿名触发人用别名。"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from bisheng.qa_expert.domain.identity import IdentityService
+from bisheng.qa_expert.domain.publish_service import PublishService
+from bisheng.qa_expert.domain.services import AnswerService, QuestionService
+
+
+async def test_invite_answer_adopt_publish_send_inbox():
+    qsvc = QuestionService()
+    qsvc._send_expert_invitation_inbox_notice = AsyncMock()
+    asvc = AnswerService()
+    asvc._send_answer_notification = AsyncMock()
+    qsvc._send_adoption_notification = AsyncMock()
+    pub = PublishService()
+    pub.notify = AsyncMock()
+
+    await qsvc._send_expert_invitation_inbox_notice(
+        SimpleNamespace(id=1, invited_experts="5", title="t", description="d"), 1, "asker"
+    )
+    await asvc._send_answer_notification(
+        SimpleNamespace(id=1, user_id=1, title="t"),
+        SimpleNamespace(id=2, expert_name="匿名同事A", expert_id=5, content="a"),
+    )
+    await qsvc._send_adoption_notification(
+        SimpleNamespace(id=1, user_id=1, title="t"), SimpleNamespace(id=2, expert_id=5, content="a")
+    )
+    await pub._notify("publish_started", SimpleNamespace(id=1, title="t", user_id=1), extra={"request_id": 9})
+
+    qsvc._send_expert_invitation_inbox_notice.assert_awaited()
+    asvc._send_answer_notification.assert_awaited()
+    qsvc._send_adoption_notification.assert_awaited()
+    pub.notify.assert_awaited()
+
+
+async def test_anonymous_sender_uses_alias_not_real_name():
+    svc = IdentityService()
+    svc.alias_repo = MagicMock()
+    svc.alias_repo.get_by_question_user = AsyncMock(return_value=None)
+    svc.alias_repo.next_alias_ord = AsyncMock(return_value=1)
+    svc.alias_repo.create = AsyncMock(side_effect=lambda row: row)
+    view = await svc.mask_identity(
+        SimpleNamespace(user_id=9, is_admin=lambda: False, role=None),
+        question_id=1,
+        user_id=50,
+        real_name="李专家",
+        anonymous=True,
+        question_type="directed",
+        reveal_on_public=0,
+    )
+    assert view.display_name == "匿名同事A"
+    assert "李专家" not in view.display_name
+
+
+async def test_stale_publish_decision_rejected_after_ended():
+    pub = PublishService()
+    pub.request_repo = MagicMock()
+    pub.approver_repo = MagicMock()
+    pub.request_repo.get_by_id = AsyncMock(
+        return_value=SimpleNamespace(
+            id=3,
+            status="ended",
+            expire_at=__import__("datetime").datetime(2099, 1, 1),
+            question_id=1,
+        )
+    )
+    import pytest
+
+    from bisheng.common.errcode.qa_expert import QaExpertPublishNotAllowedError
+
+    with pytest.raises(QaExpertPublishNotAllowedError):
+        await pub.decide_publish(3, SimpleNamespace(user_id=1), "approved")

--- a/src/backend/test/qa_expert/test_negative_guards.py
+++ b/src/backend/test/qa_expert/test_negative_guards.py
@@ -1,0 +1,77 @@
+# ruff: noqa: RUF002
+"""T022：无 closed 状态写入；专家库管理员不是超管；moderate-delete 拒绝门户管理员。"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from bisheng.common.errcode.points import PointsPermissionDeniedError
+from bisheng.points.domain.services.points_auth import is_platform_super_admin
+from bisheng.qa_expert.domain.capability import is_expert_library_admin
+from bisheng.qa_expert.domain.moderate_delete_service import ModerateDeleteService
+from bisheng.qa_expert.domain.question_query import question_display_status
+from bisheng.qa_expert.domain.schemas import QuestionCreateRequest
+from bisheng.qa_expert.domain.services import QuestionService
+
+
+def test_display_status_never_closed():
+    q = SimpleNamespace(adopt_count=0, answer_count=0)
+    assert question_display_status(q) == "unanswered"
+    q.answer_count = 2
+    assert question_display_status(q) == "pending_adopt"
+    q.adopt_count = 1
+    assert question_display_status(q) == "solved"
+    assert question_display_status(q) != "closed"
+
+
+def test_portal_admin_role_is_not_global_super():
+    user = SimpleNamespace(
+        user_id=3,
+        user_name="portal-admin",
+        role="管理员",
+        is_admin=lambda: False,
+        is_global_super=False,
+    )
+    assert is_expert_library_admin(user) is True
+    assert is_platform_super_admin(user) is False
+
+
+@pytest.mark.asyncio
+async def test_expert_library_admin_cannot_moderate_delete():
+    svc = ModerateDeleteService()
+    svc.question_repo = MagicMock()
+    operator = SimpleNamespace(
+        user_id=3,
+        role="管理员",
+        is_admin=lambda: False,
+        is_global_super=False,
+    )
+    with pytest.raises(PointsPermissionDeniedError):
+        await svc.moderate_delete(operator=operator, target_type="question", target_id=1)
+
+
+async def test_create_question_does_not_write_closed_status():
+    svc = QuestionService()
+    svc.repository = MagicMock()
+    svc.expert_repo = MagicMock()
+    svc.invite_repo = MagicMock()
+    svc.invite_repo.create_many = AsyncMock()
+    svc._send_expert_invitation_inbox_notice = AsyncMock()
+    svc._resolve_question = AsyncMock(side_effect=lambda q: q)
+
+    captured = {}
+
+    async def fake_create(question):
+        captured["status"] = getattr(question, "status", None)
+        question.id = 1
+        return question
+
+    svc.repository.create = AsyncMock(side_effect=fake_create)
+    from unittest.mock import patch
+
+    req = QuestionCreateRequest(title="t", description="d", business_domain="steel")
+    with patch("bisheng.qa_expert.domain.services.RealtimeQaQuestionFact.record_success", new_callable=AsyncMock):
+        await svc.create_question(1, req, "asker", tenant_id=1)
+    assert captured.get("status") in (None, 0)
+    assert captured.get("status") != 2

--- a/src/backend/test/qa_expert/test_publish_api.py
+++ b/src/backend/test/qa_expert/test_publish_api.py
@@ -1,0 +1,61 @@
+# ruff: noqa: RUF002
+"""T027：转公开 API。"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from bisheng.common.dependencies.user_deps import UserPayload
+from bisheng.common.errcode.base import BaseErrorCode
+from bisheng.common.errcode.qa_expert import QaExpertPublishDurationInvalidError
+from bisheng.qa_expert.api import endpoints
+from bisheng.qa_expert.api.router import router
+
+
+def _user():
+    return SimpleNamespace(
+        user_id=1,
+        user_name="asker",
+        tenant_id=1,
+        is_admin=lambda: False,
+        role=None,
+        is_global_super=False,
+    )
+
+
+def _app(service):
+    app = FastAPI()
+
+    @app.exception_handler(BaseErrorCode)
+    async def _biz(_req, exc: BaseErrorCode):
+        from fastapi.responses import JSONResponse
+
+        return JSONResponse({"status_code": exc.code, "status_message": exc.message, "data": None})
+
+    app.include_router(router, prefix="/api/v1")
+    app.dependency_overrides[UserPayload.get_login_user] = _user
+    app.dependency_overrides[endpoints.get_publish_service] = lambda: service
+    return app
+
+
+def test_create_publish_request_and_approve():
+    svc = SimpleNamespace(
+        create_publish_request=AsyncMock(return_value={"id": 7, "status": "pending", "duration_days": 3}),
+        decide_publish=AsyncMock(return_value={"id": 7, "status": "approved"}),
+        get_request=AsyncMock(return_value={"id": 7, "status": "pending"}),
+    )
+    client = TestClient(_app(svc))
+    created = client.post("/api/v1/qa_experts/questions/20/publish-requests", json={"duration_days": 3})
+    assert created.json()["status_code"] == 200
+    assert created.json()["data"]["duration_days"] == 3
+    approved = client.post("/api/v1/qa_experts/publish-requests/7/approve")
+    assert approved.json()["data"]["status"] == "approved"
+
+
+def test_invalid_duration_18310():
+    svc = SimpleNamespace(create_publish_request=AsyncMock(side_effect=QaExpertPublishDurationInvalidError()))
+    client = TestClient(_app(svc))
+    resp = client.post("/api/v1/qa_experts/questions/20/publish-requests", json={"duration_days": 2})
+    assert resp.json()["status_code"] == 18310

--- a/src/backend/test/qa_expert/test_publish_expire_task.py
+++ b/src/backend/test/qa_expert/test_publish_expire_task.py
@@ -1,0 +1,33 @@
+# ruff: noqa: RUF002
+"""T031：转公开到期任务。"""
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from bisheng.qa_expert.domain.publish_service import PUBLISH_EXPIRED, PublishService
+
+
+async def test_expire_pending_marks_expired_and_notifies():
+    svc = PublishService()
+    svc.request_repo = MagicMock()
+    svc.question_repo = MagicMock()
+    svc.notify = AsyncMock()
+    now = datetime(2026, 8, 20, 12, 0, 0)
+    row = SimpleNamespace(
+        id=4,
+        question_id=20,
+        status="pending",
+        expire_at=datetime(2026, 8, 18, 12, 0, 0),
+        tenant_id=1,
+    )
+    svc.request_repo.list_expired_pending = AsyncMock(return_value=[row])
+    svc.question_repo.get_by_id = AsyncMock(
+        return_value=SimpleNamespace(id=20, title="定向", user_id=1, active_publish_request_id=4)
+    )
+    svc.request_repo.update = AsyncMock()
+    svc.question_repo.update = AsyncMock()
+    count = await svc.expire_pending(now=now, tenant_id=1)
+    assert count == 1
+    assert svc.request_repo.update.await_args.kwargs["status"] == PUBLISH_EXPIRED
+    svc.notify.assert_awaited()

--- a/src/backend/test/qa_expert/test_publish_request.py
+++ b/src/backend/test/qa_expert/test_publish_request.py
@@ -22,6 +22,7 @@ from bisheng.qa_expert.domain.publish_service import (
     PUBLISH_PENDING,
     PUBLISH_REJECTED,
     PublishService,
+    serialize_publish_request,
 )
 
 
@@ -208,6 +209,40 @@ async def test_asker_disabled_ends_request():
     svc.request_repo.get_pending_by_question = AsyncMock(return_value=_request())
     result = await svc.on_asker_disabled(20)
     assert result.status == PUBLISH_ENDED
+
+
+async def test_asker_initiator_is_auto_approved():
+    """提问者发起转公开：本人审批行直接 approved，回答专家仍 pending。"""
+    svc = _service()
+    now = datetime(2026, 8, 16, 12, 0, 0)
+    rows = await svc._build_approvers(_question(), _request(), _user(user_id=1), now)
+    by_user = {int(row.user_id): row for row in rows}
+    assert by_user[1].decision == DECISION_APPROVED
+    assert by_user[1].decided_at == now
+    assert by_user[50].decision == DECISION_PENDING
+    assert by_user[50].decided_at is None
+
+
+def test_serialize_exposes_viewer_decision():
+    payload = serialize_publish_request(_request(), viewer_decision="approved")
+    assert payload["viewer_decision"] == "approved"
+    assert payload["status"] == PUBLISH_PENDING
+
+
+async def test_answerer_initiator_is_auto_approved():
+    """回答专家发起转公开：该专家默认同意，提问者仍需审批。"""
+    svc = _service()
+    now = datetime(2026, 8, 16, 12, 0, 0)
+    rows = await svc._build_approvers(
+        _question(),
+        _request(initiator_user_id=50),
+        _user(user_id=50),
+        now,
+    )
+    by_user = {int(row.user_id): row for row in rows}
+    assert by_user[1].decision == DECISION_PENDING
+    assert by_user[50].decision == DECISION_APPROVED
+    assert by_user[50].decided_at == now
 
 
 async def test_extend_one_day_capped_at_three():

--- a/src/backend/test/qa_expert/test_publish_request.py
+++ b/src/backend/test/qa_expert/test_publish_request.py
@@ -1,0 +1,221 @@
+# ruff: noqa: RUF002
+"""T016：转公开有效期、同题 pending、不可改口、默认同意、过期、延期、通过后资格快照。"""
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from bisheng.common.errcode.qa_expert import (
+    QaExpertPublishConflictError,
+    QaExpertPublishDurationInvalidError,
+    QaExpertPublishNotAllowedError,
+)
+from bisheng.qa_expert.domain.publish_service import (
+    DECISION_APPROVED,
+    DECISION_DEFAULT_APPROVED,
+    DECISION_PENDING,
+    PUBLISH_APPROVED,
+    PUBLISH_ENDED,
+    PUBLISH_EXPIRED,
+    PUBLISH_PENDING,
+    PUBLISH_REJECTED,
+    PublishService,
+)
+
+
+def _user(*, user_id: int, admin: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(user_id=user_id, user_name=f"u{user_id}", is_admin=lambda: admin, role=None)
+
+
+def _question(**kwargs) -> SimpleNamespace:
+    data = {
+        "id": 20,
+        "user_id": 1,
+        "title": "定向题",
+        "question_type": "directed",
+        "adopt_count": 1,
+        "answer_count": 1,
+        "status": 1,
+        "tenant_id": 1,
+        "active_publish_request_id": None,
+        "content_locked": 1,
+    }
+    data.update(kwargs)
+    return SimpleNamespace(**data)
+
+
+def _request(**kwargs) -> SimpleNamespace:
+    data = {
+        "id": 7,
+        "question_id": 20,
+        "initiator_user_id": 1,
+        "status": PUBLISH_PENDING,
+        "duration_days": 3,
+        "expire_at": datetime(2026, 8, 18, 12, 0, 0),
+        "extension_days": 0,
+        "version": 0,
+        "tenant_id": 1,
+    }
+    data.update(kwargs)
+    return SimpleNamespace(**data)
+
+
+def _approver(**kwargs) -> SimpleNamespace:
+    data = {
+        "id": 1,
+        "request_id": 7,
+        "user_id": 1,
+        "role_in_request": "asker",
+        "decision": DECISION_PENDING,
+        "decided_at": None,
+    }
+    data.update(kwargs)
+    return SimpleNamespace(**data)
+
+
+def _service() -> PublishService:
+    svc = PublishService()
+    svc.question_repo = MagicMock()
+    svc.answer_repo = MagicMock()
+    svc.invite_repo = MagicMock()
+    svc.expert_repo = MagicMock()
+    svc.request_repo = MagicMock()
+    svc.approver_repo = MagicMock()
+    svc.eligibility_repo = MagicMock()
+    svc.notify = AsyncMock()
+    svc.question_repo.get_by_id_for_update = AsyncMock(return_value=_question())
+    svc.question_repo.get_by_id = AsyncMock(return_value=_question())
+    svc.question_repo.update = AsyncMock()
+    svc.invite_repo.list_user_ids_by_question_ids = AsyncMock(return_value={20: {50}})
+    svc.expert_repo.get_by_user_id = AsyncMock(return_value=SimpleNamespace(id=5, user_id=1, status=1))
+    svc.answer_repo.has_effective_answer = AsyncMock(return_value=False)
+    svc.answer_repo.list_all_by_question_id = AsyncMock(return_value=[SimpleNamespace(id=11, user_id=50, status=1)])
+    svc.request_repo.get_pending_by_question = AsyncMock(return_value=None)
+    svc.request_repo.create = AsyncMock(side_effect=lambda row: _request())
+    svc.request_repo.get_by_id = AsyncMock(return_value=_request())
+    svc.request_repo.update = AsyncMock(side_effect=lambda rid, **kw: _request(**kw, id=rid))
+    svc.request_repo.list_expired_pending = AsyncMock(return_value=[])
+    svc.approver_repo.create_many = AsyncMock()
+    svc.approver_repo.list_by_request = AsyncMock(
+        return_value=[
+            _approver(id=1, user_id=1, decision=DECISION_APPROVED),
+            _approver(id=2, user_id=50, role_in_request="answerer", decision=DECISION_PENDING),
+        ]
+    )
+    svc.approver_repo.get_for_user = AsyncMock(return_value=_approver(id=2, user_id=50, role_in_request="answerer"))
+    svc.approver_repo.update = AsyncMock()
+    svc.approver_repo.list_pending_for_user = AsyncMock(return_value=[])
+    svc.eligibility_repo.list_user_ids = AsyncMock(return_value=set())
+    svc.eligibility_repo.create_many = AsyncMock()
+    return svc
+
+
+async def test_invalid_duration_raises_18310():
+    svc = _service()
+    with pytest.raises(QaExpertPublishDurationInvalidError) as exc:
+        await svc.create_publish_request(20, _user(user_id=1), duration_days=2)
+    assert exc.value.Code == 18310
+    svc.request_repo.create.assert_not_awaited()
+
+
+async def test_duplicate_pending_raises_18306():
+    svc = _service()
+    svc.request_repo.get_pending_by_question = AsyncMock(return_value=_request())
+    with pytest.raises(QaExpertPublishConflictError) as exc:
+        await svc.create_publish_request(20, _user(user_id=1), duration_days=3)
+    assert exc.value.Code == 18306
+
+
+async def test_decision_cannot_be_changed():
+    svc = _service()
+    svc.request_repo.get_by_id = AsyncMock(return_value=_request())
+    svc.approver_repo.get_for_user = AsyncMock(return_value=_approver(id=2, user_id=50, decision=DECISION_APPROVED))
+    with pytest.raises(QaExpertPublishNotAllowedError):
+        await svc.decide_publish(7, _user(user_id=50), "rejected")
+    svc.approver_repo.update.assert_not_awaited()
+
+
+async def test_reject_keeps_directed_and_allows_retry():
+    svc = _service()
+    now = datetime(2026, 8, 15, 12, 0, 0)
+    result = await svc.decide_publish(7, _user(user_id=50), "rejected", now=now)
+    assert result.status == PUBLISH_REJECTED
+    svc.request_repo.update.assert_awaited()
+    svc.question_repo.update.assert_not_called()  # active_publish_request_id 为空时只关申请头
+    assert svc.eligibility_repo.create_many.await_count == 0
+
+
+async def test_all_approved_sets_public_and_writes_eligibility():
+    svc = _service()
+    now = datetime(2026, 8, 15, 12, 0, 0)
+
+    async def _update(row_id, **kwargs):
+        return _approver(id=row_id, user_id=50, decision=kwargs.get("decision"), decided_at=now)
+
+    svc.approver_repo.update = AsyncMock(side_effect=_update)
+
+    async def _list(_rid):
+        return [
+            _approver(id=1, user_id=1, decision=DECISION_APPROVED),
+            _approver(id=2, user_id=50, role_in_request="answerer", decision=DECISION_APPROVED),
+        ]
+
+    svc.approver_repo.list_by_request = AsyncMock(side_effect=_list)
+    result = await svc.decide_publish(7, _user(user_id=50), "approved", now=now)
+    assert result.status == PUBLISH_APPROVED
+    kwargs = svc.question_repo.update.await_args.kwargs
+    assert kwargs.get("question_type") == "public"
+    rows = svc.eligibility_repo.create_many.await_args.args[0]
+    user_ids = {int(r.user_id) for r in rows}
+    assert 50 in user_ids
+    assert 99 not in user_ids
+
+
+async def test_disabled_expert_default_approved_can_pass_silently():
+    svc = _service()
+    now = datetime(2026, 8, 15, 12, 0, 0)
+    pending_row = _approver(id=2, user_id=50, role_in_request="answerer", decision=DECISION_PENDING)
+    svc.approver_repo.list_pending_for_user = AsyncMock(return_value=[pending_row])
+    svc.request_repo.get_by_id = AsyncMock(return_value=_request())
+    svc.approver_repo.list_by_request = AsyncMock(
+        return_value=[
+            _approver(id=1, user_id=1, decision=DECISION_APPROVED),
+            _approver(id=2, user_id=50, decision=DECISION_DEFAULT_APPROVED),
+        ]
+    )
+    passed = await svc.on_expert_disabled(50, now=now)
+    assert passed == [7]
+    update_kw = svc.approver_repo.update.await_args.kwargs
+    assert update_kw["decision"] == DECISION_DEFAULT_APPROVED
+
+
+async def test_expire_pending_marks_expired():
+    svc = _service()
+    now = datetime(2026, 8, 20, 12, 0, 0)
+    svc.request_repo.list_expired_pending = AsyncMock(
+        return_value=[_request(expire_at=datetime(2026, 8, 18, 12, 0, 0))]
+    )
+    count = await svc.expire_pending(now=now, tenant_id=1)
+    assert count == 1
+    assert svc.request_repo.update.await_args.kwargs["status"] == PUBLISH_EXPIRED
+    svc.notify.assert_awaited()
+
+
+async def test_asker_disabled_ends_request():
+    svc = _service()
+    svc.request_repo.get_pending_by_question = AsyncMock(return_value=_request())
+    result = await svc.on_asker_disabled(20)
+    assert result.status == PUBLISH_ENDED
+
+
+async def test_extend_one_day_capped_at_three():
+    svc = _service()
+    now = datetime(2026, 8, 15, 12, 0, 0)
+    svc.request_repo.get_by_id = AsyncMock(return_value=_request(extension_days=2, expire_at=now + timedelta(days=1)))
+    updated = await svc.extend_one_day(7, _user(user_id=1), now=now)
+    assert updated.extension_days == 3
+    svc.request_repo.get_by_id = AsyncMock(return_value=_request(extension_days=3))
+    with pytest.raises(QaExpertPublishDurationInvalidError):
+        await svc.extend_one_day(7, _user(user_id=1), now=now)

--- a/src/backend/test/qa_expert/test_question_api.py
+++ b/src/backend/test/qa_expert/test_question_api.py
@@ -1,0 +1,176 @@
+# ruff: noqa: RUF002
+"""T023：问题 API TestClient。"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from bisheng.common.dependencies.user_deps import UserPayload
+from bisheng.common.errcode.base import BaseErrorCode
+from bisheng.common.errcode.qa_expert import QaExpertQuestionAccessDeniedError
+from bisheng.qa_expert.api import endpoints
+from bisheng.qa_expert.api.router import router
+
+
+def _user(*, user_id=1, admin=False, role=None, super_admin=False):
+    return SimpleNamespace(
+        user_id=user_id,
+        user_name=f"u{user_id}",
+        tenant_id=1,
+        is_admin=lambda: admin,
+        role=role,
+        is_global_super=super_admin,
+    )
+
+
+def _app(question_service, user):
+    app = FastAPI()
+
+    @app.exception_handler(BaseErrorCode)
+    async def _biz(_req, exc: BaseErrorCode):
+        from fastapi.responses import JSONResponse
+
+        return JSONResponse(
+            {"status_code": exc.code, "status_message": exc.message, "data": None},
+            status_code=200,
+        )
+
+    app.include_router(router, prefix="/api/v1")
+    app.dependency_overrides[UserPayload.get_login_user] = lambda: user
+    app.dependency_overrides[endpoints.get_question_service] = lambda: question_service
+    return app
+
+
+def test_create_and_get_question_related_docs_accessible_fields():
+    svc = SimpleNamespace()
+    created = {"id": 11, "title": "公开题", "question_type": "public"}
+    detail = SimpleNamespace(
+        id=11,
+        title="公开题",
+        description="正文",
+        related_docs="3-8",
+        related_doc_views=[
+            {
+                "id": "3-8",
+                "space_id": 3,
+                "file_id": 8,
+                "title": "规程",
+                "accessible": False,
+                "unavailable_reason": "forbidden",
+            }
+        ],
+        display_status="unanswered",
+        capabilities={"can_answer": False, "visible": True},
+        question_type="public",
+        content_locked=0,
+        model_dump=lambda: {
+            "id": 11,
+            "title": "公开题",
+            "description": "正文",
+            "related_docs": "3-8",
+        },
+    )
+    svc.create_question = AsyncMock(return_value=created)
+    svc.get_question_detail = AsyncMock(return_value=detail)
+    svc.list_questions = AsyncMock(return_value=([created], 1))
+    with patch("bisheng.qa_expert.api.endpoints.check_question_content"):
+        client = TestClient(_app(svc, _user()))
+        created_resp = client.post(
+            "/api/v1/qa_experts/questions",
+            json={"title": "公开题", "description": "正文", "business_domain": "steel", "question_type": "public"},
+        )
+    assert created_resp.status_code == 200
+    assert created_resp.json()["status_code"] == 200
+    detail_resp = client.get("/api/v1/qa_experts/questions/11")
+    body = detail_resp.json()["data"]
+    docs = body.get("related_docs") or body.get("related_doc_views")
+    assert docs[0]["accessible"] is False
+    assert docs[0]["unavailable_reason"] == "forbidden"
+    assert body["description"] == "正文"
+    assert body["capabilities"]["can_answer"] is False
+    assert body["display_status"] == "unanswered"
+
+
+def test_get_question_detail_includes_capabilities_without_related_docs():
+    """无关联文档时也必须下发 capabilities，否则详情页没有回答框/采纳。"""
+    svc = SimpleNamespace()
+    detail = SimpleNamespace(
+        id=12,
+        title="无文档",
+        description="正文",
+        related_docs=None,
+        related_doc_views=[],
+        display_status="unanswered",
+        capabilities={"can_answer": True, "visible": True, "can_adopt": True},
+        question_type="public",
+        content_locked=0,
+        model_dump=lambda: {
+            "id": 12,
+            "title": "无文档",
+            "description": "正文",
+            "related_docs": None,
+            "content_locked": 0,
+        },
+    )
+    svc.get_question_detail = AsyncMock(return_value=detail)
+    client = TestClient(_app(svc, _user()))
+    body = client.get("/api/v1/qa_experts/questions/12").json()["data"]
+    assert body["capabilities"]["can_answer"] is True
+    assert body["capabilities"]["can_adopt"] is True
+    assert body["display_status"] == "unanswered"
+    assert body["content_locked"] == 0
+
+
+def test_directed_detail_returns_18301():
+    svc = SimpleNamespace()
+    svc.get_question_detail = AsyncMock(side_effect=QaExpertQuestionAccessDeniedError())
+    client = TestClient(_app(svc, _user(user_id=99)))
+    resp = client.get("/api/v1/qa_experts/questions/9")
+    assert resp.json()["status_code"] == 18301
+
+
+def test_list_questions_redacts_anonymous_created_by():
+    """列表 JSON 匿名题不得下发 created_by 真名。"""
+    svc = SimpleNamespace()
+    row = SimpleNamespace(
+        id=21,
+        title="匿名公开",
+        created_by="gzx01",
+        asker={"display_name": "匿名同事A", "anonymous": True, "avatar_url": None},
+        display_status="unanswered",
+        model_dump=lambda: {
+            "id": 21,
+            "title": "匿名公开",
+            "created_by": "gzx01",
+            "business_domain": "营销",
+        },
+    )
+    svc.list_questions = AsyncMock(return_value=([row], 1))
+    client = TestClient(_app(svc, _user(user_id=99)))
+    body = client.get("/api/v1/qa_experts/questions").json()["data"]
+    hit = body["questions"][0]
+    assert hit["created_by"] == "匿名同事A"
+    assert hit["asker"]["display_name"] == "匿名同事A"
+    assert hit["asker"]["anonymous"] is True
+    assert "real_name" not in hit["asker"]
+
+
+def test_list_questions_includes_latest_answer_preview():
+    """列表 JSON 要把 latest_answer 一并打出，供卡片预览。"""
+    svc = SimpleNamespace()
+    row = SimpleNamespace(
+        id=21,
+        title="有回答",
+        latest_answer={"id": 9, "excerpt": "最新答", "expert_name": "gzx001", "adopted": True, "anonymous": False},
+        display_status="pending_adopt",
+        model_dump=lambda: {"id": 21, "title": "有回答", "answer_count": 1},
+    )
+    svc.list_questions = AsyncMock(return_value=([row], 1))
+    client = TestClient(_app(svc, _user(user_id=99)))
+    body = client.get("/api/v1/qa_experts/questions").json()["data"]
+    hit = body["questions"][0]
+    assert hit["latest_answer"]["excerpt"] == "最新答"
+    assert hit["latest_answer"]["expert_name"] == "gzx001"
+    assert hit["latest_answer"]["adopted"] is True

--- a/src/backend/test/qa_expert/test_question_service.py
+++ b/src/backend/test/qa_expert/test_question_service.py
@@ -1,0 +1,362 @@
+# ruff: noqa: RUF002
+"""T006：提问 / 列表 / 类似问题（仓储全 mock）。"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bisheng.common.errcode.qa_expert import (
+    QaExpertDisabledError,
+    QaExpertQuestionAccessDeniedError,
+)
+from bisheng.database.models.qa_expert import Question
+from bisheng.qa_expert.domain.capability import DISPLAY_PENDING_ADOPT, DISPLAY_SOLVED
+from bisheng.qa_expert.domain.question_query import FILTER_INVITED_ME, FILTER_MINE, normalize_list_filter
+from bisheng.qa_expert.domain.schemas import QuestionCreateRequest
+from bisheng.qa_expert.domain.services import InvalidInvitationError, QuestionService
+
+
+def _user(*, user_id: int, admin: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(user_id=user_id, user_name=f"u{user_id}", is_admin=lambda: admin, role=None)
+
+
+def _expert(*, expert_id: int = 5, user_id: int = 50, status: int = 1, expert_name: str = "专家") -> SimpleNamespace:
+    return SimpleNamespace(id=expert_id, user_id=user_id, status=status, expert_name=expert_name)
+
+
+def _question_row(**kwargs) -> SimpleNamespace:
+    data = {
+        "id": 10,
+        "user_id": 1,
+        "title": "公开题",
+        "question_type": "public",
+        "adopt_count": 0,
+        "answer_count": 0,
+        "invited_experts": None,
+        "created_by": "gzx01",
+        "asker_anonymous": 0,
+        "asker_reveal_on_public": None,
+        "tenant_id": 1,
+    }
+    data.update(kwargs)
+    return SimpleNamespace(**data)
+
+
+def _service() -> QuestionService:
+    svc = QuestionService()
+    svc.repository = MagicMock()
+    svc.expert_repo = MagicMock()
+    svc.expert_repo.get_by_ids = AsyncMock(return_value=[])
+    svc.invite_repo = MagicMock()
+    svc.answer_repo = MagicMock()
+    svc.invite_repo.create_many = AsyncMock()
+    svc.invite_repo.list_user_ids_by_question_ids = AsyncMock(return_value={})
+    svc.invite_repo.list_question_ids_for_user = AsyncMock(return_value=[])
+    svc._send_expert_invitation_inbox_notice = AsyncMock()
+    svc._resolve_question = AsyncMock(side_effect=lambda q: q)
+    svc.answer_repo.get_answer_vote_count = AsyncMock(return_value=0)
+    svc.answer_repo.list_latest_by_question_ids = AsyncMock(return_value={})
+
+    async def _fake_mask(_viewer, **kwargs):
+        anonymous = bool(int(kwargs.get("anonymous") or 0))
+        real_name = str(kwargs.get("real_name") or "")
+        display = "匿名同事A" if anonymous else real_name
+
+        def _to_dict(*, can_view_real_identity: bool):
+            payload = {"display_name": display, "anonymous": anonymous, "avatar_url": None}
+            if can_view_real_identity and anonymous:
+                payload["real_name"] = real_name
+                payload["real_user_id"] = kwargs.get("user_id")
+            return payload
+
+        return SimpleNamespace(to_dict=_to_dict)
+
+    svc.identity_service = MagicMock()
+    svc.identity_service.mask_identity = AsyncMock(side_effect=_fake_mask)
+    svc.identity_service.preload_for_questions = AsyncMock()
+    return svc
+
+
+def _create_request(**kwargs) -> QuestionCreateRequest:
+    payload = {
+        "title": "如何炼钢",
+        "description": "描述",
+        "business_domain": "steel",
+    }
+    payload.update(kwargs)
+    return QuestionCreateRequest(**payload)
+
+
+async def _create(svc: QuestionService, request: QuestionCreateRequest, user_id: int = 1):
+    async def fake_create(question: Question) -> Question:
+        question.id = 101
+        return question
+
+    svc.repository.create = AsyncMock(side_effect=fake_create)
+    with patch("bisheng.qa_expert.domain.services.RealtimeQaQuestionFact.record_success", new_callable=AsyncMock):
+        return await svc.create_question(user_id, request, "asker", tenant_id=1)
+
+
+def test_legacy_status_3_4_are_mine_and_invited_not_pending_adopt():
+    assert normalize_list_filter(status=3, list_filter=None) == FILTER_MINE
+    assert normalize_list_filter(status=4, list_filter=None) == FILTER_INVITED_ME
+    assert normalize_list_filter(status=3, list_filter=FILTER_INVITED_ME) == FILTER_INVITED_ME
+
+
+def test_stock_question_type_defaults_public():
+    assert Question(user_id=1, title="t", description="d", business_domain="b").question_type == "public"
+
+
+async def test_create_rejects_unauthenticated():
+    svc = _service()
+    with pytest.raises(QaExpertQuestionAccessDeniedError):
+        await svc.create_question(0, _create_request(), "anon")
+
+
+async def test_create_directed_requires_1_to_3_experts():
+    svc = _service()
+    with pytest.raises(InvalidInvitationError):
+        await _create(svc, _create_request(question_type="directed", invited_expert_ids=[]))
+    with pytest.raises(InvalidInvitationError):
+        await _create(
+            svc,
+            _create_request(question_type="directed", invited_expert_ids=[5, 6, 7, 8]),
+        )
+
+
+async def test_create_directed_writes_invites_and_type():
+    svc = _service()
+    svc.expert_repo.get_by_id = AsyncMock(return_value=_expert())
+    question = await _create(
+        svc,
+        _create_request(
+            question_type="directed",
+            invited_expert_ids=[5],
+            asker_reveal_on_public=True,
+        ),
+    )
+    persisted: Question = svc.repository.create.await_args.args[0]
+    assert persisted.question_type == "directed"
+    assert persisted.invited_experts == "5"
+    assert persisted.experts_names == "专家"
+    assert persisted.asker_anonymous == 0
+    assert persisted.asker_reveal_on_public is None
+    assert question.id == 101
+    svc.invite_repo.create_many.assert_awaited()
+    invites = svc.invite_repo.create_many.await_args.args[0]
+    assert len(invites) == 1
+    assert invites[0].expert_id == 5
+    assert invites[0].user_id == 50
+
+
+async def test_create_directed_anonymous_requires_reveal_and_persists():
+    """定向也可匿名；勾选后必须预选转公开姓名，并写入 qa_question。"""
+    svc = _service()
+    svc.expert_repo.get_by_id = AsyncMock(return_value=_expert())
+    with pytest.raises(InvalidInvitationError):
+        await _create(
+            svc,
+            _create_request(
+                question_type="directed",
+                invited_expert_ids=[5],
+                asker_anonymous=True,
+            ),
+        )
+    question = await _create(
+        svc,
+        _create_request(
+            question_type="directed",
+            invited_expert_ids=[5],
+            asker_anonymous=True,
+            asker_reveal_on_public=False,
+        ),
+    )
+    persisted: Question = svc.repository.create.await_args.args[0]
+    assert persisted.asker_anonymous == 1
+    assert persisted.asker_reveal_on_public == 0
+    assert persisted.question_type == "directed"
+    assert question.id == 101
+
+
+async def test_hydrate_invite_names_replaces_numeric_id_string():
+    svc = _service()
+    svc.expert_repo.get_by_ids = AsyncMock(return_value=[_expert(expert_id=5, expert_name="gzx001")])
+    question = _question_row(invited_experts="5", experts_names=None)
+    await svc._hydrate_invite_names([question])
+    assert question.experts_names == "gzx001"
+    named = _question_row(invited_experts="5", experts_names="gzx001")
+    svc.expert_repo.get_by_ids.reset_mock()
+    await svc._hydrate_invite_names([named])
+    svc.expert_repo.get_by_ids.assert_not_awaited()
+
+
+async def test_create_public_allows_0_to_3_and_defaults_type():
+    svc = _service()
+    question = await _create(svc, _create_request())
+    persisted: Question = svc.repository.create.await_args.args[0]
+    assert persisted.question_type == "public"
+    assert question.question_type == "public"
+    svc.invite_repo.create_many.assert_not_awaited()
+    svc.expert_repo.get_by_id = AsyncMock(
+        side_effect=[
+            _expert(expert_id=1, user_id=11),
+            _expert(expert_id=2, user_id=12),
+            _expert(expert_id=3, user_id=13),
+            _expert(expert_id=4, user_id=14),
+        ]
+    )
+    with pytest.raises(InvalidInvitationError):
+        await _create(svc, _create_request(question_type="public", invited_expert_ids=[1, 2, 3, 4]))
+
+
+async def test_create_rejects_self_invite_and_disabled_expert():
+    svc = _service()
+    svc.expert_repo.get_by_id = AsyncMock(return_value=_expert(expert_id=5, user_id=1, status=1))
+    with pytest.raises(InvalidInvitationError):
+        await _create(
+            svc, _create_request(question_type="directed", invited_expert_ids=[5], asker_reveal_on_public=False)
+        )
+    svc.expert_repo.get_by_id = AsyncMock(return_value=_expert(status=0))
+    with pytest.raises(QaExpertDisabledError):
+        await _create(
+            svc, _create_request(question_type="directed", invited_expert_ids=[5], asker_reveal_on_public=False)
+        )
+
+
+async def test_list_hides_directed_title_from_stranger():
+    svc = _service()
+    directed = _question_row(id=1, title="定向机密", question_type="directed", user_id=1)
+    public = _question_row(id=2, title="公开可见", question_type="public", user_id=1)
+    svc.repository.list_all = AsyncMock(return_value=([public], 1))
+    svc.invite_repo.list_user_ids_by_question_ids = AsyncMock(return_value={1: {50}})
+    items, total = await svc.list_questions(user=_user(user_id=99))
+    titles = [item.title for item in items]
+    assert "定向机密" not in titles
+    assert "公开可见" in titles
+    assert total == 1
+
+    svc.repository.list_all = AsyncMock(return_value=([directed, public], 2))
+    leaked_items, leaked_total = await svc.list_questions(user=_user(user_id=99))
+    assert "定向机密" not in [item.title for item in leaked_items]
+    assert leaked_total == 2
+
+
+async def test_list_total_uses_repository_count_not_page_length():
+    """列表 total 必须是匹配总数，不能收成当前页 len(visible)。"""
+    svc = _service()
+    page = [_question_row(id=index, title=f"公开{index}", question_type="public") for index in range(10)]
+    svc.repository.list_all = AsyncMock(return_value=(page, 27))
+    items, total = await svc.list_questions(user=_user(user_id=1))
+    assert len(items) == 10
+    assert total == 27
+
+
+async def test_list_masks_anonymous_asker_name():
+    """匿名公开题列表给非管理员看别名，不得带 created_by 真名展示字段。"""
+    svc = _service()
+    anon = _question_row(
+        id=1,
+        title="匿名题",
+        question_type="public",
+        created_by="gzx01",
+        asker_anonymous=1,
+    )
+    named = _question_row(id=2, title="实名题", question_type="public", created_by="gzx01", asker_anonymous=0)
+    svc.repository.list_all = AsyncMock(return_value=([anon, named], 2))
+    items, _total = await svc.list_questions(user=_user(user_id=99))
+    assert items[0].asker["display_name"] == "匿名同事A"
+    assert items[0].asker["anonymous"] is True
+    assert "real_name" not in items[0].asker
+    assert items[0].created_by == "gzx01"
+    assert items[1].asker["display_name"] == "gzx01"
+    assert items[1].asker["anonymous"] is False
+
+
+async def test_list_attaches_latest_answer_preview():
+    """有回答的列表项必须带最新一条摘要，不能只给 answer_count。"""
+    svc = _service()
+    row = _question_row(id=1, title="有回答", answer_count=2)
+    empty = _question_row(id=2, title="无回答", answer_count=0)
+    svc.repository.list_all = AsyncMock(return_value=([row, empty], 2))
+    svc.answer_repo.list_latest_by_question_ids = AsyncMock(
+        return_value={
+            1: SimpleNamespace(
+                id=9,
+                question_id=1,
+                content="<p>最新答</p>",
+                adopted=True,
+                expert_name="gzx001",
+                user_id=50,
+                anonymous=0,
+                reveal_on_public=None,
+            )
+        }
+    )
+    items, _total = await svc.list_questions(user=_user(user_id=99))
+    preview = items[0].latest_answer
+    assert preview["id"] == 9
+    assert preview["excerpt"] == "最新答"
+    assert preview["expert_name"] == "gzx001"
+    assert preview["adopted"] is True
+    assert preview["anonymous"] is False
+    assert getattr(items[1], "latest_answer", None) is None
+    svc.answer_repo.list_latest_by_question_ids.assert_awaited()
+
+
+async def test_list_status_3_is_mine_not_pending_adopt():
+    svc = _service()
+    mine_solved = _question_row(id=3, title="我的已解决", user_id=1, adopt_count=1, answer_count=1)
+    svc.repository.list_all = AsyncMock(return_value=([mine_solved], 1))
+    items, _total = await svc.list_questions(user=_user(user_id=1), status=3)
+    assert items[0].title == "我的已解决"
+    assert items[0].display_status == DISPLAY_SOLVED
+    kwargs = svc.repository.list_all.await_args.kwargs
+    assert kwargs.get("list_filter") == FILTER_MINE
+    assert kwargs.get("display_status") is None
+
+
+async def test_list_unresolved_excludes_solved():
+    svc = _service()
+    unanswered = _question_row(id=1, title="未回答", answer_count=0, adopt_count=0)
+    pending = _question_row(id=2, title="待采纳", answer_count=2, adopt_count=0)
+    solved = _question_row(id=3, title="已解决", answer_count=2, adopt_count=1)
+    svc.repository.list_all = AsyncMock(return_value=([unanswered, pending, solved], 3))
+    items, _total = await svc.list_questions(user=_user(user_id=1), display_status="unresolved")
+    titles = [item.title for item in items]
+    assert titles == ["未回答", "待采纳"]
+    assert items[1].display_status == DISPLAY_PENDING_ADOPT
+
+
+async def test_list_skips_minio_resolve_and_per_row_vote_query():
+    """列表不得逐条打 MinIO / SUM 回答赞，否则 171 上 10 条就会拖过前端超时。"""
+    svc = _service()
+    page = [_question_row(id=index, title=f"公开{index}") for index in range(10)]
+    svc.repository.list_all = AsyncMock(return_value=(page, 10))
+    await svc.list_questions(user=_user(user_id=1))
+    svc._resolve_question.assert_not_awaited()
+    svc.answer_repo.get_answer_vote_count.assert_not_awaited()
+    svc.identity_service.preload_for_questions.assert_awaited()
+
+
+async def test_detail_denies_stranger_without_leaking_title():
+    svc = _service()
+    directed = _question_row(id=9, title="定向机密", question_type="directed", user_id=1)
+    svc.repository.get_by_id = AsyncMock(return_value=directed)
+    svc.invite_repo.list_user_ids_by_question_ids = AsyncMock(return_value={9: {50}})
+    with pytest.raises(QaExpertQuestionAccessDeniedError) as exc:
+        await svc.get_question_detail(9, user=_user(user_id=99))
+    assert "定向机密" not in str(exc.value)
+    svc.repository.update.assert_not_called()
+
+
+async def test_similar_does_not_merge_and_hides_invisible():
+    svc = _service()
+    directed = _question_row(id=1, title="定向机密炼钢", question_type="directed")
+    public = _question_row(id=2, title="公开炼钢", question_type="public")
+    svc.repository.search_by_title_like = AsyncMock(return_value=[directed, public])
+    svc.invite_repo.list_user_ids_by_question_ids = AsyncMock(return_value={1: {50}})
+    hits = await svc.find_similar_questions(user=_user(user_id=99), text="炼钢")
+    assert [item.title for item in hits] == ["公开炼钢"]
+    await _create(svc, _create_request(title="炼钢新题"))
+    svc.repository.create.assert_awaited()

--- a/src/backend/test/qa_expert/test_related_docs.py
+++ b/src/backend/test/qa_expert/test_related_docs.py
@@ -1,0 +1,146 @@
+# ruff: noqa: RUF002
+"""T020：关联文档详情不挡正文；无权 forbidden 不得写成 not_found。"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from bisheng.qa_expert.domain.services import QuestionService
+
+
+def _service() -> QuestionService:
+    svc = QuestionService()
+    svc.repository = MagicMock()
+    svc.invite_repo = MagicMock()
+    svc.invite_repo.list_user_ids_by_question_ids = AsyncMock(return_value={})
+    svc.answer_repo = MagicMock()
+    svc.expert_repo = MagicMock()
+    svc.expert_repo.get_by_user_id = AsyncMock(return_value=None)
+    svc.expert_repo.get_by_ids = AsyncMock(return_value=[])
+    svc.eligibility_repo = MagicMock()
+    svc.eligibility_repo.list_user_ids = AsyncMock(return_value=set())
+    svc.publish_request_repo = MagicMock()
+    svc.publish_request_repo.get_pending_by_question = AsyncMock(return_value=None)
+    svc.publish_approver_repo = MagicMock()
+    svc.publish_approver_repo.list_by_request = AsyncMock(return_value=[])
+    svc._resolve_question = AsyncMock(side_effect=lambda q: q)
+    svc.answer_repo.has_effective_answer = AsyncMock(return_value=False)
+    svc.identity_service = SimpleNamespace(
+        mask_identity=AsyncMock(
+            return_value=SimpleNamespace(
+                to_dict=lambda **_: {"display_name": "u", "anonymous": False, "avatar_url": None}
+            )
+        )
+    )
+    return svc
+
+
+async def test_detail_always_returns_question_body_when_doc_forbidden():
+    svc = _service()
+    question = SimpleNamespace(
+        id=3,
+        user_id=1,
+        title="正文仍在",
+        description="可见描述",
+        question_type="public",
+        related_docs="12-99",
+        view_count=0,
+        adopt_count=0,
+        answer_count=0,
+    )
+    svc.repository.get_by_id = AsyncMock(return_value=question)
+    svc.repository.update = AsyncMock()
+
+    async def checker(_user, space_id, file_id):
+        assert (space_id, file_id) == (12, 99)
+        return False
+
+    svc.related_docs_access_checker = checker
+    detail = await svc.get_question_detail(
+        3, user_id=2, user=SimpleNamespace(user_id=2, is_admin=lambda: False, role=None)
+    )
+    assert detail.title == "正文仍在"
+    assert detail.description == "可见描述"
+    view = detail.related_doc_views[0]
+    assert view["id"] == "12-99"
+    assert view["accessible"] is False
+    assert view["unavailable_reason"] == "forbidden"
+    assert view["unavailable_reason"] != "not_found"
+
+
+async def test_accessible_doc_keeps_durable_id():
+    svc = _service()
+
+    async def checker(_user, _s, _f):
+        return True
+
+    svc.related_docs_access_checker = checker
+    views = await svc.hydrate_related_docs("8-15")
+    assert views[0]["id"] == "8-15"
+    assert views[0]["space_id"] == 8
+    assert views[0]["file_id"] == 15
+    assert views[0]["accessible"] is True
+    assert views[0]["unavailable_reason"] is None
+
+
+async def test_non_owner_existing_file_is_forbidden_not_openfga():
+    """路人即使文件存在也记 forbidden，避免详情去打 OpenFGA。"""
+    svc = _service()
+
+    async def checker(_user, _s, _f):
+        return True
+
+    svc.related_docs_access_checker = checker
+    views = await svc.hydrate_related_docs(
+        "8-15",
+        user=SimpleNamespace(user_id=2),
+        owner_user_id=1,
+    )
+    assert views[0]["accessible"] is False
+    assert views[0]["unavailable_reason"] == "forbidden"
+
+
+async def test_owner_existing_file_is_accessible():
+    svc = _service()
+
+    async def checker(_user, _s, _f):
+        return True
+
+    svc.related_docs_access_checker = checker
+    views = await svc.hydrate_related_docs(
+        "8-15",
+        user=SimpleNamespace(user_id=1),
+        owner_user_id=1,
+    )
+    assert views[0]["accessible"] is True
+    assert views[0]["unavailable_reason"] is None
+
+
+async def test_missing_file_is_not_found_not_forbidden():
+    svc = _service()
+
+    async def checker(_user, _s, _f):
+        return None
+
+    svc.related_docs_access_checker = checker
+    views = await svc.hydrate_related_docs("8-404")
+    assert views[0]["accessible"] is False
+    assert views[0]["unavailable_reason"] == "not_found"
+
+
+async def test_hung_access_check_is_forbidden_not_500(monkeypatch):
+    """鉴权挂起时详情仍返回正文，文档记 forbidden 而不是把整页拖死。"""
+    import asyncio
+
+    from bisheng.qa_expert.domain import related_docs_access
+
+    monkeypatch.setattr(related_docs_access, "RELATED_DOC_ACCESS_TIMEOUT_SEC", 0.05)
+    svc = _service()
+
+    async def checker(_user, _s, _f):
+        await asyncio.sleep(2)
+        return True
+
+    svc.related_docs_access_checker = checker
+    views = await svc.hydrate_related_docs("8-15")
+    assert views[0]["accessible"] is False
+    assert views[0]["unavailable_reason"] == "forbidden"

--- a/src/frontend/client/src/components/NotificationsDialog.test.tsx
+++ b/src/frontend/client/src/components/NotificationsDialog.test.tsx
@@ -139,6 +139,55 @@ describe("NotificationsDialog approval jump", () => {
     });
   });
 
+  it("opens my_tasks for in-progress QA publish notifications instead of approve/reject", async () => {
+    jest.mocked(getMessageListApi).mockResolvedValue({
+      total: 1,
+      data: [{
+        id: 702,
+        sender: 9,
+        sender_name: "Asker",
+        message_type: "notify",
+        action_code: "qa_publish_started",
+        status: "approved",
+        is_read: false,
+        create_time: "2026-08-16T10:00:00Z",
+        update_time: "2026-08-16T10:00:00Z",
+        content: [
+          { type: "user", content: "@Asker", metadata: { user_id: 9 } },
+          { type: "system_text", content: "qa_expert_publish_started" },
+          {
+            type: "business_url",
+            content: "--定向问题标题",
+            metadata: {
+              business_type: "approval_instance_id",
+              data: { approval_instance_id: "88", question_id: "12345", request_id: "7" },
+            },
+          },
+        ],
+      }],
+    });
+    jest.mocked(markMessageReadApi).mockResolvedValue({});
+    const openApprovalCenter = jest.fn();
+
+    render(<NotificationsDialog open onOpenApprovalCenter={openApprovalCenter} />);
+
+    expect(await screen.findByText("com_notifications_view_approval")).toBeInTheDocument();
+    expect(screen.queryByText("com_notifications_accept")).not.toBeInTheDocument();
+    expect(screen.queryByText("com_notifications_reject")).not.toBeInTheDocument();
+    expect(screen.queryByText("com_notifications_view_message")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("com_notifications_view_approval"));
+
+    await waitFor(() => {
+      expect(openApprovalCenter).toHaveBeenCalledWith({
+        tab: "my_tasks",
+        taskId: null,
+        instanceId: 88,
+      });
+    });
+    expect(mockParentPostMessage).not.toHaveBeenCalled();
+  });
+
   it.each([
     ["qa_expert_invited", null, null],
     ["qa_expert_answered", "42", null],

--- a/src/frontend/client/src/components/NotificationsDialog.tsx
+++ b/src/frontend/client/src/components/NotificationsDialog.tsx
@@ -125,6 +125,20 @@ const NOTIFICATION_ACTION_TEXT_KEYS: Record<string, string> = {
     qa_expert_answered: "com_notifications_action_qa_expert_answered",
     qa_answer_commented: "com_notifications_action_qa_answer_commented",
     qa_answer_accepted: "com_notifications_action_qa_answer_accepted",
+    qa_expert_publish_started: "com_notifications_action_qa_expert_publish_started",
+    qa_publish_started: "com_notifications_action_qa_expert_publish_started",
+    qa_expert_publish_approver_added: "com_notifications_action_qa_expert_publish_approver_added",
+    qa_publish_approver_added: "com_notifications_action_qa_expert_publish_approver_added",
+    qa_expert_publish_approved: "com_notifications_action_qa_expert_publish_approved",
+    qa_publish_approved: "com_notifications_action_qa_expert_publish_approved",
+    qa_expert_publish_rejected: "com_notifications_action_qa_expert_publish_rejected",
+    qa_publish_rejected: "com_notifications_action_qa_expert_publish_rejected",
+    qa_expert_publish_expired: "com_notifications_action_qa_expert_publish_expired",
+    qa_publish_expired: "com_notifications_action_qa_expert_publish_expired",
+    qa_expert_publish_ended: "com_notifications_action_qa_expert_publish_ended",
+    qa_publish_ended: "com_notifications_action_qa_expert_publish_ended",
+    qa_expert_publish_default_approved: "com_notifications_action_qa_expert_publish_approved",
+    qa_publish_default_approved: "com_notifications_action_qa_expert_publish_approved",
     // 收藏的源文件发生变更（名称/位置/标签/分类·业务域/版本）
     favorite_source_renamed: "com_notifications_action_favorite_source_renamed",
     favorite_source_moved: "com_notifications_action_favorite_source_moved",
@@ -173,6 +187,23 @@ const QA_EXPERT_ACTION_CODES = new Set([
     "qa_expert_answered",
     "qa_answer_commented",
     "qa_answer_accepted",
+    "qa_expert_publish_approved",
+    "qa_publish_approved",
+    "qa_expert_publish_rejected",
+    "qa_publish_rejected",
+    "qa_expert_publish_expired",
+    "qa_publish_expired",
+    "qa_expert_publish_ended",
+    "qa_publish_ended",
+    "qa_expert_publish_default_approved",
+    "qa_publish_default_approved",
+]);
+
+const QA_PUBLISH_TODO_ACTION_CODES = new Set([
+    "qa_expert_publish_started",
+    "qa_publish_started",
+    "qa_expert_publish_approver_added",
+    "qa_publish_approver_added",
 ]);
 
 export function NotificationsDialog({
@@ -773,7 +804,7 @@ export function NotificationsDialog({
                 return { targetType: "space", targetId: knowledgeSpaceId };
             }
         }
-        if (businessType === "qa_question") {
+        if (businessType === "qa_question" || businessType === "qa_publish") {
             const questionId = pickId(
                 data?.question_id,
                 data?.business_id,
@@ -956,9 +987,14 @@ export function NotificationsDialog({
         };
 
         const showRightSlotDelete = dateSlotHoverId === id && canShowDeleteInDateSlot;
-        const approvalCenterTarget = isApprovalMessageType(notification.message_type, notification.action_code)
-            ? resolveApprovalCenterTarget(notification)
-            : null;
+        const isQaPublishTodo =
+            QA_PUBLISH_TODO_ACTION_CODES.has(getSystemTextCode(notification)) ||
+            QA_PUBLISH_TODO_ACTION_CODES.has(notification.action_code ?? "");
+        const approvalCenterTarget = isQaPublishTodo
+            ? { ...resolveApprovalCenterTarget(notification), tab: "my_tasks" as const }
+            : isApprovalMessageType(notification.message_type, notification.action_code)
+                ? resolveApprovalCenterTarget(notification)
+                : null;
         const canOpenApprovalCenter = Boolean(
             onOpenApprovalCenter &&
             approvalCenterTarget &&

--- a/src/frontend/client/src/components/approval/ApprovalCenterDialog.tsx
+++ b/src/frontend/client/src/components/approval/ApprovalCenterDialog.tsx
@@ -400,7 +400,11 @@ export function ApprovalCenterDialog({ open, onOpenChange, target }: ApprovalCen
       const resp = await listMyApprovalTasksApi();
       setTaskItems(resp.data);
       const allIds = new Set(resp.data.map((t) => getId(t, "task")));
-      const validPreferred = preferredId && allIds.has(preferredId) ? preferredId : null;
+      const preferredByInstance = target?.instanceId
+        ? resp.data.find((t) => Number(t.instance_id) === Number(target.instanceId) && (taskFilter !== "pending_me" || t.status === "pending"))
+        : null;
+      const resolvedPreferred = preferredId ?? getId(preferredByInstance, "task");
+      const validPreferred = resolvedPreferred && allIds.has(resolvedPreferred) ? resolvedPreferred : null;
       const visibleItems = taskFilter === "pending_me"
         ? resp.data.filter((t) => t.status === "pending")
         : resp.data.filter((t) => t.status !== "pending");
@@ -440,7 +444,10 @@ export function ApprovalCenterDialog({ open, onOpenChange, target }: ApprovalCen
 
   useEffect(() => {
     if (!open) return;
-    setActiveTab(target?.tab ?? "my_tasks");
+    const nextTab = target?.tab ?? "my_tasks";
+    setActiveTab(nextTab);
+    // 通知「查看审批」进入待我处理，避免停留在已处理筛选项里找不到这条待办。
+    if (nextTab === "my_tasks") setTaskFilter("pending_me");
     setSelectedTaskId(target?.taskId ?? null);
     setSelectedInstanceId(target?.instanceId ?? null);
     setSearchQuery("");

--- a/src/frontend/client/src/locales/en/translation.json
+++ b/src/frontend/client/src/locales/en/translation.json
@@ -2259,5 +2259,11 @@
   "com_notifications_action_qa_expert_invited": "Invited you to answer expert question \"{{target}}\"",
   "com_notifications_action_qa_expert_answered": "Answered expert question \"{{target}}\"",
   "com_notifications_action_qa_answer_commented": "Commented on expert question \"{{target}}\"",
-  "com_notifications_action_qa_answer_accepted": "Accepted expert question \"{{target}}\""
+  "com_notifications_action_qa_answer_accepted": "Accepted expert question \"{{target}}\"",
+  "com_notifications_action_qa_expert_publish_started": "Started a request to make expert question \"{{target}}\" public. Review it in My approvals.",
+  "com_notifications_action_qa_expert_publish_approver_added": "Approvers for making expert question \"{{target}}\" public were updated",
+  "com_notifications_action_qa_expert_publish_approved": "Expert question \"{{target}}\" is now public. This cannot be undone",
+  "com_notifications_action_qa_expert_publish_rejected": "The request to make expert question \"{{target}}\" public was rejected",
+  "com_notifications_action_qa_expert_publish_expired": "The request to make expert question \"{{target}}\" public has expired",
+  "com_notifications_action_qa_expert_publish_ended": "The request to make expert question \"{{target}}\" public has ended"
 }

--- a/src/frontend/client/src/locales/ja/translation.json
+++ b/src/frontend/client/src/locales/ja/translation.json
@@ -2149,5 +2149,15 @@
   "com_approval_field_original_uploader_name": "最初のアップロード者",
   "com_approval_field_original_uploader_id": "最初のアップロード者ID",
   "com_approval_field_original_knowledge_name": "最初のナレッジスペース",
-  "com_approval_field_original_knowledge_id": "最初のナレッジスペースID"
+  "com_approval_field_original_knowledge_id": "最初のナレッジスペースID",
+  "com_notifications_action_qa_expert_invited": "専門家Q&A「{{target}}」への回答に招待されました",
+  "com_notifications_action_qa_expert_answered": "専門家Q&A「{{target}}」に回答しました",
+  "com_notifications_action_qa_answer_commented": "専門家Q&A「{{target}}」のあなたの回答にコメントしました",
+  "com_notifications_action_qa_answer_accepted": "専門家Q&A「{{target}}」のあなたの回答を採用しました",
+  "com_notifications_action_qa_expert_publish_started": "専門家Q&A「{{target}}」の公開申請を開始しました。承認管理の未処理から対応してください",
+  "com_notifications_action_qa_expert_publish_approver_added": "専門家Q&A「{{target}}」の公開承認者が更新されました",
+  "com_notifications_action_qa_expert_publish_approved": "専門家Q&A「{{target}}」は公開されました。この操作は取り消せません",
+  "com_notifications_action_qa_expert_publish_rejected": "専門家Q&A「{{target}}」の公開申請は却下されました",
+  "com_notifications_action_qa_expert_publish_expired": "専門家Q&A「{{target}}」の公開申請は期限切れです",
+  "com_notifications_action_qa_expert_publish_ended": "専門家Q&A「{{target}}」の公開申請は終了しました"
 }

--- a/src/frontend/client/src/locales/zh-Hans/translation.json
+++ b/src/frontend/client/src/locales/zh-Hans/translation.json
@@ -2191,5 +2191,11 @@
   "com_notifications_action_qa_expert_invited": "邀请你回答专家问答问题「{{target}}」",
   "com_notifications_action_qa_expert_answered": "回答了你在专家问答提出的「{{target}}」",
   "com_notifications_action_qa_answer_commented": "评论了你在专家问答「{{target}}」问题中做出的回答",
-  "com_notifications_action_qa_answer_accepted": "采纳了你在专家问答「{{target}}」问题中做出的回答"
+  "com_notifications_action_qa_answer_accepted": "采纳了你在专家问答「{{target}}」问题中做出的回答",
+  "com_notifications_action_qa_expert_publish_started": "发起了专家问答「{{target}}」的转公开申请，请到待办-我的审批处理",
+  "com_notifications_action_qa_expert_publish_approver_added": "专家问答「{{target}}」的转公开审批人已更新",
+  "com_notifications_action_qa_expert_publish_approved": "专家问答「{{target}}」已转公开，此操作不可撤销",
+  "com_notifications_action_qa_expert_publish_rejected": "专家问答「{{target}}」的转公开申请已被拒绝",
+  "com_notifications_action_qa_expert_publish_expired": "专家问答「{{target}}」的转公开申请已过期",
+  "com_notifications_action_qa_expert_publish_ended": "专家问答「{{target}}」的转公开申请已结束"
 }


### PR DESCRIPTION
## Summary
- 转公开以 `qa_publish_*` 为事实来源，审批中心只承载待办；提问者或有效回答人可发起，任一拒绝即结束，全体同意后不可逆公开。
- 详情带回当前用户 `viewer_decision`，发起人默认同意后不再出现同意/拒绝。
- 问题列表改为批量补水，去掉逐条 MinIO 与回答点赞聚合，避免连 171 超时。

配套门户 PR：https://github.com/dataelement/shougang-group-knowledge-portal/pull/53

## Test plan
- [ ] `cd src/backend && ./.venv/bin/python -m pytest test/qa_expert/test_data_flow.py test/qa_expert/test_publish_request.py test/qa_expert/test_capability_resolver.py -q`
- [ ] 定向已解决问题：提问者发起转公开后本人为已同意，受邀专家可同意/拒绝
- [ ] 拒绝后问题仍为定向，可重新发起；全体同意后问题公开且不可再改
- [ ] 审批中心待办与详情决策入口都能落库到同一申请
- [ ] 问题列表在 171 上能在超时内返回