### PR TITLE
fix(tags): 标签审核改为独立管理员与科室库管理员并集

### DIFF
--- a/src/backend/bisheng/user/domain/models/user.py
+++ b/src/backend/bisheng/user/domain/models/user.py
@@ -141,7 +141,7 @@ class UserRead(UserBase):
     # PRD 3.2.2 用户组管理入口：超管 / 部门管理员
     can_manage_user_groups: bool | None = None
     is_department_admin: bool | None = None
-    # 标签审核入口：库 admin/creator 或部门管理员（团队/个人）或超管/租户管理员
+    # 标签审核入口：独立管理员（含部门/用户组继承，不含仅所有者）或上传人科室下科室库管理员，或超管/租户管理员
     can_review_tags: bool | None = None
     # Multi-tenant fields (F010)
     requires_tenant_selection: bool | None = None

--- a/src/backend/bisheng/workstation/domain/repositories/review_tags_repository.py
+++ b/src/backend/bisheng/workstation/domain/repositories/review_tags_repository.py
@@ -10,16 +10,81 @@ from bisheng.common.errcode.tag import (
     TargetTagInUsedError,
 )
 from bisheng.core.storage.minio.minio_manager import get_minio_storage
+from bisheng.database.models.department import Department, UserDepartment
 from bisheng.database.models.review_tags import ApproveOrRejectEnum, ReviewTag, ReviewTagLink
 from bisheng.database.models.tag import Tag, TagBusinessTypeEnum, TagResourceTypeEnum
 from bisheng.knowledge.domain.models.knowledge_file import KnowledgeFile
 from bisheng.knowledge.domain.models.knowledge_space_scope import KnowledgeSpaceScope
+from bisheng.points.domain.constants.org_levels import ORG_LEVEL_OFFICE
 from bisheng.workstation.domain.repositories.tags_repository import TagRepositoryImpl
 from bisheng.workstation.domain.schemas.review_tags_schema import (
     ORG_UPLOADER_REVIEW_LEVELS,
     ReviewTagScope,
     ReviewTagSubmitterTarget,
 )
+
+
+def build_clinic_uploader_match_clause(tenant_id: int, department_ids: set[int]):
+    """团队/个人库：文件上传人主部门是已打 office 标、且落在给定科室 ID 集合。
+
+    必须用 ``knowledge_file.user_id``，不能用 review_tag / review_tag_link.user_id。
+    """
+    dept_id_list = sorted(int(dept_id) for dept_id in department_ids)
+    org_levels = sorted(ORG_UPLOADER_REVIEW_LEVELS)
+    org_link_match = exists(
+        select(1)
+        .select_from(ReviewTagLink)
+        .join(
+            KnowledgeFile,
+            KnowledgeFile.id == cast(ReviewTagLink.resource_id, Integer),
+        )
+        .join(
+            KnowledgeSpaceScope,
+            KnowledgeSpaceScope.space_id == KnowledgeFile.knowledge_id,
+        )
+        .join(
+            UserDepartment,
+            (UserDepartment.user_id == KnowledgeFile.user_id) & (UserDepartment.is_primary == 1),
+        )
+        .join(Department, Department.id == UserDepartment.department_id)
+        .where(
+            ReviewTagLink.tag_id == ReviewTag.id,
+            ReviewTagLink.tenant_id == tenant_id,
+            ReviewTagLink.is_deleted == False,  # noqa: E712
+            KnowledgeFile.tenant_id == tenant_id,
+            KnowledgeSpaceScope.level.in_(org_levels),
+            Department.org_level == ORG_LEVEL_OFFICE,
+            Department.id.in_(dept_id_list),
+        )
+    )
+    org_business_match = and_(
+        ReviewTag.business_type.in_(
+            [
+                TagBusinessTypeEnum.KNOWLEDGE_SPACE.value,
+                TagBusinessTypeEnum.KNOWLEDGE.value,
+            ]
+        ),
+        exists(
+            select(1)
+            .select_from(KnowledgeSpaceScope)
+            .where(
+                KnowledgeSpaceScope.space_id == cast(ReviewTag.business_id, Integer),
+                KnowledgeSpaceScope.level.in_(org_levels),
+            )
+        ),
+        exists(
+            select(1)
+            .select_from(UserDepartment)
+            .join(Department, Department.id == UserDepartment.department_id)
+            .where(
+                UserDepartment.user_id == ReviewTag.user_id,
+                UserDepartment.is_primary == 1,
+                Department.org_level == ORG_LEVEL_OFFICE,
+                Department.id.in_(dept_id_list),
+            )
+        ),
+    )
+    return or_(org_business_match, org_link_match)
 
 
 class ReviewTagsRepositoryImpl:
@@ -74,53 +139,9 @@ class ReviewTagsRepositoryImpl:
         )
         return or_(business_match, link_match)
 
-    def _org_uploader_match_clause(self, tenant_id: int, uploader_ids: set[int]):
-        """组织管理员范围：团队/个人库，且**文件上传人**在组织内。
-
-        必须用 ``knowledge_file.user_id``，不能用 review_tag / review_tag_link.user_id：
-        后者是打标人。他人（如超管）给组织成员文件打标时，待审应仍归上传人组织管理员。
-        """
-        uploader_id_list = sorted(int(uid) for uid in uploader_ids)
-        org_levels = sorted(ORG_UPLOADER_REVIEW_LEVELS)
-        org_link_match = exists(
-            select(1)
-            .select_from(ReviewTagLink)
-            .join(
-                KnowledgeFile,
-                KnowledgeFile.id == cast(ReviewTagLink.resource_id, Integer),
-            )
-            .join(
-                KnowledgeSpaceScope,
-                KnowledgeSpaceScope.space_id == KnowledgeFile.knowledge_id,
-            )
-            .where(
-                ReviewTagLink.tag_id == ReviewTag.id,
-                ReviewTagLink.tenant_id == tenant_id,
-                ReviewTagLink.is_deleted == False,  # noqa: E712
-                KnowledgeFile.tenant_id == tenant_id,
-                KnowledgeSpaceScope.level.in_(org_levels),
-                KnowledgeFile.user_id.in_(uploader_id_list),
-            )
-        )
-        # 无文件挂接的遗留空间级待审：没有 knowledge_file，只能回退 tag.user_id。
-        org_business_match = and_(
-            ReviewTag.business_type.in_(
-                [
-                    TagBusinessTypeEnum.KNOWLEDGE_SPACE.value,
-                    TagBusinessTypeEnum.KNOWLEDGE.value,
-                ]
-            ),
-            ReviewTag.user_id.in_(uploader_id_list),
-            exists(
-                select(1)
-                .select_from(KnowledgeSpaceScope)
-                .where(
-                    KnowledgeSpaceScope.space_id == cast(ReviewTag.business_id, Integer),
-                    KnowledgeSpaceScope.level.in_(org_levels),
-                )
-            ),
-        )
-        return or_(org_business_match, org_link_match)
+    def _clinic_uploader_match_clause(self, tenant_id: int, department_ids: set[int]):
+        """科室库管理员范围：团队/个人库，上传人主部门落在所管科室。"""
+        return build_clinic_uploader_match_clause(tenant_id, department_ids)
 
     def _pending_review_scope_clause(self, tenant_id: int, scope: ReviewTagScope | None):
         """按 ReviewTagScope 限制待审标签；None 表示全租户。"""
@@ -129,8 +150,8 @@ class ReviewTagsRepositoryImpl:
         parts = []
         if scope.role_managed_space_ids:
             parts.append(self._role_space_match_clause(tenant_id, set(scope.role_managed_space_ids)))
-        if scope.org_uploader_ids:
-            parts.append(self._org_uploader_match_clause(tenant_id, set(scope.org_uploader_ids)))
+        if scope.clinic_admin_department_ids:
+            parts.append(self._clinic_uploader_match_clause(tenant_id, set(scope.clinic_admin_department_ids)))
         if not parts:
             return ReviewTag.id == -1
         return or_(*parts)
@@ -586,8 +607,8 @@ class ReviewTagsRepositoryImpl:
             kid = int(tag.business_id)
             if effective is not None:
                 level = await self._level_for_space(kid)
-                if not effective.allows_space_for_uploader(
-                    space_id=kid, level=level, uploader_id=int(tag.user_id or 0)
+                if not await self._allows_in_scope(
+                    effective, space_id=kid, level=level, uploader_id=int(tag.user_id or 0)
                 ):
                     continue
             if kid not in knowledge_ids:
@@ -707,7 +728,9 @@ class ReviewTagsRepositoryImpl:
         space_id = self._space_id_from_review_tag(tag)
         if space_id is not None:
             level = await self._level_for_space(int(space_id))
-            if scope.allows_space_for_uploader(space_id=int(space_id), level=level, uploader_id=int(tag.user_id or 0)):
+            if await self._allows_in_scope(
+                scope, space_id=int(space_id), level=level, uploader_id=int(tag.user_id or 0)
+            ):
                 return True
         if tag.id is None:
             return False
@@ -724,6 +747,38 @@ class ReviewTagsRepositoryImpl:
             return None
         return str(getattr(row, "level", "") or "") or None
 
+    async def _uploader_office_department_id(self, user_id: int | None) -> int | None:
+        """上传人主部门仅在已打 office 标时返回 department_id；否则 None（不上溯）。"""
+        if user_id is None or int(user_id) <= 0:
+            return None
+        from bisheng.database.models.department import DepartmentDao, UserDepartmentDao
+
+        primary = await UserDepartmentDao.aget_user_primary_department(int(user_id))
+        if primary is None or getattr(primary, "department_id", None) is None:
+            return None
+        dept = await DepartmentDao.aget_by_id(int(primary.department_id))
+        if dept is None:
+            return None
+        if str(getattr(dept, "org_level", "") or "") != ORG_LEVEL_OFFICE:
+            return None
+        return int(dept.id)
+
+    async def _allows_in_scope(
+        self,
+        scope: ReviewTagScope,
+        *,
+        space_id: int | None,
+        level: str | None,
+        uploader_id: int | None,
+    ) -> bool:
+        office_dept_id = await self._uploader_office_department_id(uploader_id)
+        return scope.allows_space_for_uploader(
+            space_id=space_id,
+            level=level,
+            uploader_id=uploader_id,
+            uploader_office_department_id=office_dept_id,
+        )
+
     async def link_in_review_scope(
         self,
         link: ReviewTagLink,
@@ -738,7 +793,7 @@ class ReviewTagsRepositoryImpl:
         # 有文件时按上传人；无文件才回退打标人（遗留无挂接行）。
         uploader_id = int(file_uploader_id or 0) or int(link.user_id or 0) or int(tag.user_id or 0)
         level = await self._level_for_space(space_id)
-        return scope.allows_space_for_uploader(space_id=space_id, level=level, uploader_id=uploader_id)
+        return await self._allows_in_scope(scope, space_id=space_id, level=level, uploader_id=uploader_id)
 
     async def _in_scope_link_ids_for_tag(
         self,
@@ -884,7 +939,9 @@ class ReviewTagsRepositoryImpl:
             if effective is not None:
                 level = await self._level_for_space(space_id)
                 scope_uploader = file_uploader_id or user_id
-                if not effective.allows_space_for_uploader(space_id=space_id, level=level, uploader_id=scope_uploader):
+                if not await self._allows_in_scope(
+                    effective, space_id=space_id, level=level, uploader_id=scope_uploader
+                ):
                     continue
             existing = user_targets.get(user_id)
             if existing is None or (existing.knowledge_space_id is None and space_id is not None):

--- a/src/backend/bisheng/workstation/domain/repositories/tag_console_repository.py
+++ b/src/backend/bisheng/workstation/domain/repositories/tag_console_repository.py
@@ -17,6 +17,10 @@ from bisheng.database.models.tag import Tag, TagBusinessTypeEnum, TagLink
 from bisheng.knowledge.domain.models.knowledge import Knowledge
 from bisheng.knowledge.domain.models.knowledge_file import KnowledgeFile
 from bisheng.knowledge.domain.models.knowledge_space_tag_library import KnowledgeSpaceTagLibrary
+from bisheng.workstation.domain.repositories.review_tags_repository import (
+    build_clinic_uploader_match_clause,
+)
+from bisheng.workstation.domain.schemas.review_tags_schema import ReviewTagScope
 from bisheng.workstation.domain.schemas.tag_console_schema import (
     TagConsoleFilter,
     TagConsoleReviewSearchReq,
@@ -385,37 +389,42 @@ class TagConsoleRepositoryImpl:
         )
 
     @classmethod
-    def _space_scope_clause(cls, tenant_id: int, space_ids: set[int] | None):
-        """Department-admin scope, mirroring the pending-review listing.
+    def _space_scope_clause(cls, tenant_id: int, scope: ReviewTagScope | None):
+        """按 ReviewTagScope 收窄审核列表；None 表示全租户不过滤。
 
-        Unlike library mode, review-mode rows *do* have per-space provenance, so
-        this narrowing is meaningful here (AC-38).
+        role 空间走 business_id / 文件 knowledge_id；科室路径并上上传人主部门
+        且 org_level=office 的团队/个人库（与待审列表同一 SQL）。
         """
-        if space_ids is None:
+        if scope is None or scope.full_tenant:
             return None
-        if not space_ids:
-            return ReviewTag.id == -1  # empty managed set matches nothing
-        space_id_list = sorted(int(space_id) for space_id in space_ids)
-        business_match = ReviewTag.business_type.in_(
-            [TagBusinessTypeEnum.KNOWLEDGE_SPACE.value, TagBusinessTypeEnum.KNOWLEDGE.value]
-        ) & ReviewTag.business_id.in_([str(space_id) for space_id in space_id_list])
-        link_match = exists(
-            select(1)
-            .select_from(ReviewTagLink)
-            .join(
-                KnowledgeFile,
-                # Compare as integers: resource_id is varchar, and CAST(id AS CHAR)
-                # hits collation mismatches on MySQL.
-                KnowledgeFile.id == cast(ReviewTagLink.resource_id, Integer),
+        parts = []
+        if scope.role_managed_space_ids:
+            space_id_list = sorted(int(space_id) for space_id in scope.role_managed_space_ids)
+            business_match = ReviewTag.business_type.in_(
+                [TagBusinessTypeEnum.KNOWLEDGE_SPACE.value, TagBusinessTypeEnum.KNOWLEDGE.value]
+            ) & ReviewTag.business_id.in_([str(space_id) for space_id in space_id_list])
+            link_match = exists(
+                select(1)
+                .select_from(ReviewTagLink)
+                .join(
+                    KnowledgeFile,
+                    # Compare as integers: resource_id is varchar, and CAST(id AS CHAR)
+                    # hits collation mismatches on MySQL.
+                    KnowledgeFile.id == cast(ReviewTagLink.resource_id, Integer),
+                )
+                .where(
+                    ReviewTagLink.tag_id == ReviewTag.id,
+                    ReviewTagLink.tenant_id == tenant_id,
+                    KnowledgeFile.tenant_id == tenant_id,
+                    KnowledgeFile.knowledge_id.in_(space_id_list),
+                )
             )
-            .where(
-                ReviewTagLink.tag_id == ReviewTag.id,
-                ReviewTagLink.tenant_id == tenant_id,
-                KnowledgeFile.tenant_id == tenant_id,
-                KnowledgeFile.knowledge_id.in_(space_id_list),
-            )
-        )
-        return or_(business_match, link_match)
+            parts.append(or_(business_match, link_match))
+        if scope.clinic_admin_department_ids:
+            parts.append(build_clinic_uploader_match_clause(tenant_id, set(scope.clinic_admin_department_ids)))
+        if not parts:
+            return ReviewTag.id == -1
+        return or_(*parts)
 
     @classmethod
     def _status_clause(cls, status: TagConsoleReviewStatus | None, tenant_id: int):
@@ -447,9 +456,9 @@ class TagConsoleRepositoryImpl:
         return or_(pending, rejected)
 
     @classmethod
-    def _review_filters(cls, req: TagConsoleReviewSearchReq, tenant_id: int, space_ids: set[int] | None) -> list:
+    def _review_filters(cls, req: TagConsoleReviewSearchReq, tenant_id: int, scope: ReviewTagScope | None) -> list:
         clauses = [ReviewTag.tenant_id == tenant_id, cls._status_clause(req.status, tenant_id)]
-        scope_clause = cls._space_scope_clause(tenant_id, space_ids)
+        scope_clause = cls._space_scope_clause(tenant_id, scope)
         if scope_clause is not None:
             clauses.append(scope_clause)
         if req.tag_name:
@@ -476,7 +485,7 @@ class TagConsoleRepositoryImpl:
         self,
         req: TagConsoleReviewSearchReq,
         tenant_id: int,
-        space_ids: set[int] | None,
+        scope: ReviewTagScope | None,
     ) -> tuple[list[tuple[str, str]], int]:
         """One page of ``(name, resource_type)`` pairs plus the unpaged total.
 
@@ -488,7 +497,7 @@ class TagConsoleRepositoryImpl:
         ``MAX(create_time) DESC, name, resource_type`` — the pair itself is
         unique, which makes that a total order and keeps paging stable.
         """
-        clauses = self._review_filters(req, tenant_id, space_ids)
+        clauses = self._review_filters(req, tenant_id, scope)
 
         total_stmt = select(func.count()).select_from(
             select(ReviewTag.name, ReviewTag.resource_type)
@@ -535,7 +544,7 @@ class TagConsoleRepositoryImpl:
         ).where(*cls._tag_field_filters(req, tenant_id), Tag.reviewer_id.is_not(None))
 
     @classmethod
-    def _rejected_leg(cls, req: TagConsoleReviewSearchReq, tenant_id: int, space_ids: set[int] | None):
+    def _rejected_leg(cls, req: TagConsoleReviewSearchReq, tenant_id: int, scope: ReviewTagScope | None):
         scoped = req.model_copy(update={"status": TagConsoleReviewStatus.REJECTED})
         return (
             select(
@@ -544,7 +553,7 @@ class TagConsoleRepositoryImpl:
                 ReviewTag.resource_type.label("resource_type"),
                 func.max(ReviewTag.review_time).label("sort_time"),
             )
-            .where(*cls._review_filters(scoped, tenant_id, space_ids))
+            .where(*cls._review_filters(scoped, tenant_id, scope))
             .group_by(ReviewTag.name, ReviewTag.resource_type)
         )
 
@@ -553,13 +562,13 @@ class TagConsoleRepositoryImpl:
         cls,
         req: TagConsoleReviewSearchReq,
         tenant_id: int,
-        space_ids: set[int] | None,
+        scope: ReviewTagScope | None,
     ):
         legs = []
         if req.status in (TagConsoleReviewStatus.APPROVED, TagConsoleReviewStatus.REVIEWED):
             legs.append(cls._approved_leg(req, tenant_id))
         if req.status in (TagConsoleReviewStatus.REJECTED, TagConsoleReviewStatus.REVIEWED):
-            legs.append(cls._rejected_leg(req, tenant_id, space_ids))
+            legs.append(cls._rejected_leg(req, tenant_id, scope))
         combined = legs[0] if len(legs) == 1 else union_all(*legs)
         return combined.subquery()
 
@@ -567,7 +576,7 @@ class TagConsoleRepositoryImpl:
         self,
         req: TagConsoleReviewSearchReq,
         tenant_id: int,
-        space_ids: set[int] | None,
+        scope: ReviewTagScope | None,
     ) -> tuple[list[tuple[int, str, str]], int]:
         """One page of ``(source, name, resource_type)`` plus the unpaged total.
 
@@ -576,7 +585,7 @@ class TagConsoleRepositoryImpl:
         stamps them all with the same value — so the pair itself and finally the
         source table break the tie, which makes the ordering total.
         """
-        subquery = self._reviewed_subquery(req, tenant_id, space_ids)
+        subquery = self._reviewed_subquery(req, tenant_id, scope)
 
         total = await self.session.scalar(select(func.count()).select_from(subquery))
 
@@ -598,7 +607,7 @@ class TagConsoleRepositoryImpl:
         self,
         req: TagConsoleReviewSearchReq,
         tenant_id: int,
-        space_ids: set[int] | None,
+        scope: ReviewTagScope | None,
     ) -> tuple[int, int, int]:
         """Pending / rejected / approved totals, deliberately ignoring the status
         filter.
@@ -609,7 +618,7 @@ class TagConsoleRepositoryImpl:
         counts = []
         for status in (TagConsoleReviewStatus.PENDING, TagConsoleReviewStatus.REJECTED):
             scoped = req.model_copy(update={"status": status})
-            clauses = self._review_filters(scoped, tenant_id, space_ids)
+            clauses = self._review_filters(scoped, tenant_id, scope)
             statement = select(func.count()).select_from(
                 select(ReviewTag.name, ReviewTag.resource_type)
                 .where(*clauses)
@@ -620,7 +629,7 @@ class TagConsoleRepositoryImpl:
 
         approved_req = req.model_copy(update={"status": TagConsoleReviewStatus.APPROVED})
         approved_total = await self.session.scalar(
-            select(func.count()).select_from(self._reviewed_subquery(approved_req, tenant_id, space_ids))
+            select(func.count()).select_from(self._reviewed_subquery(approved_req, tenant_id, scope))
         )
         counts.append(int(approved_total or 0))
         return counts[0], counts[1], counts[2]
@@ -629,7 +638,7 @@ class TagConsoleRepositoryImpl:
         self,
         pairs: list[tuple[str, str]],
         tenant_id: int,
-        space_ids: set[int] | None,
+        scope: ReviewTagScope | None,
     ) -> dict[tuple[str, str], list[ReviewTag]]:
         """All ``review_tag`` rows behind the page's grouped pairs."""
         if not pairs:
@@ -643,7 +652,7 @@ class TagConsoleRepositoryImpl:
                 ReviewTag.review_status == REJECTED_STATUS,
             ),
         ]
-        scope_clause = self._space_scope_clause(tenant_id, space_ids)
+        scope_clause = self._space_scope_clause(tenant_id, scope)
         if scope_clause is not None:
             clauses.append(scope_clause)
         rows = (await self.session.exec(select(ReviewTag).where(*clauses))).all()

--- a/src/backend/bisheng/workstation/domain/schemas/review_tags_schema.py
+++ b/src/backend/bisheng/workstation/domain/schemas/review_tags_schema.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 
 from bisheng.database.models.review_tags import ApproveOrRejectEnum, TagResourceTypeEnum
 
-# 公共/部门/科室：库角色审核；团队/个人：按上传人组织管理员审核。
+# 公共/部门/科室：库管理员（不含仅所有者）；团队/个人：上传人科室下科室库管理员并集。
 ROLE_MANAGED_REVIEW_LEVELS = frozenset({"public", "department", "team_ks"})
 ORG_UPLOADER_REVIEW_LEVELS = frozenset({"team", "personal"})
 
@@ -24,32 +24,50 @@ class ReviewTagScope:
 
     Attributes:
         full_tenant: 超管/租户管理员，不过滤。
-        role_managed_space_ids: 当前用户对 public/department/team_ks 具备 can_manage 的空间。
-        org_uploader_ids: 部门管理员所管组织内的用户（按文件上传人匹配）；None 表示非部门管理员路径。
+        role_managed_space_ids: 对 public/department/team_ks 具备独立管理员授权的空间
+            （can_manage 含部门/用户组继承，但排除「仅凭所有者」）。
+        clinic_admin_department_ids: 上述 team_ks 经 department_knowledge_space
+            绑到的科室 department_id；用于匹配团队/个人库文件上传人的主部门。
     """
 
     full_tenant: bool = False
     role_managed_space_ids: frozenset[int] = field(default_factory=frozenset)
-    org_uploader_ids: frozenset[int] | None = None
+    clinic_admin_department_ids: frozenset[int] = field(default_factory=frozenset)
 
     def has_review_capacity(self) -> bool:
-        """是否具备任一审核入口（含部门管理员空组织）。"""
-        return self.full_tenant or bool(self.role_managed_space_ids) or self.org_uploader_ids is not None
+        """是否具备任一审核入口。"""
+        return self.full_tenant or bool(self.role_managed_space_ids) or bool(self.clinic_admin_department_ids)
 
-    def allows_space_for_uploader(self, *, space_id: int | None, level: str | None, uploader_id: int | None) -> bool:
-        """判断某空间+上传人组合是否在本 scope 内。"""
+    def allows_space_for_uploader(
+        self,
+        *,
+        space_id: int | None,
+        level: str | None,
+        uploader_id: int | None,
+        uploader_office_department_id: int | None = None,
+    ) -> bool:
+        """判断某空间+上传人科室组合是否在本 scope 内。
+
+        参数:
+            space_id: 文件所在知识空间。
+            level: 空间 level。
+            uploader_id: 文件上传人（团队/个人路径不再按人集合匹配，保留兼容调用方）。
+            uploader_office_department_id: 上传人主部门且 org_level=office 时的部门 ID；
+                未打科室标则为 None。
+        """
         if self.full_tenant:
             return True
         if space_id is not None and int(space_id) in self.role_managed_space_ids:
             return True
-        if self.org_uploader_ids is None:
+        if not self.clinic_admin_department_ids:
             return False
         level_value = str(level or "")
         if level_value not in ORG_UPLOADER_REVIEW_LEVELS:
             return False
-        if uploader_id is None or int(uploader_id) <= 0:
+        if uploader_office_department_id is None or int(uploader_office_department_id) <= 0:
             return False
-        return int(uploader_id) in self.org_uploader_ids
+        _ = uploader_id
+        return int(uploader_office_department_id) in self.clinic_admin_department_ids
 
 
 class ApproveOrRejectRequest(BaseModel):

--- a/src/backend/bisheng/workstation/domain/services/tag_console_service.py
+++ b/src/backend/bisheng/workstation/domain/services/tag_console_service.py
@@ -30,7 +30,7 @@ from bisheng.workstation.domain.repositories.tag_console_repository import (
     SOURCE_TAG,
     TagConsoleRepositoryImpl,
 )
-from bisheng.workstation.domain.schemas.review_tags_schema import ApproveOrRejectRequest
+from bisheng.workstation.domain.schemas.review_tags_schema import ApproveOrRejectRequest, ReviewTagScope
 from bisheng.workstation.domain.schemas.tag_console_schema import (
     MAX_BATCH_SIZE,
     MAX_PAGE_SIZE,
@@ -104,6 +104,13 @@ class TagConsoleService:
             return
         raise ReviewTagPermissionDeniedError()
 
+    async def _review_scope_or_full(self) -> ReviewTagScope | None:
+        """解析审核范围：全租户返回 None（仓库不过滤），否则返回受限 scope。"""
+        scope = await self.tags_service.resolve_review_tag_scope()
+        if scope.full_tenant:
+            return None
+        return scope
+
     async def search(self, req: TagConsoleSearchReq, tenant_id: int) -> TagConsoleSearchResp:
         self._validate_page(req)
         await self._ensure_can_manage_tags()
@@ -176,20 +183,20 @@ class TagConsoleService:
 
     async def review_search(self, req: TagConsoleReviewSearchReq, tenant_id: int) -> TagConsoleReviewSearchResp:
         self._validate_page(req)
-        space_ids = await self.tags_service.resolve_reviewable_space_ids()
+        scope = await self._review_scope_or_full()
 
         if req.status in (TagConsoleReviewStatus.APPROVED, TagConsoleReviewStatus.REVIEWED):
             # The "已审核" tab spans two tables, so rows arrive tagged with the
             # one they came from.
-            refs, total = await self.repository.search_reviewed_tags(req, tenant_id=tenant_id, space_ids=space_ids)
+            refs, total = await self.repository.search_reviewed_tags(req, tenant_id=tenant_id, scope=scope)
         else:
-            pairs, total = await self.repository.search_review_tags(req, tenant_id=tenant_id, space_ids=space_ids)
+            pairs, total = await self.repository.search_review_tags(req, tenant_id=tenant_id, scope=scope)
             refs = [(SOURCE_REVIEW, name, resource_type) for name, resource_type in pairs]
 
         pending_count, rejected_count, approved_count = await self.repository.count_review_by_status(
-            req, tenant_id=tenant_id, space_ids=space_ids
+            req, tenant_id=tenant_id, scope=scope
         )
-        data = await self._assemble_review_page(refs, tenant_id=tenant_id, space_ids=space_ids)
+        data = await self._assemble_review_page(refs, tenant_id=tenant_id, scope=scope)
         return TagConsoleReviewSearchResp(
             data=data,
             total=total,
@@ -202,7 +209,7 @@ class TagConsoleService:
         self,
         refs: list[tuple[int, str, str]],
         tenant_id: int,
-        space_ids: set[int] | None,
+        scope: ReviewTagScope | None,
     ) -> list[TagConsoleReviewItem]:
         """Decorate each half with its own query, then restore the page order.
 
@@ -217,7 +224,7 @@ class TagConsoleService:
 
         review_items = {
             (item.name, item.resource_type): item
-            for item in await self._decorate_review(review_pairs, tenant_id=tenant_id, space_ids=space_ids)
+            for item in await self._decorate_review(review_pairs, tenant_id=tenant_id, scope=scope)
         }
         approved_items = await self._decorate_approved(approved_pairs, tenant_id=tenant_id)
 
@@ -269,9 +276,9 @@ class TagConsoleService:
 
         Shares the query used by review mode so the two numbers cannot drift.
         """
-        space_ids = await self.tags_service.resolve_reviewable_space_ids()
+        scope = await self._review_scope_or_full()
         pending, _, _ = await self.repository.count_review_by_status(
-            TagConsoleReviewSearchReq(), tenant_id=tenant_id, space_ids=space_ids
+            TagConsoleReviewSearchReq(), tenant_id=tenant_id, scope=scope
         )
         return pending
 
@@ -292,8 +299,8 @@ class TagConsoleService:
         )
 
     async def review_detail(self, ref: TagConsoleReviewRef, tenant_id: int) -> TagConsoleReviewItem:
-        space_ids = await self.tags_service.resolve_reviewable_space_ids()
-        items = await self._decorate_review([(ref.name, ref.resource_type)], tenant_id=tenant_id, space_ids=space_ids)
+        scope = await self._review_scope_or_full()
+        items = await self._decorate_review([(ref.name, ref.resource_type)], tenant_id=tenant_id, scope=scope)
         if not items:
             raise ReviewTagNotFoundError()
         return items[0]
@@ -302,11 +309,11 @@ class TagConsoleService:
         self,
         pairs: list[tuple[str, str]],
         tenant_id: int,
-        space_ids: set[int] | None,
+        scope: ReviewTagScope | None,
     ) -> list[TagConsoleReviewItem]:
         if not pairs:
             return []
-        grouped = await self.repository.load_review_group(pairs, tenant_id=tenant_id, space_ids=space_ids)
+        grouped = await self.repository.load_review_group(pairs, tenant_id=tenant_id, scope=scope)
 
         all_ids = [int(row.id) for rows in grouped.values() for row in rows if row.id is not None]
         files_by_tag = await self.repository.list_review_source_files(all_ids, tenant_id=tenant_id)
@@ -478,13 +485,13 @@ class TagConsoleService:
         target_library_id: int | None = None,
         reject_reason: str | None = None,
     ) -> TagConsoleBatchResult:
-        space_ids = await self.tags_service.resolve_reviewable_space_ids()
+        scope = await self._review_scope_or_full()
         self._validate_batch(items)
         if approve and not await self.repository.library_exists(target_library_id, tenant_id):
             raise KnowledgeSpaceTagLibraryNotExistError()
 
         pairs = [(item.name, item.resource_type) for item in items]
-        grouped = await self.repository.load_review_group(pairs, tenant_id=tenant_id, space_ids=space_ids)
+        grouped = await self.repository.load_review_group(pairs, tenant_id=tenant_id, scope=scope)
         # One batched lookup for the whole request rather than per item.
         spaces_by_review_tag = await self._map_review_tags_to_spaces(grouped, tenant_id=tenant_id) if approve else {}
 
@@ -498,7 +505,7 @@ class TagConsoleService:
                 # The underlying flow only looks at pending rows and would report
                 # a bare "tag not found"; say what is actually wrong instead.
                 raise TagConsoleActionNotApplicableError()
-            knowledge_id = self._resolve_knowledge_id(rows, space_ids, spaces_by_review_tag)
+            knowledge_id = self._resolve_knowledge_id(rows, scope, spaces_by_review_tag)
             if approve and knowledge_id is None:
                 # Logged, not silent: this rejects the whole item while still
                 # returning HTTP 200, which is invisible in the access log.
@@ -506,7 +513,12 @@ class TagConsoleService:
                     "tag console approve skipped, no in-scope source space for %s (review_tag ids=%s, scope=%s)",
                     item.name,
                     [row.id for row in rows],
-                    "all" if space_ids is None else sorted(space_ids),
+                    "all"
+                    if scope is None
+                    else (
+                        f"role={sorted(scope.role_managed_space_ids)} "
+                        f"clinic={sorted(scope.clinic_admin_department_ids)}"
+                    ),
                 )
                 result.failed.append(TagConsoleBatchFailure(name=item.name, reason="缺少来源知识"))
                 continue
@@ -571,21 +583,25 @@ class TagConsoleService:
     @staticmethod
     def _resolve_knowledge_id(
         rows,
-        space_ids: set[int] | None,
+        scope: ReviewTagScope | None,
         spaces_by_review_tag: dict[int, list[int]],
     ) -> int | None:
-        """First in-scope knowledge space carrying the tag.
+        """解析通过时写入的目标知识空间。
 
-        A tag produced in several spaces still approves into one library; the
-        review panel lists every source file so the reviewer sees the blast radius.
-
-        Source files come first because that is where the provenance actually
-        lives; ``business_id`` is only trusted when the row explicitly says it
-        holds a knowledge space.
+        优先来源文件所在、且落在 role 管理空间内的库；科室路径下再用文件来源
+        团队/个人库（2A）。``business_id`` 仅在行明确声明 knowledge_space 时兜底。
         """
+        full = scope is None or scope.full_tenant
+        role_ids = frozenset() if full else scope.role_managed_space_ids
+        clinic = False if full else bool(scope.clinic_admin_department_ids)
+
         for row in rows:
             for space_id in spaces_by_review_tag.get(int(row.id), []):
-                if space_ids is None or space_id in space_ids:
+                if full or space_id in role_ids:
+                    return space_id
+        if clinic:
+            for row in rows:
+                for space_id in spaces_by_review_tag.get(int(row.id), []):
                     return space_id
         for row in rows:
             if row.business_type != TagBusinessTypeEnum.KNOWLEDGE_SPACE.value:
@@ -593,7 +609,7 @@ class TagConsoleService:
             if not str(row.business_id or "").isdigit():
                 continue
             space_id = int(row.business_id)
-            if space_ids is None or space_id in space_ids:
+            if full or space_id in role_ids or clinic:
                 return space_id
         return None
 

--- a/src/backend/bisheng/workstation/domain/services/workstation_tags_service.py
+++ b/src/backend/bisheng/workstation/domain/services/workstation_tags_service.py
@@ -30,14 +30,113 @@ from bisheng.workstation.domain.services.review_tag_notification_service import 
 )
 
 
+def _parse_fga_user_ref(user_ref: str) -> tuple[str, int] | None:
+    """解析 OpenFGA user 字段：user:1 / department:10#member / user_group:5#admin。"""
+    raw = str(user_ref or "").strip()
+    if not raw:
+        return None
+    relation_sep = raw.find("#")
+    object_part = raw[:relation_sep] if relation_sep >= 0 else raw
+    if ":" not in object_part:
+        return None
+    kind, _, ident = object_part.partition(":")
+    if not ident.isdigit():
+        return None
+    return kind, int(ident)
+
+
+async def _user_has_independent_manager_grant(user_id: int, space_id: int) -> bool:
+    """用户是否对该空间持有独立于 owner 的 manager 授权（口径 2：含部门/用户组）。"""
+    from bisheng.database.models.department import DepartmentDao, UserDepartmentDao
+    from bisheng.database.models.user_group import UserGroupDao
+    from bisheng.permission.domain.services.permission_service import PermissionService
+
+    try:
+        fga = await PermissionService._aget_fga()
+    except Exception:
+        logger.exception("openfga client failed while excluding owner-only review spaces space_id=%s", space_id)
+        return False
+    if fga is None:
+        return False
+    try:
+        manager_tuples = await fga.read_tuples(relation="manager", object=f"knowledge_space:{int(space_id)}")
+    except Exception:
+        logger.exception("openfga read manager failed space_id=%s", space_id)
+        return False
+
+    memberships = await UserDepartmentDao.aget_user_departments(int(user_id))
+    user_dept_ids = {int(row.department_id) for row in (memberships or []) if getattr(row, "department_id", None)}
+    group_rows = await UserGroupDao.aget_user_group(int(user_id))
+    user_group_ids = {int(row.group_id) for row in (group_rows or []) if getattr(row, "group_id", None)}
+
+    for item in manager_tuples or []:
+        parsed = _parse_fga_user_ref(str(item.get("user") or ""))
+        if parsed is None:
+            continue
+        kind, ident = parsed
+        if kind == "user" and ident == int(user_id):
+            return True
+        if kind == "department":
+            dept = await DepartmentDao.aget_by_id(ident)
+            path = getattr(dept, "path", None) if dept is not None else None
+            if path:
+                subtree = await DepartmentDao.aget_subtree_ids(path)
+                if user_dept_ids.intersection(int(i) for i in (subtree or [])):
+                    return True
+            elif ident in user_dept_ids:
+                return True
+        if kind == "user_group" and ident in user_group_ids:
+            return True
+    return False
+
+
+async def _exclude_owner_only_space_ids(user_id: int, space_ids: set[int], login_user: UserPayload) -> set[int]:
+    """从 can_manage 集合中去掉仅凭所有者进入的空间。"""
+    if not space_ids:
+        return set()
+    from bisheng.permission.domain.services.permission_service import PermissionService
+
+    raw_owner_ids = await PermissionService.list_accessible_ids(
+        user_id=user_id,
+        relation="owner",
+        object_type="knowledge_space",
+        login_user=login_user,
+    )
+    owner_ids = {int(i) for i in (raw_owner_ids or []) if str(i).isdigit()}
+    for space_id in space_ids:
+        sid = int(space_id)
+        if sid in owner_ids:
+            continue
+        try:
+            creator_id = await PermissionService._get_resource_creator("knowledge_space", str(sid))
+        except Exception:
+            logger.exception("creator fallback failed while excluding owner-only review space_id=%s", sid)
+            continue
+        if creator_id is not None and int(creator_id) == int(user_id):
+            owner_ids.add(sid)
+    kept = {int(space_id) for space_id in space_ids if int(space_id) not in owner_ids}
+    for space_id in space_ids:
+        sid = int(space_id)
+        if sid not in owner_ids or sid in kept:
+            continue
+        if await _user_has_independent_manager_grant(user_id, sid):
+            kept.add(sid)
+    return kept
+
+
 async def _resolve_fga_role_managed_space_ids(login_user: UserPayload) -> frozenset[int]:
-    """解析 public/department/team_ks 下具备 can_manage 的空间（OpenFGA + 成员表 fallback）。"""
-    from bisheng.common.models.space_channel_member import SpaceChannelMemberDao
+    """解析 public/department/team_ks 下具备独立管理员授权的空间。
+
+    OpenFGA can_manage 含所有者；按身份排除后只保留独立 manager（含部门/用户组继承）。
+    FGA 无结果时回退成员表 admin，不含 creator。
+    """
+    from bisheng.common.models.space_channel_member import SpaceChannelMemberDao, UserRoleEnum
     from bisheng.knowledge.domain.models.knowledge_space_scope import KnowledgeSpaceScopeDao
     from bisheng.permission.domain.services.permission_service import PermissionService
 
     user_id = int(login_user.user_id)
     candidate_ids: list[int] = []
+    used_member_fallback = False
 
     raw_ids = await PermissionService.list_accessible_ids(
         user_id=user_id,
@@ -49,11 +148,20 @@ async def _resolve_fga_role_managed_space_ids(login_user: UserPayload) -> frozen
         candidate_ids = [int(i) for i in raw_ids if str(i).isdigit()]
 
     if not candidate_ids:
+        used_member_fallback = True
         managed_members = await SpaceChannelMemberDao.async_get_user_managed_members(user_id)
         for member in managed_members or []:
+            if getattr(member, "user_role", None) != UserRoleEnum.ADMIN:
+                continue
             business_id = str(getattr(member, "business_id", "") or "").strip()
             if business_id.isdigit():
                 candidate_ids.append(int(business_id))
+
+    if not candidate_ids:
+        return frozenset()
+
+    if not used_member_fallback:
+        candidate_ids = sorted(await _exclude_owner_only_space_ids(user_id, set(candidate_ids), login_user))
 
     if not candidate_ids:
         return frozenset()
@@ -66,6 +174,25 @@ async def _resolve_fga_role_managed_space_ids(login_user: UserPayload) -> frozen
         if level in ROLE_MANAGED_REVIEW_LEVELS:
             role_space_ids.add(int(space_id))
     return frozenset(role_space_ids)
+
+
+async def _clinic_admin_department_ids(role_space_ids: frozenset[int]) -> frozenset[int]:
+    """当前人管理的科室库绑定到的科室部门 ID（多库并集）。"""
+    from bisheng.knowledge.domain.models.department_knowledge_space import DepartmentKnowledgeSpaceDao
+    from bisheng.knowledge.domain.models.knowledge_space_scope import KnowledgeSpaceScopeDao
+
+    if not role_space_ids:
+        return frozenset()
+    scope_map = await KnowledgeSpaceScopeDao.aget_map_by_space_ids(list(role_space_ids))
+    team_ks_ids = [
+        int(space_id)
+        for space_id in role_space_ids
+        if str(getattr(scope_map.get(space_id), "level", "") or "") == "team_ks"
+    ]
+    if not team_ks_ids:
+        return frozenset()
+    bindings = await DepartmentKnowledgeSpaceDao.aget_by_space_ids(team_ks_ids)
+    return frozenset(int(row.department_id) for row in (bindings or []) if getattr(row, "department_id", None))
 
 
 async def resolve_review_tag_scope_for_user(login_user: UserPayload) -> ReviewTagScope:
@@ -91,22 +218,11 @@ async def resolve_review_tag_scope_for_user(login_user: UserPayload) -> ReviewTa
             return ReviewTagScope(full_tenant=True)
 
     role_space_ids = await _resolve_fga_role_managed_space_ids(login_user)
-
-    from bisheng.database.models.department import DepartmentDao
-    from bisheng.knowledge.domain.services.department_admin_member_access import (
-        aget_dept_admin_scoped_user_ids,
-    )
-
-    admin_depts = await DepartmentDao.aget_user_admin_departments(int(login_user.user_id))
-    org_uploader_ids: frozenset[int] | None = None
-    if admin_depts:
-        scoped = await aget_dept_admin_scoped_user_ids(int(login_user.user_id))
-        org_uploader_ids = frozenset(int(uid) for uid in (scoped or set()))
-
+    clinic_dept_ids = await _clinic_admin_department_ids(role_space_ids)
     scope = ReviewTagScope(
         full_tenant=False,
         role_managed_space_ids=role_space_ids,
-        org_uploader_ids=org_uploader_ids,
+        clinic_admin_department_ids=clinic_dept_ids,
     )
     if not scope.has_review_capacity():
         raise ReviewTagPermissionDeniedError()
@@ -161,7 +277,7 @@ class WorkStationTagsService(BaseService):
         kid = int(knowledge_id)
         if kid in scope.role_managed_space_ids:
             return
-        if scope.org_uploader_ids is None:
+        if not scope.clinic_admin_department_ids:
             raise ReviewTagSpaceOutOfScopeError()
         from bisheng.knowledge.domain.models.knowledge_space_scope import (
             KnowledgeSpaceLevelEnum,
@@ -172,7 +288,7 @@ class WorkStationTagsService(BaseService):
         level = str(getattr(scope_row, "level", "") or "") if scope_row else ""
         if level not in (KnowledgeSpaceLevelEnum.TEAM.value, KnowledgeSpaceLevelEnum.PERSONAL.value):
             raise ReviewTagSpaceOutOfScopeError()
-        # 组织管理员可将通过结果落到团队/个人库；空间本身须为这两类。
+        # 科室库管理员可将团队/个人待审写回来源团队/个人库。
         return
 
     async def delete_review_tag(

--- a/src/backend/test/workstation/test_review_tag_dept_admin_scope.py
+++ b/src/backend/test/workstation/test_review_tag_dept_admin_scope.py
@@ -1,8 +1,9 @@
-"""Unit tests for review-tag authorization by space level and org uploader."""
+"""标签审核范围：独立管理员（排除仅所有者）+ 上传人科室下科室库管理员并集。"""
 
 import importlib
 import sys
 import types
+from contextlib import ExitStack, contextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -25,6 +26,7 @@ from bisheng.common.errcode.tag import (
     ReviewTagPermissionDeniedError,
     ReviewTagSpaceOutOfScopeError,
 )
+from bisheng.common.models.space_channel_member import UserRoleEnum
 from bisheng.database.models.review_tags import ApproveOrRejectEnum, TagResourceTypeEnum
 from bisheng.workstation.domain.schemas.review_tags_schema import ApproveOrRejectRequest, ReviewTagScope
 
@@ -61,23 +63,63 @@ def _login_user():
     )
 
 
-@pytest.mark.asyncio
-async def test_resolve_review_tag_scope_denies_ordinary_user():
-    login_user = _login_user()
-    with (
+def _accessible(*, can_manage=None, owner=None):
+    async def _impl(*, relation, **kwargs):
+        if relation == "owner":
+            return list(owner or [])
+        return list(can_manage or [])
+
+    return AsyncMock(side_effect=_impl)
+
+
+@contextmanager
+def _scope_patches(
+    *,
+    can_manage=None,
+    owner=None,
+    levels=None,
+    members=None,
+    clinic_bindings=None,
+    creator=None,
+    fga=None,
+):
+    """解析审核范围时用到的 FGA / 成员表 / 科室绑定桩。"""
+    patches = (
         patch(
             "bisheng.permission.domain.services.permission_service.PermissionService.list_accessible_ids",
-            new=AsyncMock(return_value=[]),
+            new=_accessible(can_manage=can_manage, owner=owner),
+        ),
+        patch(
+            "bisheng.permission.domain.services.permission_service.PermissionService._get_resource_creator",
+            new=AsyncMock(return_value=creator),
+        ),
+        patch(
+            "bisheng.permission.domain.services.permission_service.PermissionService._aget_fga",
+            new=AsyncMock(return_value=fga),
+        ),
+        patch(
+            "bisheng.knowledge.domain.models.knowledge_space_scope.KnowledgeSpaceScopeDao.aget_map_by_space_ids",
+            new=AsyncMock(return_value=levels or {}),
         ),
         patch(
             "bisheng.common.models.space_channel_member.SpaceChannelMemberDao.async_get_user_managed_members",
-            new=AsyncMock(return_value=[]),
+            new=AsyncMock(return_value=members or []),
         ),
         patch(
-            "bisheng.database.models.department.DepartmentDao.aget_user_admin_departments",
-            new=AsyncMock(return_value=[]),
+            "bisheng.knowledge.domain.models.department_knowledge_space.DepartmentKnowledgeSpaceDao.aget_by_space_ids",
+            new=AsyncMock(return_value=clinic_bindings or []),
         ),
-    ):
+    )
+    with ExitStack() as stack:
+        for item in patches:
+            stack.enter_context(item)
+        yield
+
+
+@pytest.mark.asyncio
+async def test_resolve_review_tag_scope_denies_ordinary_user():
+    login_user = _login_user()
+    with _scope_patches():
         with pytest.raises(ReviewTagPermissionDeniedError):
             await resolve_review_tag_scope_for_user(login_user)
 
@@ -85,51 +127,72 @@ async def test_resolve_review_tag_scope_denies_ordinary_user():
 @pytest.mark.asyncio
 async def test_resolve_review_tag_scope_for_space_admin_role_libraries_only():
     login_user = _login_user()
-    with (
-        patch(
-            "bisheng.permission.domain.services.permission_service.PermissionService.list_accessible_ids",
-            new=AsyncMock(return_value=["100", "200", "300"]),
-        ),
-        patch(
-            "bisheng.knowledge.domain.models.knowledge_space_scope.KnowledgeSpaceScopeDao.aget_map_by_space_ids",
-            new=AsyncMock(
-                return_value={
-                    100: SimpleNamespace(level="public"),
-                    200: SimpleNamespace(level="team_ks"),
-                    300: SimpleNamespace(level="team"),
-                }
-            ),
-        ),
-        patch(
-            "bisheng.database.models.department.DepartmentDao.aget_user_admin_departments",
-            new=AsyncMock(return_value=[]),
-        ),
+    with _scope_patches(
+        can_manage=["100", "200", "300"],
+        owner=[],
+        levels={
+            100: SimpleNamespace(level="public"),
+            200: SimpleNamespace(level="team_ks"),
+            300: SimpleNamespace(level="team"),
+        },
+        clinic_bindings=[SimpleNamespace(department_id=55)],
     ):
         scope = await resolve_review_tag_scope_for_user(login_user)
 
     assert scope.full_tenant is False
     assert scope.role_managed_space_ids == frozenset({100, 200})
-    assert scope.org_uploader_ids is None
+    assert scope.clinic_admin_department_ids == frozenset({55})
 
 
 @pytest.mark.asyncio
-async def test_resolve_review_tag_scope_falls_back_to_member_table():
+async def test_resolve_review_tag_scope_falls_back_to_member_table_admin_only():
     login_user = _login_user()
+    with _scope_patches(
+        can_manage=[],
+        members=[
+            SimpleNamespace(business_id="100", user_role=UserRoleEnum.ADMIN),
+            SimpleNamespace(business_id="200", user_role=UserRoleEnum.CREATOR),
+        ],
+        levels={
+            100: SimpleNamespace(level="department"),
+            200: SimpleNamespace(level="public"),
+        },
+    ):
+        scope = await resolve_review_tag_scope_for_user(login_user)
+
+    assert scope.role_managed_space_ids == frozenset({100})
+    assert 200 not in scope.role_managed_space_ids
+
+
+@pytest.mark.asyncio
+async def test_owner_only_cannot_review():
+    login_user = _login_user()
+    with _scope_patches(
+        can_manage=["100"],
+        owner=["100"],
+        levels={100: SimpleNamespace(level="public")},
+    ):
+        with pytest.raises(ReviewTagPermissionDeniedError):
+            await resolve_review_tag_scope_for_user(login_user)
+
+
+@pytest.mark.asyncio
+async def test_owner_with_independent_manager_can_review():
+    login_user = _login_user()
+    fga = SimpleNamespace(read_tuples=AsyncMock(return_value=[{"user": "user:9"}]))
     with (
+        _scope_patches(
+            can_manage=["100"],
+            owner=["100"],
+            levels={100: SimpleNamespace(level="public")},
+            fga=fga,
+        ),
         patch(
-            "bisheng.permission.domain.services.permission_service.PermissionService.list_accessible_ids",
+            "bisheng.database.models.department.UserDepartmentDao.aget_user_departments",
             new=AsyncMock(return_value=[]),
         ),
         patch(
-            "bisheng.common.models.space_channel_member.SpaceChannelMemberDao.async_get_user_managed_members",
-            new=AsyncMock(return_value=[SimpleNamespace(business_id="100")]),
-        ),
-        patch(
-            "bisheng.knowledge.domain.models.knowledge_space_scope.KnowledgeSpaceScopeDao.aget_map_by_space_ids",
-            new=AsyncMock(return_value={100: SimpleNamespace(level="department")}),
-        ),
-        patch(
-            "bisheng.database.models.department.DepartmentDao.aget_user_admin_departments",
+            "bisheng.database.models.user_group.UserGroupDao.aget_user_group",
             new=AsyncMock(return_value=[]),
         ),
     ):
@@ -139,58 +202,46 @@ async def test_resolve_review_tag_scope_falls_back_to_member_table():
 
 
 @pytest.mark.asyncio
-async def test_resolve_review_tag_scope_for_department_admin_org_uploaders_only():
+async def test_department_inherited_manager_can_review():
     login_user = _login_user()
-    with (
-        patch(
-            "bisheng.permission.domain.services.permission_service.PermissionService.list_accessible_ids",
-            new=AsyncMock(return_value=[]),
-        ),
-        patch(
-            "bisheng.common.models.space_channel_member.SpaceChannelMemberDao.async_get_user_managed_members",
-            new=AsyncMock(return_value=[]),
-        ),
-        patch(
-            "bisheng.database.models.department.DepartmentDao.aget_user_admin_departments",
-            new=AsyncMock(return_value=[SimpleNamespace(id=10, path="1/10/")]),
-        ),
-        patch(
-            "bisheng.knowledge.domain.services.department_admin_member_access.aget_dept_admin_scoped_user_ids",
-            new=AsyncMock(return_value={42, 43}),
-        ),
-    ):
-        scope = await resolve_review_tag_scope_for_user(login_user)
-
-    assert scope.full_tenant is False
-    assert scope.role_managed_space_ids == frozenset()
-    assert scope.org_uploader_ids == frozenset({42, 43})
-
-
-@pytest.mark.asyncio
-async def test_resolve_review_tag_scope_combines_role_and_org():
-    login_user = _login_user()
-    with (
-        patch(
-            "bisheng.permission.domain.services.permission_service.PermissionService.list_accessible_ids",
-            new=AsyncMock(return_value=["100"]),
-        ),
-        patch(
-            "bisheng.knowledge.domain.models.knowledge_space_scope.KnowledgeSpaceScopeDao.aget_map_by_space_ids",
-            new=AsyncMock(return_value={100: SimpleNamespace(level="department")}),
-        ),
-        patch(
-            "bisheng.database.models.department.DepartmentDao.aget_user_admin_departments",
-            new=AsyncMock(return_value=[SimpleNamespace(id=10, path="1/10/")]),
-        ),
-        patch(
-            "bisheng.knowledge.domain.services.department_admin_member_access.aget_dept_admin_scoped_user_ids",
-            new=AsyncMock(return_value={7}),
-        ),
+    with _scope_patches(
+        can_manage=["100"],
+        owner=[],
+        levels={100: SimpleNamespace(level="department")},
     ):
         scope = await resolve_review_tag_scope_for_user(login_user)
 
     assert scope.role_managed_space_ids == frozenset({100})
-    assert scope.org_uploader_ids == frozenset({7})
+
+
+@pytest.mark.asyncio
+async def test_department_admin_without_space_admin_cannot_review():
+    login_user = _login_user()
+    with _scope_patches():
+        with pytest.raises(ReviewTagPermissionDeniedError):
+            await resolve_review_tag_scope_for_user(login_user)
+        assert await user_can_review_tags(login_user) is False
+
+
+@pytest.mark.asyncio
+async def test_clinic_admin_department_ids_are_union_of_team_ks():
+    login_user = _login_user()
+    with _scope_patches(
+        can_manage=["200", "201"],
+        owner=[],
+        levels={
+            200: SimpleNamespace(level="team_ks"),
+            201: SimpleNamespace(level="team_ks"),
+        },
+        clinic_bindings=[
+            SimpleNamespace(department_id=10),
+            SimpleNamespace(department_id=11),
+        ],
+    ):
+        scope = await resolve_review_tag_scope_for_user(login_user)
+
+    assert scope.role_managed_space_ids == frozenset({200, 201})
+    assert scope.clinic_admin_department_ids == frozenset({10, 11})
 
 
 @pytest.mark.asyncio
@@ -199,7 +250,7 @@ async def test_user_can_review_tags():
     with patch.object(
         workstation_tags_service,
         "resolve_review_tag_scope_for_user",
-        new=AsyncMock(return_value=ReviewTagScope(org_uploader_ids=frozenset({1}))),
+        new=AsyncMock(return_value=ReviewTagScope(clinic_admin_department_ids=frozenset({1}))),
     ):
         assert await user_can_review_tags(login_user) is True
 
@@ -214,7 +265,7 @@ async def test_user_can_review_tags():
 @pytest.mark.asyncio
 async def test_list_review_tag_by_page_passes_scope():
     service = _build_service()
-    scope = ReviewTagScope(org_uploader_ids=frozenset({1}))
+    scope = ReviewTagScope(clinic_admin_department_ids=frozenset({1}))
     service.resolve_review_tag_scope = AsyncMock(return_value=scope)
     service.review_tags_repository.get_review_tag_group_list_by_page = AsyncMock(
         return_value=[{"name": "foo", "resource_type": TagResourceTypeEnum.MANUAL_TAG}]
@@ -253,6 +304,57 @@ async def test_approve_rejects_role_library_outside_scope():
         pytest.raises(ReviewTagSpaceOutOfScopeError),
     ):
         await service.approve_or_reject_review_tag(data, tenant_id=1)
+
+
+@pytest.mark.asyncio
+async def test_approve_allows_personal_space_for_clinic_admin():
+    service = _build_service()
+    scope = ReviewTagScope(clinic_admin_department_ids=frozenset({10}))
+    service.resolve_review_tag_scope = AsyncMock(return_value=scope)
+    data = ApproveOrRejectRequest(
+        tag_name="personal",
+        status=ApproveOrRejectEnum.APPROVE,
+        resource_type=TagResourceTypeEnum.MANUAL_TAG,
+        tag_library_id=10,
+        knowledge_id=20,
+    )
+    service.approve_tag_to_move_operation = AsyncMock(return_value=[])
+    service.review_tags_repository.approve_review_tag = AsyncMock()
+    service.review_tags_repository.list_submitter_notification_targets = AsyncMock(return_value=[])
+    service.review_tags_repository.get_review_tag_list_by_tag_name = AsyncMock(
+        return_value=[SimpleNamespace(business_type="knowledge_space", business_id="20")],
+    )
+
+    with (
+        patch(
+            "bisheng.knowledge.domain.models.knowledge_space_scope.KnowledgeSpaceScopeDao.aget_by_space_id",
+            new=AsyncMock(return_value=SimpleNamespace(level="personal")),
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_tag_library_service.KnowledgeSpaceTagLibraryService",
+        ) as library_service_cls,
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_tag_library_service.KnowledgeSpaceTagLibraryService.resolve_bound_library_ids",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "bisheng.workstation.domain.services.review_tag_notification_service.ReviewTagNotificationService.notify_after_decision",
+            new=AsyncMock(),
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.tag_library_tag_service.TagLibraryTagService.invalidate_link_b_tenant_catalog_cache_async",
+            new=AsyncMock(),
+        ),
+    ):
+        library_service_cls.return_value.append_review_tag = AsyncMock()
+        await service.approve_or_reject_review_tag(data, tenant_id=1)
+
+    service.review_tags_repository.approve_review_tag.assert_awaited_once_with(
+        "personal",
+        TagResourceTypeEnum.MANUAL_TAG,
+        1,
+        scope=scope,
+    )
 
 
 @pytest.mark.asyncio
@@ -313,7 +415,7 @@ async def test_approve_passes_scope_to_repository():
 @pytest.mark.asyncio
 async def test_reject_passes_scope_to_repository():
     service = _build_service()
-    scope = ReviewTagScope(org_uploader_ids=frozenset({42}))
+    scope = ReviewTagScope(clinic_admin_department_ids=frozenset({42}))
     service.resolve_review_tag_scope = AsyncMock(return_value=scope)
     data = ApproveOrRejectRequest(
         tag_name="scoped",
@@ -356,21 +458,35 @@ async def test_global_super_has_full_scope():
     assert scope.full_tenant is True
 
 
-@pytest.mark.asyncio
-async def test_review_tag_scope_allows_predicates():
+def test_review_tag_scope_allows_predicates():
     scope = ReviewTagScope(
         role_managed_space_ids=frozenset({10}),
-        org_uploader_ids=frozenset({5}),
+        clinic_admin_department_ids=frozenset({5}),
     )
     assert scope.allows_space_for_uploader(space_id=10, level="public", uploader_id=99) is True
-    assert scope.allows_space_for_uploader(space_id=20, level="team", uploader_id=5) is True
-    assert scope.allows_space_for_uploader(space_id=20, level="team_ks", uploader_id=5) is False
-    assert scope.allows_space_for_uploader(space_id=20, level="personal", uploader_id=6) is False
+    assert (
+        scope.allows_space_for_uploader(space_id=20, level="team", uploader_id=99, uploader_office_department_id=5)
+        is True
+    )
+    assert (
+        scope.allows_space_for_uploader(space_id=20, level="team_ks", uploader_id=99, uploader_office_department_id=5)
+        is False
+    )
+    assert (
+        scope.allows_space_for_uploader(space_id=20, level="personal", uploader_id=99, uploader_office_department_id=6)
+        is False
+    )
+    assert (
+        scope.allows_space_for_uploader(
+            space_id=20, level="personal", uploader_id=99, uploader_office_department_id=None
+        )
+        is False
+    )
 
 
 @pytest.mark.asyncio
-async def test_link_in_review_scope_uses_file_uploader_not_tagger():
-    """他人给组织成员文件打标时，团队库待审归文件上传人的组织管理员。"""
+async def test_link_in_review_scope_uses_file_uploader_office_not_tagger():
+    """他人给组织成员文件打标时，团队库待审归上传人科室下的科室库管理员。"""
     from bisheng.workstation.domain.repositories.review_tags_repository import ReviewTagsRepositoryImpl
 
     repo = ReviewTagsRepositoryImpl(session=AsyncMock(), tags_repository=AsyncMock())
@@ -384,21 +500,24 @@ async def test_link_in_review_scope_uses_file_uploader_not_tagger():
         )
     )
     repo._level_for_space = AsyncMock(return_value="team")
+    repo._uploader_office_department_id = AsyncMock(side_effect=lambda uid: 10 if int(uid) == 42 else 99)
     link = SimpleNamespace(resource_id="15", user_id=1)
     tag = SimpleNamespace(user_id=1)
 
-    org_of_uploader = ReviewTagScope(org_uploader_ids=frozenset({42}))
-    assert await repo.link_in_review_scope(link, tag, 1, org_of_uploader) is True
+    clinic_of_uploader = ReviewTagScope(clinic_admin_department_ids=frozenset({10}))
+    assert await repo.link_in_review_scope(link, tag, 1, clinic_of_uploader) is True
 
-    org_of_tagger = ReviewTagScope(org_uploader_ids=frozenset({1}))
-    assert await repo.link_in_review_scope(link, tag, 1, org_of_tagger) is False
+    clinic_of_tagger = ReviewTagScope(clinic_admin_department_ids=frozenset({99}))
+    assert await repo.link_in_review_scope(link, tag, 1, clinic_of_tagger) is False
 
 
-def test_org_uploader_sql_matches_knowledge_file_user_id():
+def test_clinic_uploader_sql_matches_knowledge_file_user_id_and_office_level():
     from bisheng.workstation.domain.repositories.review_tags_repository import ReviewTagsRepositoryImpl
 
     repo = ReviewTagsRepositoryImpl(session=AsyncMock(), tags_repository=AsyncMock())
-    clause = repo._org_uploader_match_clause(1, {42})
+    clause = repo._clinic_uploader_match_clause(1, {42})
     compiled = str(clause.compile(compile_kwargs={"literal_binds": True})).lower().replace("`", "")
     assert "knowledgefile.user_id" in compiled
     assert "review_tag_link.user_id" not in compiled
+    assert "org_level" in compiled
+    assert "office" in compiled

--- a/src/backend/test/workstation/test_tag_console_approve_scope.py
+++ b/src/backend/test/workstation/test_tag_console_approve_scope.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from bisheng.database.models.review_tags import ApproveOrRejectEnum
+from bisheng.workstation.domain.schemas.review_tags_schema import ReviewTagScope
 from bisheng.workstation.domain.schemas.tag_console_schema import TagConsoleReviewRef
 from bisheng.workstation.domain.services.tag_console_service import TagConsoleService
 
@@ -42,7 +43,7 @@ def _review_row():
     )
 
 
-def _build_service(*, space_ids=None, files_by_tag=None, briefs=None):
+def _build_service(*, scope=None, files_by_tag=None, briefs=None):
     repository = AsyncMock()
     repository.library_exists.return_value = True
     repository.load_review_group.return_value = {(TAG.name, TAG.resource_type): [_review_row()]}
@@ -56,7 +57,7 @@ def _build_service(*, space_ids=None, files_by_tag=None, briefs=None):
     )
 
     tags_service = AsyncMock()
-    tags_service.resolve_reviewable_space_ids.return_value = space_ids
+    tags_service.resolve_review_tag_scope.return_value = ReviewTagScope(full_tenant=True) if scope is None else scope
     return (
         TagConsoleService(
             login_user=SimpleNamespace(user_id=1, tenant_id=TENANT_ID),
@@ -84,7 +85,7 @@ async def test_approve_uses_the_space_from_the_source_file():
 @pytest.mark.asyncio
 async def test_approve_fails_when_the_space_is_out_of_the_admins_scope():
     """A department admin must not approve a tag sourced from someone else's space."""
-    service, tags_service = _build_service(space_ids={999})
+    service, tags_service = _build_service(scope=ReviewTagScope(role_managed_space_ids=frozenset({999})))
 
     result = await service.batch_approve([TAG], LIBRARY_ID, TENANT_ID)
 
@@ -115,3 +116,16 @@ async def test_reject_does_not_need_a_source_space():
     request = tags_service.approve_or_reject_review_tag.await_args.args[0]
     assert request.status == ApproveOrRejectEnum.REJECT
     assert request.reject_reason == "不建议新增"
+
+
+@pytest.mark.asyncio
+async def test_approve_clinic_admin_uses_source_team_or_personal_space():
+    """科室路径下来源空间不在 role 集合里，仍应写回来源团队/个人库。"""
+    service, tags_service = _build_service(scope=ReviewTagScope(clinic_admin_department_ids=frozenset({10})))
+
+    result = await service.batch_approve([TAG], LIBRARY_ID, TENANT_ID)
+
+    assert result.succeeded == 1
+    request = tags_service.approve_or_reject_review_tag.await_args.args[0]
+    assert request.knowledge_id == SPACE_ID
+    assert request.tag_library_id == LIBRARY_ID

--- a/src/backend/test/workstation/test_tag_console_library_sync.py
+++ b/src/backend/test/workstation/test_tag_console_library_sync.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from bisheng.database.models.tag import Tag, TagBusinessTypeEnum, TagResourceTypeEnum
+from bisheng.workstation.domain.schemas.review_tags_schema import ReviewTagScope
 from bisheng.workstation.domain.services.tag_console_service import TagConsoleService
 
 TENANT_ID = 1
@@ -45,7 +46,7 @@ def _build_service(found: list[Tag], calls: list[str]):
     repository.session.commit = AsyncMock(side_effect=lambda: calls.append("commit"))
 
     tags_service = AsyncMock()
-    tags_service.resolve_reviewable_space_ids.return_value = None
+    tags_service.resolve_review_tag_scope.return_value = ReviewTagScope(full_tenant=True)
     return TagConsoleService(
         login_user=SimpleNamespace(
             user_id=1,

--- a/src/backend/test/workstation/test_tag_console_review_search.py
+++ b/src/backend/test/workstation/test_tag_console_review_search.py
@@ -25,6 +25,7 @@ from bisheng.workstation.domain.repositories.tag_console_repository import (
     SOURCE_TAG,
     TagConsoleRepositoryImpl,
 )
+from bisheng.workstation.domain.schemas.review_tags_schema import ReviewTagScope
 from bisheng.workstation.domain.schemas.tag_console_schema import (
     TagConsoleReviewSearchReq,
     TagConsoleReviewStatus,
@@ -185,10 +186,10 @@ async def _seed(session):
     return {"scale": scale, "rejected": rejected, "orphan": orphan}
 
 
-async def _search(session, *, space_ids=None, **overrides):
+async def _search(session, *, scope=None, **overrides):
     repository = TagConsoleRepositoryImpl(session=session)
     req = TagConsoleReviewSearchReq(**overrides)
-    return await repository.search_review_tags(req, tenant_id=TENANT_ID, space_ids=space_ids)
+    return await repository.search_review_tags(req, tenant_id=TENANT_ID, scope=scope)
 
 
 @pytest.mark.asyncio
@@ -263,7 +264,7 @@ async def test_counts_ignore_status_filter(async_db_session):
     repository = TagConsoleRepositoryImpl(session=async_db_session)
 
     narrowed = TagConsoleReviewSearchReq(status=TagConsoleReviewStatus.PENDING)
-    pending, rejected, approved = await repository.count_review_by_status(narrowed, tenant_id=TENANT_ID, space_ids=None)
+    pending, rejected, approved = await repository.count_review_by_status(narrowed, tenant_id=TENANT_ID, scope=None)
 
     assert pending == 3
     assert rejected == 1, "rejected total must stay real while viewing pending"
@@ -311,17 +312,21 @@ async def test_department_scope_narrows_rows(async_db_session):
     """Review rows do have per-space provenance, unlike library-mode tags."""
     await _seed(async_db_session)
 
-    _, in_scope = await _search(async_db_session, space_ids={201}, status=TagConsoleReviewStatus.PENDING)
+    _, in_scope = await _search(
+        async_db_session,
+        scope=ReviewTagScope(role_managed_space_ids=frozenset({201})),
+        status=TagConsoleReviewStatus.PENDING,
+    )
     assert in_scope == 2  # 结垢 (has a row in 201) / 边裂
 
-    _, empty_scope = await _search(async_db_session, space_ids=set())
+    _, empty_scope = await _search(async_db_session, scope=ReviewTagScope())
     assert empty_scope == 0
 
 
-async def _search_reviewed(session, *, space_ids=None, **overrides):
+async def _search_reviewed(session, *, scope=None, **overrides):
     repository = TagConsoleRepositoryImpl(session=session)
     req = TagConsoleReviewSearchReq(**overrides)
-    return await repository.search_reviewed_tags(req, tenant_id=TENANT_ID, space_ids=space_ids)
+    return await repository.search_reviewed_tags(req, tenant_id=TENANT_ID, scope=scope)
 
 
 @pytest.mark.asyncio
@@ -389,7 +394,7 @@ async def test_load_group_and_source_files(async_db_session):
     seeded = await _seed(async_db_session)
     repository = TagConsoleRepositoryImpl(session=async_db_session)
 
-    grouped = await repository.load_review_group([("结垢", AI)], tenant_id=TENANT_ID, space_ids=None)
+    grouped = await repository.load_review_group([("结垢", AI)], tenant_id=TENANT_ID, scope=None)
     assert len(grouped[("结垢", AI)]) == 3
 
     files = await repository.list_review_source_files(


### PR DESCRIPTION
## Summary
- 公共/部门/科室库只认独立管理员（含部门/用户组继承），排除仅凭所有者审核
- 团队/个人库按文件上传人已打标科室下的科室库管理员并集审核，通过后写回来源库
- 纯部门管理员不再具备标签审核入口；Tag Console 审核列表走完整 ReviewTagScope

## Test plan
- [ ] 仅所有者的公共/部门/科室库：除超管/租户管理员外无人可审
- [ ] 所有者另有独立 manager（含部门继承）时可审
- [ ] 上传人主部门已打 office 标：该科室下多座科室库管理员都能看到团队/个人待审
- [ ] 主部门未打标或班组：科室库管理员看不见该待审
- [ ] 纯部门管理员 `can_review_tags=false`，门户无审核菜单
- [ ] 通过后标签写入来源团队/个人库


Made with [Cursor](https://cursor.com)