### PR TITLE
fix(points): 校验可配置的 G3 单文档终身上限

### DIFF
--- a/src/backend/bisheng/points/domain/constants/tier_rule_score_expr.py
+++ b/src/backend/bisheng/points/domain/constants/tier_rule_score_expr.py
@@ -1,0 +1,61 @@
+"""G3 等阶梯规则 score_expr 校验。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# 与门户调分绝对值上限对齐，防止异常大 lifetime_cap。
+G3_LIFETIME_CAP_MAX = 10_000
+
+
+def _parse_tier_rows(tiers: Any) -> list[tuple[int, int]] | None:
+    """解析 tiers 为 (threshold, score) 列表；结构非法时返回 None。"""
+    if not isinstance(tiers, list) or not tiers:
+        return None
+    parsed: list[tuple[int, int]] = []
+    for raw in tiers:
+        if not isinstance(raw, dict):
+            return None
+        try:
+            threshold = int(raw.get("threshold"))
+            score = int(raw.get("score"))
+        except (TypeError, ValueError):
+            return None
+        if threshold < 0 or score < 0:
+            return None
+        parsed.append((threshold, score))
+    parsed.sort(key=lambda row: row[0])
+    for i in range(1, len(parsed)):
+        if parsed[i][0] <= parsed[i - 1][0]:
+            return None
+        if parsed[i][1] < parsed[i - 1][1]:
+            return None
+    return parsed
+
+
+def validate_g3_tier_score_expr(score_expr: dict[str, Any] | None) -> str | None:
+    """校验 G3 阶梯 score_expr；通过返回 None，否则返回业务错误文案。
+
+    Args:
+        score_expr: 规则 score_expr JSON
+
+    Returns:
+        错误文案或 None
+    """
+    if not score_expr or score_expr.get("mode") != "tier":
+        return None
+    tiers = _parse_tier_rows(score_expr.get("tiers"))
+    if not tiers:
+        return "G3 阶梯规则须至少配置一档且阈值、分值合法"
+    try:
+        lifetime_cap = int(score_expr.get("lifetime_cap"))
+    except (TypeError, ValueError):
+        return "G3 终身上限须为非负整数"
+    if lifetime_cap < 0:
+        return "G3 终身上限须为非负整数"
+    if lifetime_cap > G3_LIFETIME_CAP_MAX:
+        return f"G3 终身上限最大为 {G3_LIFETIME_CAP_MAX} 分"
+    top_score = tiers[-1][1]
+    if lifetime_cap < top_score:
+        return "G3 终身上限不得低于最高档奖励分"
+    return None

--- a/src/backend/bisheng/points/domain/services/points_rule_service.py
+++ b/src/backend/bisheng/points/domain/services/points_rule_service.py
@@ -8,6 +8,7 @@ from bisheng.common.dependencies.user_deps import UserPayload
 from bisheng.common.errcode.points import PointsRuleConflictError, PointsRuleNotFoundError
 from bisheng.points.domain.constants.beneficiary import allowed_beneficiaries
 from bisheng.points.domain.constants.optional_fixed_score_rules import validate_deferred_config_rule_can_enable
+from bisheng.points.domain.constants.tier_rule_score_expr import validate_g3_tier_score_expr
 from bisheng.points.domain.models import PointRule
 from bisheng.points.domain.schemas.points_schema import (
     PointCopiesUpdateRequest,
@@ -67,6 +68,16 @@ class PointsRuleService:
         rows = await self.repository.list_rules(tenant_id, rule_type=rule_type, status=status)
         return [self._to_dto(r) for r in rows]
 
+    @staticmethod
+    def validate_score_expr(rule_code: str, score_expr: dict | None) -> None:
+        """校验规则 score_expr 结构（当前仅 G3 阶梯）。"""
+        code = (rule_code or "").strip().upper()
+        if code != "G3":
+            return
+        err = validate_g3_tier_score_expr(score_expr)
+        if err:
+            raise PointsRuleConflictError(msg=err)
+
     async def create_rule(self, tenant_id: int, user: UserPayload, body: PointRuleRequest) -> PointRuleResponse:
         """创建规则；rule_code 租户内唯一。"""
         require_platform_admin(user)
@@ -76,6 +87,7 @@ class PointsRuleService:
         if await self.repository.get_rule(tenant_id, code):
             raise PointsRuleConflictError(msg=f"规则编码 {code} 已存在")
         self.validate_beneficiary(code, body.rule_type, body.beneficiary)
+        self.validate_score_expr(code, body.score_expr)
         rule = PointRule(
             tenant_id=tenant_id,
             rule_code=code,
@@ -108,6 +120,7 @@ class PointsRuleService:
         if "name" in fields and body.name is not None:
             rule.name = body.name
         if "score_expr" in fields and body.score_expr is not None:
+            self.validate_score_expr(rule.rule_code, body.score_expr)
             rule.score_expr = body.score_expr
             flag_modified(rule, "score_expr")
         if "daily_cap" in fields:

--- a/src/backend/test/points/test_tier_rule_score_expr.py
+++ b/src/backend/test/points/test_tier_rule_score_expr.py
@@ -1,0 +1,40 @@
+"""G3 阶梯 score_expr 校验单测。"""
+
+from bisheng.points.domain.constants.tier_rule_score_expr import validate_g3_tier_score_expr
+
+
+def test_validate_g3_accepts_configurable_lifetime_cap():
+    err = validate_g3_tier_score_expr(
+        {
+            "mode": "tier",
+            "tiers": [
+                {"threshold": 3, "score": 5},
+                {"threshold": 10, "score": 12},
+                {"threshold": 20, "score": 20},
+            ],
+            "lifetime_cap": 30,
+        }
+    )
+    assert err is None
+
+
+def test_validate_g3_rejects_lifetime_below_top_tier():
+    err = validate_g3_tier_score_expr(
+        {
+            "mode": "tier",
+            "tiers": [{"threshold": 3, "score": 10}],
+            "lifetime_cap": 5,
+        }
+    )
+    assert err == "G3 终身上限不得低于最高档奖励分"
+
+
+def test_validate_g3_rejects_excessive_lifetime_cap():
+    err = validate_g3_tier_score_expr(
+        {
+            "mode": "tier",
+            "tiers": [{"threshold": 3, "score": 5}],
+            "lifetime_cap": 10001,
+        }
+    )
+    assert "最大为" in (err or "")


### PR DESCRIPTION
## Summary
- 保存 G3 规则时校验 `score_expr`：`lifetime_cap` 须为非负整数、不超过 10000、且不低于最高档奖励分
- 支持门户管理端将 G3 单文档终身上限配置为大于 15 的值（发分引擎本就按 `lifetime_cap` 读取，此前仅缺服务端校验）

## 涉及数据表
- `point_rule`：读写 `score_expr` JSON（无 DDL）

## Test plan
- [ ] 管理端/API 更新 G3：`lifetime_cap: 30` 且档位合法 → 保存成功
- [ ] `lifetime_cap` 低于最高档分值 → 返回业务错误
- [ ] `lifetime_cap > 10000` → 返回业务错误
- [ ] `cd src/backend && uv run pytest test/points/test_tier_rule_score_expr.py -q`


Made with [Cursor](https://cursor.com)