### PR TITLE
fix: normalize spaces in workflow variable inputs

### DIFF
--- a/src/frontend/platform/src/pages/BuildPage/flow/FlowNode/component/VarInput.test.tsx
+++ b/src/frontend/platform/src/pages/BuildPage/flow/FlowNode/component/VarInput.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render } from "@/test/test-utils";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import VarInput from "./VarInput";
+
+vi.mock("../../flowStore", () => ({
+    default: () => ({ flow: { nodes: [] } }),
+}));
+
+vi.mock("../flowNodeStore", () => ({
+    useUpdateVariableState: () => [null],
+}));
+
+vi.mock("./SelectVar", async () => {
+    const { forwardRef } = await import("react");
+    return {
+        default: forwardRef<unknown, { children: ReactNode }>(({ children }, _ref) => children),
+    };
+});
+
+vi.mock("@/components/bs-ui/tooltip/tip", () => ({
+    default: ({ children }) => children,
+}));
+
+vi.mock("@/components/bs-icons/rbDrag", () => ({
+    RbDragIcon: () => null,
+}));
+
+describe("VarInput", () => {
+    it("normalizes non-breaking spaces when serializing variable input", () => {
+        const onChange = vi.fn();
+        const { container } = render(
+            <VarInput
+                nodeId="mcp-node"
+                itemKey="query"
+                paramItem={{
+                    label: "SQL",
+                    required: false,
+                    varZh: { "code.result": "code/result" },
+                }}
+                value=""
+                onChange={onChange}
+            />,
+        );
+        const input = container.querySelector('[contenteditable="true"]');
+        expect(input).not.toBeNull();
+
+        input!.innerHTML =
+            'select * from risk_info where name = <span class="textarea-badge" contenteditable="false">code/result</span>&nbsp;limit 2000';
+        fireEvent.input(input!);
+
+        expect(onChange).toHaveBeenLastCalledWith(
+            "select * from risk_info where name = {{#code.result#}} limit 2000",
+        );
+    });
+});

--- a/src/frontend/platform/src/pages/BuildPage/flow/FlowNode/component/VarInput.tsx
+++ b/src/frontend/platform/src/pages/BuildPage/flow/FlowNode/component/VarInput.tsx
@@ -43,7 +43,7 @@ function parseToValue(input, paramItem) {
             if (child.nodeName === 'BR') {
                 result += '\n'; // 换行符
             } else if (child.nodeType === Node.TEXT_NODE) {
-                result += child.textContent; // 文本内容
+                result += child.textContent.replace(/\u00a0/g, ' '); // 文本内容
             } else if (child.nodeType === Node.ELEMENT_NODE) {
                 result += traverseNodes(child); // 递归解析子元素
             }


### PR DESCRIPTION
## What

- Normalize browser-generated non-breaking spaces when serializing workflow variable inputs.
- Add a regression test covering an MCP SQL parameter with an inserted variable followed by `U+00A0`.

## Why

`VarInput` copied `contentEditable` text nodes verbatim. Browsers can represent the space next to a non-editable variable badge as `U+00A0`, so the saved SQL reached the MCP database with an invalid separator and failed to parse.

## How

Replace `U+00A0` with an ordinary `U+0020` while traversing text nodes. Variable badges, line breaks, and all other input remain on the existing serialization path.

## Test

- [x] 本地测试通过
- [ ] 114 测试服务器验证通过
- Regression before: `npm test -- --run src/pages/BuildPage/flow/FlowNode/component/VarInput.test.tsx` exited `1` with `U+00A0` preserved.
- Regression after: the same command exited `0`.
- Smoke + affected tests: `npm test -- --run src/test/smoke.test.ts src/pages/BuildPage/flow/FlowNode/component/VarInput.test.tsx`
- Production build: `npm run build`
- Architecture guard: `bash scripts/arch-guard.sh`
- Staged diff check: `git diff --cached --check`
- Full platform suite has 14 unrelated baseline failures both before and after this patch; the patched run adds this regression as one additional passing test.

## Related

- Issue/ticket: Fixes #2155

## Scope

- 2 files changed, +58 / -1 lines
