### PR TITLE
fix(knowledge): QA children 对齐 spaces 的 discovery_scope

### DIFF
--- a/src/backend/bisheng/knowledge/api/endpoints/shougang_portal.py
+++ b/src/backend/bisheng/knowledge/api/endpoints/shougang_portal.py
@@ -542,13 +542,19 @@ async def search_shougang_portal_qa_files(
     return resp_200(ShougangPortalQaFileSearchResp(**result).model_dump(mode="json"))
 
 
+# 与 /spaces 列表对齐。门户登录选库会传 portal_configured；只接受 public 时会 422，门户再翻成 502。
+PortalQaChildrenDiscoveryScope = Literal[
+    "public",
+    "public_and_department",
+    "portal_public",
+    "portal_configured",
+]
+
+
 @router.get("/qa/spaces/{space_id}/children")
 async def list_shougang_portal_qa_children(
     space_id: int,
-    discovery_scope: Literal[
-        "public",
-        "public_and_department",
-    ] = "public_and_department",
+    discovery_scope: PortalQaChildrenDiscoveryScope = "public_and_department",
     parent_id: int | None = None,
     cursor: str | None = None,
     page_size: int = Query(default=10, ge=1, le=100),
@@ -568,10 +574,7 @@ async def list_shougang_portal_qa_children(
 async def get_shougang_portal_qa_folder_stats(
     space_id: int,
     req: KnowledgeSpaceFolderStatsReq,
-    discovery_scope: Literal[
-        "public",
-        "public_and_department",
-    ] = "public_and_department",
+    discovery_scope: PortalQaChildrenDiscoveryScope = "public_and_department",
     svc: Any = Depends(get_knowledge_space_service),
 ) -> Any:
     result = await svc.get_shougang_portal_qa_folder_stats(

--- a/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
+++ b/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
@@ -6630,6 +6630,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
         space_id: int,
         discovery_scope: str,
     ) -> tuple[Knowledge, bool]:
+        """按当前 discovery_scope 取空间；不在可见集合里则拒绝展开目录。"""
         spaces = await self._get_shougang_portal_request_spaces(
             requested_space_ids=[space_id],
             space_level=None,

--- a/src/backend/test/knowledge/test_portal_qa_tree_selection.py
+++ b/src/backend/test/knowledge/test_portal_qa_tree_selection.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -926,3 +927,41 @@ async def test_handle_file_folder_extra_info_uses_folder_count_override():
     assert result[0]["success_file_num"] == 1
     assert result[0]["visible_success_file_num"] == 1
     assert result[0]["processing_file_num"] == 1
+
+
+@pytest.mark.asyncio
+async def test_portal_qa_children_denies_space_outside_visibility(monkeypatch):
+    """不在当前 discovery_scope 可见集合里的空间，展开目录必须拒绝。"""
+    service = object.__new__(svc_mod.KnowledgeSpaceService)
+    monkeypatch.setattr(
+        service,
+        "_get_shougang_portal_request_spaces",
+        AsyncMock(return_value=[]),
+    )
+
+    with pytest.raises(SpacePermissionDeniedError):
+        await service.list_shougang_portal_qa_children(
+            space_id=120,
+            parent_id=None,
+            cursor=None,
+            page_size=10,
+            discovery_scope="portal_configured",
+        )
+
+
+def test_portal_qa_children_endpoint_accepts_configured_discovery_scopes():
+    source = Path(svc_mod.__file__).resolve().parents[2] / "api" / "endpoints" / "shougang_portal.py"
+    text = source.read_text()
+    alias_start = text.find("PortalQaChildrenDiscoveryScope")
+    assert alias_start != -1
+    alias_src = text[alias_start : alias_start + 280]
+    assert '"portal_configured"' in alias_src
+    assert '"portal_public"' in alias_src
+    children_src = text[
+        text.find("async def list_shougang_portal_qa_children") : text.find(
+            "async def get_shougang_portal_qa_folder_stats"
+        )
+    ]
+    stats_src = text[text.find("async def get_shougang_portal_qa_folder_stats") :]
+    assert "PortalQaChildrenDiscoveryScope" in children_src
+    assert "PortalQaChildrenDiscoveryScope" in stats_src[:400]


### PR DESCRIPTION
## Summary
- 门户登录选库会传 `portal_configured`；原先 `/qa/spaces/{id}/children` 与 folder-stats 只接受 `public` / `public_and_department`，FastAPI 422 后被门户翻成 502。
- children / folder-stats 的 `discovery_scope` 与 `/spaces` 列表对齐，并继续拒绝展开当前可见集合外的空间。

## Test plan
- [ ] `pytest src/backend/test/knowledge/test_portal_qa_tree_selection.py -k portal_qa_children`
- [ ] 登录用户对可见空间展开 children 返回 200
- [ ] 对不可见部门库（如无权限的 120）展开 children 返回权限拒绝，而不是 422/502
- [ ] 未登录仍走 `public`，公共库 children 200


Made with [Cursor](https://cursor.com)