### PR TITLE
fix(qa-expert): 完善作者删答规则并为关联文档走知识空间 can_read

### DIFF
--- a/src/backend/bisheng/common/errcode/qa_expert.py
+++ b/src/backend/bisheng/common/errcode/qa_expert.py
@@ -68,3 +68,9 @@ class QaExpertAnonymousRevealRequiredError(BaseErrorCode):
     """定向且勾选匿名时，必须预选转公开后是否公开姓名。"""
 
     Code, Msg = 18311, "定向匿名须选择转公开后是否公开姓名"
+
+
+class QaExpertAnswerDeleteNotAllowedError(BaseErrorCode):
+    """作者删答：已采纳，或存在有效转公开申请。"""
+
+    Code, Msg = 18312, "当前不可删除该回答"

--- a/src/backend/bisheng/qa_expert/api/endpoints.py
+++ b/src/backend/bisheng/qa_expert/api/endpoints.py
@@ -414,6 +414,12 @@ def answer_payload(answer) -> dict:
         payload["author"] = author
     if isinstance(author, dict) and author.get("anonymous") and "real_name" not in author:
         payload["expert_name"] = author.get("display_name")
+    can_delete = getattr(answer, "can_delete", payload.get("can_delete"))
+    if can_delete is not None:
+        payload["can_delete"] = bool(can_delete)
+    related_doc_views = getattr(answer, "related_doc_views", payload.get("related_doc_views"))
+    if related_doc_views is not None:
+        payload["related_doc_views"] = related_doc_views
     return payload
 
 
@@ -567,8 +573,9 @@ async def delete_answer(
     """删除回答"""
     try:
         success = await service.delete_answer(answer_id, user.user_id)
-
         return resp_200(data={"success": success})
+    except BaseErrorCode as exc:
+        return exc.return_resp_instance()
     except Exception as e:
         return resp_500(code=500, message=str(e))
 

--- a/src/backend/bisheng/qa_expert/domain/related_docs_access.py
+++ b/src/backend/bisheng/qa_expert/domain/related_docs_access.py
@@ -1,5 +1,5 @@
 # ruff: noqa: RUF002
-"""关联文档 knowledge 鉴权适配：无权=forbidden，无文件=not_found。不在本域另造映射。"""
+"""关联文档 knowledge 鉴权：文件存在性 + 知识空间 can_read。无权=forbidden，无文件=not_found。"""
 
 from __future__ import annotations
 
@@ -8,29 +8,64 @@ from typing import Any
 RELATED_DOC_ACCESS_TIMEOUT_SEC = 3.0
 
 
-async def check_related_doc_access(user: Any, space_id: int, file_id: int) -> bool | None:
-    """True 文件存在；None 文件不存在。
-
-    不在这里调 PermissionService / OpenFGA：当前 LoginUser 缺 get_visible_tenants，
-    list_accessible_ids 会卡住 uvicorn 单 worker，整道问题详情 8s 超时。
-    可见性由 QuestionService.hydrate_related_docs 按提问者/路人切开。
-    """
-    del user
+async def _file_belongs_to_space(space_id: int, file_id: int) -> bool:
+    """knowledgefile 是否存在且归属该知识空间。"""
     try:
         from sqlmodel import select
 
         from bisheng.core.database import get_async_db_session
         from bisheng.knowledge.domain.models.knowledge_file import KnowledgeFile
     except Exception:
-        return None
+        return False
 
     async with get_async_db_session() as session:
         stmt = select(KnowledgeFile).where(KnowledgeFile.id == int(file_id))
         result = await session.exec(stmt)
         row = result.first()
     if row is None:
-        return None
+        return False
     knowledge_id = int(getattr(row, "knowledge_id", 0) or 0)
-    if knowledge_id and knowledge_id != int(space_id):
+    return (not knowledge_id) or knowledge_id == int(space_id)
+
+
+async def _space_can_read(user: Any, space_id: int) -> bool:
+    """单点 PermissionService.check，禁止 list_accessible_ids。"""
+    user_id = getattr(user, "user_id", None) if user is not None else None
+    if user_id is None:
+        return False
+    try:
+        from bisheng.permission.domain.services.permission_service import PermissionService
+
+        return bool(
+            await PermissionService.check(
+                user_id=int(user_id),
+                relation="can_read",
+                object_type="knowledge_space",
+                object_id=str(int(space_id)),
+                login_user=user,
+            )
+        )
+    except Exception:
+        return False
+
+
+async def check_related_doc_access(
+    user: Any,
+    space_id: int,
+    file_id: int,
+    *,
+    space_cache: dict[int, bool] | None = None,
+) -> bool | None:
+    """True 可读；False 文件在但当前用户无权；None 文件不存在或空间不匹配。
+
+    同一次 hydrate 通过 space_cache 对相同 space_id 只 check 一次。
+    """
+    if not await _file_belongs_to_space(int(space_id), int(file_id)):
         return None
-    return True
+    cache_key = int(space_id)
+    if space_cache is not None and cache_key in space_cache:
+        return space_cache[cache_key]
+    allowed = await _space_can_read(user, cache_key)
+    if space_cache is not None:
+        space_cache[cache_key] = allowed
+    return allowed

--- a/src/backend/bisheng/qa_expert/domain/services.py
+++ b/src/backend/bisheng/qa_expert/domain/services.py
@@ -19,6 +19,7 @@ from bisheng.common.errcode.base import BaseErrorCode
 from bisheng.common.errcode.qa_expert import (
     QaExpertAdminRequiredError,
     QaExpertAdoptLimitError,
+    QaExpertAnswerDeleteNotAllowedError,
     QaExpertAnswerNotAllowedError,
     QaExpertCommentNotAllowedError,
     QaExpertContentLockedError,
@@ -29,6 +30,7 @@ from bisheng.core.database import get_async_db_session
 from bisheng.core.storage.minio.minio_manager import get_minio_storage
 from bisheng.database.models.department import DepartmentDao
 from bisheng.database.models.qa_expert import (
+    ANSWER_STATUS_DELETED,
     EXPERT_STATUS_ACTIVE,
     EXPERT_STATUS_DISABLED,
     Answer,
@@ -773,19 +775,21 @@ class QuestionService:
     async def hydrate_related_docs(
         self, related_docs: str | None, user=None, owner_user_id: int | None = None
     ) -> list[dict]:
-        """解析关联文档串；无权用 forbidden，禁止用 not_found 表示无权限。
+        """解析关联文档串。问答可见不等于文档可读；无权 forbidden，缺失 not_found。
 
-        不调 OpenFGA：提问者视为有权，其他浏览者一律 forbidden。避免 LoginUser
-        缺 get_visible_tenants 时 list_accessible_ids 卡住整道详情。
+        owner_user_id 仅为兼容旧调用方，不再按提问者特判。
         """
+        del owner_user_id
         views: list[dict] = []
-        checker = getattr(self, "related_docs_access_checker", None)
-        if checker is None:
+        injected = getattr(self, "related_docs_access_checker", None)
+        space_cache: dict[int, bool] = {}
+
+        async def _default_checker(_user, space_id: int, file_id: int):
             from bisheng.qa_expert.domain.related_docs_access import check_related_doc_access
 
-            checker = check_related_doc_access
-        viewer_id = getattr(user, "user_id", None) if user is not None else None
-        is_owner = owner_user_id is not None and viewer_id is not None and int(viewer_id) == int(owner_user_id)
+            return await check_related_doc_access(_user, space_id, file_id, space_cache=space_cache)
+
+        checker = injected if callable(injected) else _default_checker
         for token in parse_related_doc_tokens(related_docs):
             parsed = parse_related_doc_ref(token)
             if parsed is None:
@@ -802,31 +806,27 @@ class QuestionService:
                 continue
             space_id, file_id = parsed
             doc_id = f"{space_id}-{file_id}"
-            accessible = True
-            reason = None
-            if callable(checker):
-                access = checker(user, space_id, file_id)
-                if inspect.isawaitable(access):
-                    try:
-                        from bisheng.qa_expert.domain.related_docs_access import (
-                            RELATED_DOC_ACCESS_TIMEOUT_SEC,
-                        )
+            accessible = False
+            reason = "forbidden"
+            access = checker(user, space_id, file_id)
+            if inspect.isawaitable(access):
+                try:
+                    from bisheng.qa_expert.domain.related_docs_access import (
+                        RELATED_DOC_ACCESS_TIMEOUT_SEC,
+                    )
 
-                        access = await asyncio.wait_for(access, timeout=RELATED_DOC_ACCESS_TIMEOUT_SEC)
-                    except Exception:
-                        access = False
-                if access is None:
-                    accessible = False
-                    reason = "not_found"
-                elif access is False:
-                    accessible = False
-                    reason = "forbidden"
-                elif is_owner or owner_user_id is None:
-                    accessible = True
-                    reason = None
-                else:
-                    accessible = False
-                    reason = "forbidden"
+                    access = await asyncio.wait_for(access, timeout=RELATED_DOC_ACCESS_TIMEOUT_SEC)
+                except Exception:
+                    access = False
+            if access is None:
+                accessible = False
+                reason = "not_found"
+            elif access is False:
+                accessible = False
+                reason = "forbidden"
+            else:
+                accessible = True
+                reason = None
             views.append(
                 {
                     "id": doc_id,
@@ -1306,6 +1306,8 @@ class AnswerService:
         self.invite_repo = QuestionInviteRepository()
         self.eligibility_repo = AnswerEligibilityRepository()
         self.notification_repo = NotificationRepository()
+        self.comment_repo = CommentRepository()
+        self.publish_request_repo = PublishRequestRepository()
         self.asset_service = asset_service
         self.capability_resolver = CapabilityResolver()
         self.identity_service = None
@@ -1361,6 +1363,53 @@ class AnswerService:
         if question is None:
             return answer
         return await self._attach_answer_author(viewer, answer, question)
+
+    @staticmethod
+    def _is_adopted_answer(answer) -> bool:
+        """已采纳：认 qa_answer.adopted，兼容旧 status=2。"""
+        if bool(getattr(answer, "adopted", False)):
+            return True
+        return int(getattr(answer, "status", 1) or 0) == 2
+
+    async def _answer_author_id(self, answer) -> int | None:
+        """解析回答作者用户 ID：优先 qa_answer.user_id，否则专家档案。"""
+        if getattr(answer, "user_id", None):
+            return int(answer.user_id)
+        if getattr(answer, "expert_id", None) is not None:
+            expert = await self.expert_repo.get_by_id(answer.expert_id)
+            if expert is not None and getattr(expert, "user_id", None) is not None:
+                return int(expert.user_id)
+        return None
+
+    async def _assert_question_visible(self, question, user) -> None:
+        """回答/评论读路径与问题详情同一套定向可见性。"""
+        if question is None:
+            raise QuestionNotFoundError()
+        viewer = user or SimpleNamespace(user_id=0, is_admin=lambda: False, role=None)
+        invite_map = await self.invite_repo.list_user_ids_by_question_ids([int(question.id)])
+        invited = invite_map.get(int(question.id), set())
+        snapshot = CapabilitySnapshot(invited_user_ids=frozenset(invited))
+        if not self.capability_resolver.resolve(viewer, question, snapshot).capabilities.visible:
+            raise QaExpertQuestionAccessDeniedError()
+
+    async def _can_author_delete(self, answer, operator_id: int, *, pending_publish: bool) -> bool:
+        """作者可删：本人、未采纳、无进行中转公开、未软删。"""
+        if int(getattr(answer, "status", 0) or 0) == ANSWER_STATUS_DELETED:
+            return False
+        if self._is_adopted_answer(answer) or pending_publish:
+            return False
+        author_id = await self._answer_author_id(answer)
+        return author_id is not None and int(author_id) == int(operator_id)
+
+    async def _pending_publish_after_lazy_expire(self, question_id: int):
+        """列答/删答前复用转公开详情的惰性过期，避免到期后仍按 pending 拦删除。"""
+        from bisheng.qa_expert.domain.publish_service import PublishService
+
+        refresher = getattr(self, "publish_refresher", None)
+        if refresher is None:
+            refresher = PublishService().refresh_latest_for_question
+        await refresher(int(question_id))
+        return await self.publish_request_repo.get_pending_by_question(int(question_id))
 
     async def _resolve_answer(self, answer: Answer) -> Answer:
         values = {"images_url": answer.images_url, "attachments": answer.attachments}
@@ -1480,13 +1529,25 @@ class AnswerService:
     ) -> tuple[list[Answer], int]:
         """获取问题的回答列表；匿名回答者 expert_name 在 JSON 层改成别名。"""
         question = await self.question_repo.get_by_id(question_id)
+        await self._assert_question_visible(question, user)
         answers, total = await self.repository.get_by_question_id(question_id, skip=skip, limit=limit, sort_by=sort_by)
         viewer = user or SimpleNamespace(user_id=0, is_admin=lambda: False, role=None)
+        viewer_id = int(getattr(viewer, "user_id", 0) or 0)
+        pending = await self._pending_publish_after_lazy_expire(int(question.id))
+        pending_publish = pending is not None
+        question_svc = QuestionService()
+        question_svc.related_docs_access_checker = getattr(self, "related_docs_access_checker", None)
         resolved: list[Answer] = []
         for answer in answers:
             item = await self._resolve_answer(answer)
-            if question is not None:
-                item = await self._attach_answer_author(viewer, item, question)
+            item = await self._attach_answer_author(viewer, item, question)
+            can_delete = await self._can_author_delete(item, viewer_id, pending_publish=pending_publish)
+            related_doc_views = await question_svc.hydrate_related_docs(
+                getattr(item, "related_docs", None),
+                user=viewer,
+                owner_user_id=int(getattr(question, "user_id", 0) or 0),
+            )
+            self._annotate(item, can_delete=can_delete, related_doc_views=related_doc_views)
             resolved.append(item)
         return resolved, total
 
@@ -1563,25 +1624,29 @@ class AnswerService:
         return await self._resolve_answer(updated)
 
     async def delete_answer(self, answer_id: int, operator_id: int) -> bool:
-        """删除回答：有效回答数可回 0，content_locked 不解除。"""
+        """作者删除未采纳回答：软删回答、硬删其下评论；有效转公开申请进行中时拒绝。"""
         answer = await self.repository.get_by_id(answer_id)
-        if not answer:
+        if not answer or int(getattr(answer, "status", 0) or 0) == ANSWER_STATUS_DELETED:
             raise AnswerNotFoundError()
 
-        author_id = getattr(answer, "user_id", None)
-        if author_id is None and getattr(answer, "expert_id", None) is not None:
-            expert = await self.expert_repo.get_by_id(answer.expert_id)
-            author_id = getattr(expert, "user_id", None) if expert is not None else None
-        if author_id != operator_id:
-            raise PermissionDeniedError(message="Only answer author can delete")
+        author_id = await self._answer_author_id(answer)
+        if author_id is None or int(author_id) != int(operator_id):
+            raise PermissionDeniedError(msg="Only answer author can delete")
+        if self._is_adopted_answer(answer):
+            raise QaExpertAnswerDeleteNotAllowedError(msg="已采纳的回答不可删除")
+        pending = await self._pending_publish_after_lazy_expire(int(answer.question_id))
+        if pending is not None:
+            raise QaExpertAnswerDeleteNotAllowedError(msg="转公开申请进行中，暂不可删除回答")
 
         deleted = await self.repository.delete(answer_id)
-        if deleted:
-            question = await self.question_repo.get_by_id(answer.question_id)
-            if question is not None:
-                new_count = max(int(getattr(question, "answer_count", 0) or 0) - 1, 0)
-                await self.question_repo.update(answer.question_id, answer_count=new_count)
-        return deleted
+        if not deleted:
+            raise AnswerNotFoundError()
+        await self.comment_repo.delete_by_answer_id(answer_id)
+        question = await self.question_repo.get_by_id(answer.question_id)
+        if question is not None:
+            new_count = max(int(getattr(question, "answer_count", 0) or 0) - 1, 0)
+            await self.question_repo.update(answer.question_id, answer_count=new_count)
+        return True
 
     async def _send_answer_notification(self, question: Question, answer: Answer):
         """每次提交回答通知提问者；匿名专家用同题别名。"""
@@ -1790,25 +1855,31 @@ class CommentService:
         limit: int = 100,
         user=None,
     ) -> tuple[list[Comment], int]:
-        """获取回答的评论；匿名评论 user_name 在 JSON 层改成别名。"""
+        """获取回答的评论；可见性跟随问题，匿名评论 user_name 在 JSON 层改成别名。"""
+        question = None
+        if answer_id:
+            answer = await self.answer_repo.get_by_id(answer_id)
+            qid = int(getattr(answer, "question_id", 0) or 0) if answer is not None else int(question_id or 0)
+            if not qid:
+                raise AnswerNotFoundError()
+            question = await self.question_repo.get_by_id(qid)
+        elif question_id:
+            question = await self.question_repo.get_by_id(question_id)
+        if question is None:
+            raise QuestionNotFoundError()
+        viewer = user or SimpleNamespace(user_id=0, is_admin=lambda: False, role=None)
+        invite_map = await self.invite_repo.list_user_ids_by_question_ids([int(question.id)])
+        invited = invite_map.get(int(question.id), set())
+        snapshot = CapabilitySnapshot(invited_user_ids=frozenset(invited))
+        if not self.capability_resolver.resolve(viewer, question, snapshot).capabilities.visible:
+            raise QaExpertQuestionAccessDeniedError()
         comments, total = await self.repository.get_by_answer_id(
-            answer_id, question_id=question_id, skip=skip, limit=limit
+            answer_id, question_id=question_id or int(question.id), skip=skip, limit=limit
         )
         if not comments:
             return comments, total
-        question_ids = {
-            int(comment.question_id) for comment in comments if getattr(comment, "question_id", None) is not None
-        }
-        questions: dict[int, Question] = {}
-        for qid in question_ids:
-            row = await self.question_repo.get_by_id(qid)
-            if row is not None:
-                questions[qid] = row
-        viewer = user or SimpleNamespace(user_id=0, is_admin=lambda: False, role=None)
         for comment in comments:
-            question = questions.get(int(getattr(comment, "question_id", 0) or 0))
-            if question is not None:
-                await self._attach_comment_author(viewer, comment, question)
+            await self._attach_comment_author(viewer, comment, question)
         return comments, total
 
     async def _send_comment_notification(
@@ -1816,14 +1887,16 @@ class CommentService:
         answer: Answer,
         comment: Comment,
     ):
-        """评论通知回答作者；匿名评论用同题别名。"""
+        """评论通知回答作者和提问者；匿名评论用同题别名。发件人由 send_qa_inbox 排除。"""
         if not answer or not comment:
             return
         question = await self.question_repo.get_by_id(answer.question_id)
         if not question:
             return
-        receiver = int(getattr(answer, "user_id", 0) or 0)
-        if receiver <= 0:
+        answerer = int(getattr(answer, "user_id", 0) or 0)
+        asker = int(getattr(question, "user_id", 0) or 0)
+        receivers = list(dict.fromkeys(uid for uid in (answerer, asker) if uid > 0))
+        if not receivers:
             return
         from bisheng.qa_expert.domain.inbox_notice import display_name_for_trigger, send_qa_inbox
 
@@ -1838,7 +1911,7 @@ class CommentService:
             action_code="qa_answer_commented",
             system_text="qa_answer_commented",
             question=question,
-            receivers=[receiver],
+            receivers=receivers,
             sender_user_id=int(comment.user_id),
             sender_display=display,
             sender_anonymous=masked,

--- a/src/backend/test/qa_expert/test_answer_lock.py
+++ b/src/backend/test/qa_expert/test_answer_lock.py
@@ -44,6 +44,11 @@ def _answer_service() -> AnswerService:
     svc.invite_repo.list_user_ids_by_question_ids = AsyncMock(return_value={})
     svc.expert_repo.increment_answer_count = AsyncMock()
     svc.expert_repo.get_by_id = AsyncMock(return_value=_expert())
+    svc.comment_repo = MagicMock()
+    svc.comment_repo.delete_by_answer_id = AsyncMock(return_value=0)
+    svc.publish_request_repo = MagicMock()
+    svc.publish_request_repo.get_pending_by_question = AsyncMock(return_value=None)
+    svc.publish_refresher = AsyncMock()
     svc._send_answer_notification = AsyncMock()
     svc._resolve_answer = AsyncMock(side_effect=lambda answer: answer)
     return svc

--- a/src/backend/test/qa_expert/test_data_flow.py
+++ b/src/backend/test/qa_expert/test_data_flow.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock
 
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import text
@@ -22,8 +24,10 @@ from bisheng.database.models.qa_expert import (
     Question,
     QuestionInvite,
 )
+from bisheng.qa_expert.domain.services import CommentService
 
 PREFIX = "/api/v1/qa_experts"
+_REAL_SEND_COMMENT_NOTIFICATION = CommentService._send_comment_notification
 
 
 def _ok(resp) -> dict:
@@ -187,6 +191,76 @@ async def test_df04_related_docs_persisted_as_space_file_id(flow_env):
         assert views[0].get("unavailable_reason") == "forbidden"
         assert views[0].get("unavailable_reason") != "not_found"
     assert "正文仍在" in str(data)
+
+
+async def test_df04b_related_docs_follow_space_read_not_asker(flow_env, monkeypatch):
+    """落库 related_docs 后，可点链接跟知识空间 can_read，不跟提问者身份。"""
+    from bisheng.qa_expert.domain import related_docs_access as related_docs_access_mod
+
+    env = flow_env
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df04b权限切开",
+            "description": "正文仍在",
+            "business_domain": "steel",
+            "question_type": "public",
+            "related_doc_ids": ["8-15", "8-16"],
+        },
+    )
+    stored = await env.reload_row(Question, id=qid)
+    assert stored.related_docs
+    assert "8-15" in stored.related_docs
+
+    monkeypatch.setattr(related_docs_access_mod, "_file_belongs_to_space", AsyncMock(return_value=True))
+
+    async def fake_check(*, user_id, relation, object_type, object_id, login_user=None):
+        assert relation == "can_read"
+        assert object_type == "knowledge_space"
+        assert object_id == "8"
+        return int(user_id) == int(env.stranger.user_id)
+
+    monkeypatch.setattr(
+        "bisheng.permission.domain.services.permission_service.PermissionService.check",
+        fake_check,
+    )
+
+    async def live_check(user, space_id, file_id, *, space_cache=None):
+        if not await related_docs_access_mod._file_belongs_to_space(int(space_id), int(file_id)):
+            return None
+        cache_key = int(space_id)
+        if space_cache is not None and cache_key in space_cache:
+            return space_cache[cache_key]
+        allowed = await related_docs_access_mod._space_can_read(user, cache_key)
+        if space_cache is not None:
+            space_cache[cache_key] = allowed
+        return allowed
+
+    monkeypatch.setattr(
+        "bisheng.qa_expert.domain.related_docs_access.check_related_doc_access",
+        live_check,
+    )
+
+    asker_detail = _ok(await env.client.get(f"{PREFIX}/questions/{qid}"))
+    assert asker_detail["status_code"] == 200
+    asker_views = (asker_detail.get("data") or {}).get("related_doc_views") or []
+    assert asker_views
+    assert all(item.get("accessible") is False for item in asker_views)
+    assert all(item.get("unavailable_reason") == "forbidden" for item in asker_views)
+
+    env.as_user(env.stranger)
+    stranger_detail = _ok(await env.client.get(f"{PREFIX}/questions/{qid}"))
+    assert stranger_detail["status_code"] == 200
+    stranger_views = (stranger_detail.get("data") or {}).get("related_doc_views") or []
+    assert len(stranger_views) == 2
+    assert all(item.get("accessible") is True for item in stranger_views)
+    again = await env.reload_row(Question, id=qid)
+    assert "8-15" in again.related_docs
+    env.as_user(env.asker)
+    asker_again = _ok(await env.client.get(f"{PREFIX}/questions/{qid}"))
+    asker_views_again = (asker_again.get("data") or {}).get("related_doc_views") or []
+    assert all(item.get("accessible") is False for item in asker_views_again)
 
 
 async def test_df05_first_answer_locks_content(flow_env):
@@ -1000,3 +1074,217 @@ async def test_df13_reject_keeps_viewer_decision_on_latest(flow_env):
     assert asker_latest.get("status") == "rejected"
     assert asker_latest.get("viewer_decision") == "approved"
     assert (asker_detail.get("data") or {}).get("capabilities", {}).get("can_start_publish") is True
+
+
+def _commented_rows(rows: list[dict]) -> list[dict]:
+    return [row for row in rows if row.get("action_code") == "qa_answer_commented"]
+
+
+async def test_df23_comment_notifies_asker_and_answerer(flow_env, monkeypatch):
+    """第三人评回答：提问者与回答者都进 inbox_message；自评不再通知自己；拒绝评论不写脏行。"""
+    monkeypatch.setattr(CommentService, "_send_comment_notification", _REAL_SEND_COMMENT_NOTIFICATION)
+    env = flow_env
+    await env.seed_expert(user_id=201, name="专家甲")
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df23评论通知提问者",
+            "description": "公开题",
+            "business_domain": "steel",
+            "question_type": "public",
+        },
+    )
+    env.as_user(env.user(201, name="专家甲"))
+    aid = await _create_answer(env, qid, "甲先答")
+    title = env.t("df23评论通知提问者")
+    before_inbox = await _inbox_rows(env, title)
+    env.as_user(env.stranger)
+    created = _ok(
+        await env.client.post(
+            f"{PREFIX}/comments",
+            json={"answer_id": aid, "content": "第三人来评"},
+        )
+    )
+    assert created["status_code"] == 200
+    comments = await env.reload_all(Comment, question_id=qid)
+    assert len(comments) == 1
+    assert comments[0].content == "第三人来评"
+    first_inbox = _commented_rows(await _inbox_rows(env, title))
+    assert len(first_inbox) == len(_commented_rows(before_inbox)) + 1
+    receivers = _receiver_ids(first_inbox[-1]["receiver"])
+    assert env.asker.user_id in receivers
+    assert env.uid(201) in receivers
+    assert env.stranger.user_id not in receivers
+
+    env.as_user(env.asker)
+    self_comment = _ok(
+        await env.client.post(
+            f"{PREFIX}/comments",
+            json={"answer_id": aid, "content": "提问者自评"},
+        )
+    )
+    assert self_comment["status_code"] == 200
+    assert len(await env.reload_all(Comment, question_id=qid)) == 2
+    after_self = _commented_rows(await _inbox_rows(env, title))
+    assert len(after_self) == len(first_inbox) + 1
+    self_receivers = _receiver_ids(after_self[-1]["receiver"])
+    assert env.uid(201) in self_receivers
+    assert env.asker.user_id not in self_receivers
+
+    env.as_user(env.stranger)
+    denied = _ok(
+        await env.client.post(
+            f"{PREFIX}/comments",
+            json={"answer_id": 9_999_999_001, "content": "回答不存在"},
+        )
+    )
+    assert denied["status_code"] != 200
+    assert len(await env.reload_all(Comment, question_id=qid)) == 2
+    assert len(_commented_rows(await _inbox_rows(env, title))) == len(after_self)
+
+
+async def test_df24_author_delete_answer_rules(flow_env):
+    """未采纳可删并级联评论；已采纳拒绝；转公开 pending 拒绝未采纳删答；拒绝后可删。"""
+    env = flow_env
+    first = await env.seed_expert(user_id=201, name="专家甲")
+    second = await env.seed_expert(user_id=202, name="专家乙")
+    env.as_user(env.asker)
+    public_id = await _create_question(
+        env,
+        {"title": "df24公开删答", "description": "公开", "business_domain": "steel", "question_type": "public"},
+    )
+    env.as_user(env.user(201, name="专家甲"))
+    public_aid = await _create_answer(env, public_id, "可删答")
+    env.as_user(env.stranger)
+    commented = _ok(
+        await env.client.post(
+            f"{PREFIX}/comments",
+            json={"answer_id": public_aid, "content": "随答删除"},
+        )
+    )
+    assert commented["status_code"] == 200
+    assert len(await env.reload_all(Comment, question_id=public_id)) == 1
+    env.as_user(env.user(201, name="专家甲"))
+    listed = _ok(await env.client.get(f"{PREFIX}/answers/{public_id}"))
+    answers = (listed.get("data") or {}).get("answers") or listed.get("data") or []
+    if isinstance(answers, dict):
+        answers = answers.get("answers") or []
+    hit = next((item for item in answers if int(item.get("id")) == public_aid), None)
+    assert hit is not None
+    assert hit.get("can_delete") is True
+    deleted = _ok(await env.client.delete(f"{PREFIX}/answers/{public_aid}"))
+    assert deleted["status_code"] == 200
+    stored = await env.reload_row(Answer, id=public_aid)
+    assert int(stored.status) == 3
+    assert len(await env.reload_all(Comment, question_id=public_id)) == 0
+    after = _ok(await env.client.get(f"{PREFIX}/answers/{public_id}"))
+    after_answers = (after.get("data") or {}).get("answers") or after.get("data") or []
+    if isinstance(after_answers, dict):
+        after_answers = after_answers.get("answers") or []
+    assert all(int(item.get("id")) != public_aid for item in after_answers)
+
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df24转公开锁删",
+            "description": "定向",
+            "business_domain": "steel",
+            "question_type": "directed",
+            "invited_expert_ids": [first.id, second.id],
+            "asker_reveal_on_public": True,
+        },
+    )
+    env.as_user(env.user(201, name="专家甲"))
+    adopted_aid = await _create_answer(env, qid, "将被采纳")
+    env.as_user(env.user(202, name="专家乙"))
+    other_aid = await _create_answer(env, qid, "未采纳")
+    env.as_user(env.asker)
+    _ok(await env.client.post(f"{PREFIX}/questions/{qid}/adopt", json={"answer_id": adopted_aid}))
+    env.as_user(env.user(201, name="专家甲"))
+    adopted_denied = _ok(await env.client.delete(f"{PREFIX}/answers/{adopted_aid}"))
+    assert adopted_denied["status_code"] == 18312
+    still_adopted = await env.reload_row(Answer, id=adopted_aid)
+    assert int(still_adopted.status) != 3
+    assert bool(still_adopted.adopted)
+
+    env.as_user(env.asker)
+    started = _ok(await env.client.post(f"{PREFIX}/questions/{qid}/publish-requests", json={"duration_days": 3}))
+    assert started["status_code"] == 200
+    env.as_user(env.user(202, name="专家乙"))
+    pending_denied = _ok(await env.client.delete(f"{PREFIX}/answers/{other_aid}"))
+    assert pending_denied["status_code"] == 18312
+    still_other = await env.reload_row(Answer, id=other_aid)
+    assert int(still_other.status) != 3
+
+    request = await env.reload_row(PublishRequest, question_id=qid)
+    env.as_user(env.user(201, name="专家甲"))
+    rejected = _ok(await env.client.post(f"{PREFIX}/publish-requests/{int(request.id)}/reject"))
+    assert rejected["status_code"] == 200
+    env.as_user(env.user(202, name="专家乙"))
+    after_reject = _ok(await env.client.delete(f"{PREFIX}/answers/{other_aid}"))
+    assert after_reject["status_code"] == 200
+    gone = await env.reload_row(Answer, id=other_aid)
+    assert int(gone.status) == 3
+
+    env.as_user(env.stranger)
+    hidden = _ok(await env.client.post(f"{PREFIX}/allcomments", json={"answer_id": adopted_aid, "question_id": qid}))
+    assert hidden["status_code"] == 18301
+
+
+async def test_df25_expired_publish_allows_unadopted_delete(flow_env):
+    """转公开 pending 但 expire_at 已过：删答应惰性过期申请，并允许删除未采纳回答。"""
+    env = flow_env
+    first = await env.seed_expert(user_id=201, name="专家甲")
+    second = await env.seed_expert(user_id=202, name="专家乙")
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df25过期后可删",
+            "description": "定向",
+            "business_domain": "steel",
+            "question_type": "directed",
+            "invited_expert_ids": [first.id, second.id],
+            "asker_reveal_on_public": True,
+        },
+    )
+    env.as_user(env.user(201, name="专家甲"))
+    adopted_aid = await _create_answer(env, qid, "已采纳")
+    env.as_user(env.user(202, name="专家乙"))
+    other_aid = await _create_answer(env, qid, "未采纳待删")
+    env.as_user(env.asker)
+    _ok(await env.client.post(f"{PREFIX}/questions/{qid}/adopt", json={"answer_id": adopted_aid}))
+    started = _ok(await env.client.post(f"{PREFIX}/questions/{qid}/publish-requests", json={"duration_days": 1}))
+    assert started["status_code"] == 200
+    env.as_user(env.user(202, name="专家乙"))
+    still_blocked = _ok(await env.client.delete(f"{PREFIX}/answers/{other_aid}"))
+    assert still_blocked["status_code"] == 18312
+    async with AsyncSession(env.engine, expire_on_commit=False) as session:
+        await session.execute(
+            text("UPDATE qa_publish_request SET expire_at = :expired WHERE question_id = :qid"),
+            {"expired": datetime.utcnow() - timedelta(minutes=1), "qid": qid},
+        )
+        await session.commit()
+    listed = _ok(await env.client.get(f"{PREFIX}/answers/{qid}"))
+    answers = (listed.get("data") or {}).get("answers") or listed.get("data") or []
+    if isinstance(answers, dict):
+        answers = answers.get("answers") or []
+    hit = next((item for item in answers if int(item.get("id")) == other_aid), None)
+    assert hit is not None
+    assert hit.get("can_delete") is True
+    deleted = _ok(await env.client.delete(f"{PREFIX}/answers/{other_aid}"))
+    assert deleted["status_code"] == 200
+    gone = await env.reload_row(Answer, id=other_aid)
+    assert int(gone.status) == 3
+    request = await env.reload_row(PublishRequest, question_id=qid)
+    assert str(request.status) == "expired"
+    adopted = await env.reload_row(Answer, id=adopted_aid)
+    assert int(adopted.status) != 3
+    env.as_user(env.user(202, name="专家乙"))
+    listed_again = _ok(await env.client.get(f"{PREFIX}/answers/{qid}"))
+    again = (listed_again.get("data") or {}).get("answers") or listed_again.get("data") or []
+    if isinstance(again, dict):
+        again = again.get("answers") or []
+    assert all(int(item.get("id")) != other_aid for item in again)

--- a/src/backend/test/qa_expert/test_delete_answer.py
+++ b/src/backend/test/qa_expert/test_delete_answer.py
@@ -1,0 +1,122 @@
+# ruff: noqa: RUF002
+"""作者删答：未采纳可删并级联评论；已采纳/转公开 pending 拒绝。"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from bisheng.common.errcode.qa_expert import QaExpertAnswerDeleteNotAllowedError, QaExpertQuestionAccessDeniedError
+from bisheng.qa_expert.domain.services import AnswerService, CommentService, PermissionDeniedError
+
+
+def _answer_service() -> AnswerService:
+    svc = AnswerService()
+    svc.repository = MagicMock()
+    svc.question_repo = MagicMock()
+    svc.expert_repo = MagicMock()
+    svc.invite_repo = MagicMock()
+    svc.comment_repo = MagicMock()
+    svc.publish_request_repo = MagicMock()
+    svc.comment_repo.delete_by_answer_id = AsyncMock(return_value=2)
+    svc.publish_request_repo.get_pending_by_question = AsyncMock(return_value=None)
+    svc.publish_refresher = AsyncMock()
+    svc.question_repo.update = AsyncMock()
+    svc.invite_repo.list_user_ids_by_question_ids = AsyncMock(return_value={})
+    return svc
+
+
+async def test_author_deletes_unadopted_and_cascades_comments():
+    svc = _answer_service()
+    question = SimpleNamespace(id=9, user_id=1, content_locked=1, answer_count=1)
+    answer = SimpleNamespace(id=11, question_id=9, user_id=8, expert_id=3, status=1, adopted=False)
+    svc.repository.get_by_id = AsyncMock(return_value=answer)
+    svc.repository.delete = AsyncMock(return_value=True)
+    svc.question_repo.get_by_id = AsyncMock(return_value=question)
+    assert await svc.delete_answer(11, 8) is True
+    svc.comment_repo.delete_by_answer_id.assert_awaited_once_with(11)
+    kwargs = svc.question_repo.update.await_args.kwargs
+    assert kwargs.get("answer_count") == 0
+    assert "content_locked" not in kwargs
+
+
+async def test_non_author_cannot_delete():
+    svc = _answer_service()
+    svc.repository.get_by_id = AsyncMock(
+        return_value=SimpleNamespace(id=11, question_id=9, user_id=8, expert_id=3, status=1, adopted=False)
+    )
+    svc.repository.delete = AsyncMock()
+    with pytest.raises(PermissionDeniedError):
+        await svc.delete_answer(11, 99)
+    svc.repository.delete.assert_not_awaited()
+
+
+async def test_adopted_answer_cannot_delete():
+    svc = _answer_service()
+    svc.repository.get_by_id = AsyncMock(
+        return_value=SimpleNamespace(id=11, question_id=9, user_id=8, expert_id=3, status=1, adopted=True)
+    )
+    svc.repository.delete = AsyncMock()
+    with pytest.raises(QaExpertAnswerDeleteNotAllowedError):
+        await svc.delete_answer(11, 8)
+    svc.repository.delete.assert_not_awaited()
+    svc.comment_repo.delete_by_answer_id.assert_not_awaited()
+
+
+async def test_delete_runs_lazy_expire_before_pending_check():
+    svc = _answer_service()
+    question = SimpleNamespace(id=9, user_id=1, answer_count=1)
+    svc.repository.get_by_id = AsyncMock(
+        return_value=SimpleNamespace(id=11, question_id=9, user_id=8, expert_id=3, status=1, adopted=False)
+    )
+    svc.repository.delete = AsyncMock(return_value=True)
+    svc.question_repo.get_by_id = AsyncMock(return_value=question)
+    assert await svc.delete_answer(11, 8) is True
+    svc.publish_refresher.assert_awaited_once_with(9)
+    svc.publish_request_repo.get_pending_by_question.assert_awaited_once_with(9)
+
+
+async def test_pending_publish_blocks_unadopted_delete():
+    svc = _answer_service()
+    svc.repository.get_by_id = AsyncMock(
+        return_value=SimpleNamespace(id=11, question_id=9, user_id=8, expert_id=3, status=1, adopted=False)
+    )
+    svc.publish_request_repo.get_pending_by_question = AsyncMock(return_value=SimpleNamespace(id=4, status="pending"))
+    svc.repository.delete = AsyncMock()
+    with pytest.raises(QaExpertAnswerDeleteNotAllowedError):
+        await svc.delete_answer(11, 8)
+    svc.repository.delete.assert_not_awaited()
+
+
+async def test_finished_publish_allows_unadopted_delete():
+    svc = _answer_service()
+    question = SimpleNamespace(id=9, user_id=1, answer_count=2)
+    svc.repository.get_by_id = AsyncMock(
+        return_value=SimpleNamespace(id=11, question_id=9, user_id=8, expert_id=3, status=1, adopted=False)
+    )
+    svc.repository.delete = AsyncMock(return_value=True)
+    svc.question_repo.get_by_id = AsyncMock(return_value=question)
+    svc.publish_request_repo.get_pending_by_question = AsyncMock(return_value=None)
+    assert await svc.delete_answer(11, 8) is True
+    svc.repository.delete.assert_awaited_once_with(11)
+
+
+async def test_directed_stranger_cannot_list_comments():
+    svc = CommentService()
+    svc.answer_repo = MagicMock()
+    svc.question_repo = MagicMock()
+    svc.invite_repo = MagicMock()
+    svc.repository = MagicMock()
+    svc.answer_repo.get_by_id = AsyncMock(return_value=SimpleNamespace(id=11, question_id=9))
+    svc.question_repo.get_by_id = AsyncMock(
+        return_value=SimpleNamespace(id=9, user_id=1, question_type="directed", adopt_count=0, answer_count=1)
+    )
+    svc.invite_repo.list_user_ids_by_question_ids = AsyncMock(return_value={9: {8}})
+    svc.repository.get_by_answer_id = AsyncMock()
+    with pytest.raises(QaExpertQuestionAccessDeniedError):
+        await svc.get_comments(
+            answer_id=11,
+            question_id=9,
+            user=SimpleNamespace(user_id=301, is_admin=lambda: False, role=None),
+        )
+    svc.repository.get_by_answer_id.assert_not_awaited()

--- a/src/backend/test/qa_expert/test_inbox_notify.py
+++ b/src/backend/test/qa_expert/test_inbox_notify.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 from bisheng.qa_expert.domain.identity import IdentityService
 from bisheng.qa_expert.domain.publish_service import PublishService
-from bisheng.qa_expert.domain.services import AnswerService, QuestionService
+from bisheng.qa_expert.domain.services import AnswerService, CommentService, QuestionService
 
 
 async def test_invite_answer_adopt_publish_send_inbox():
@@ -34,6 +34,36 @@ async def test_invite_answer_adopt_publish_send_inbox():
     asvc._send_answer_notification.assert_awaited()
     qsvc._send_adoption_notification.assert_awaited()
     pub.notify.assert_awaited()
+
+
+async def test_comment_inbox_notifies_asker_and_answerer(monkeypatch):
+    captured: dict = {}
+
+    async def fake_display(*_args, **_kwargs):
+        return "评者", False
+
+    async def fake_send(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr("bisheng.qa_expert.domain.inbox_notice.display_name_for_trigger", fake_display)
+    monkeypatch.setattr("bisheng.qa_expert.domain.inbox_notice.send_qa_inbox", fake_send)
+    svc = CommentService()
+    svc.question_repo = MagicMock()
+    svc.question_repo.get_by_id = AsyncMock(return_value=SimpleNamespace(id=1, user_id=101, title="题", tenant_id=1))
+    await svc._send_comment_notification(
+        SimpleNamespace(id=2, question_id=1, user_id=201),
+        SimpleNamespace(
+            id=9,
+            user_id=301,
+            user_name="评者",
+            anonymous=0,
+            reveal_on_public=None,
+            content="评",
+        ),
+    )
+    assert captured["action_code"] == "qa_answer_commented"
+    assert captured["receivers"] == [201, 101]
+    assert captured["sender_user_id"] == 301
 
 
 async def test_anonymous_sender_uses_alias_not_real_name():

--- a/src/backend/test/qa_expert/test_related_docs.py
+++ b/src/backend/test/qa_expert/test_related_docs.py
@@ -20,6 +20,7 @@ def _service() -> QuestionService:
     svc.eligibility_repo.list_user_ids = AsyncMock(return_value=set())
     svc.publish_request_repo = MagicMock()
     svc.publish_request_repo.get_pending_by_question = AsyncMock(return_value=None)
+    svc.publish_request_repo.get_latest_by_question = AsyncMock(return_value=None)
     svc.publish_approver_repo = MagicMock()
     svc.publish_approver_repo.list_by_request = AsyncMock(return_value=[])
     svc._resolve_question = AsyncMock(side_effect=lambda q: q)
@@ -34,7 +35,11 @@ def _service() -> QuestionService:
     return svc
 
 
-async def test_detail_always_returns_question_body_when_doc_forbidden():
+async def test_detail_always_returns_question_body_when_doc_forbidden(monkeypatch):
+    monkeypatch.setattr(
+        "bisheng.qa_expert.domain.publish_service.PublishService.refresh_latest_for_question",
+        AsyncMock(return_value=None),
+    )
     svc = _service()
     question = SimpleNamespace(
         id=3,
@@ -82,8 +87,8 @@ async def test_accessible_doc_keeps_durable_id():
     assert views[0]["unavailable_reason"] is None
 
 
-async def test_non_owner_existing_file_is_forbidden_not_openfga():
-    """路人即使文件存在也记 forbidden，避免详情去打 OpenFGA。"""
+async def test_non_owner_with_permission_is_accessible():
+    """有库权限的路人可点链接，不再因不是提问者一律 forbidden。"""
     svc = _service()
 
     async def checker(_user, _s, _f):
@@ -93,6 +98,23 @@ async def test_non_owner_existing_file_is_forbidden_not_openfga():
     views = await svc.hydrate_related_docs(
         "8-15",
         user=SimpleNamespace(user_id=2),
+        owner_user_id=1,
+    )
+    assert views[0]["accessible"] is True
+    assert views[0]["unavailable_reason"] is None
+
+
+async def test_owner_without_permission_is_forbidden():
+    """提问者无知识库权限时不可点，不再因是作者特判放行。"""
+    svc = _service()
+
+    async def checker(_user, _s, _f):
+        return False
+
+    svc.related_docs_access_checker = checker
+    views = await svc.hydrate_related_docs(
+        "8-15",
+        user=SimpleNamespace(user_id=1),
         owner_user_id=1,
     )
     assert views[0]["accessible"] is False

--- a/src/backend/test/qa_expert/test_related_docs_access.py
+++ b/src/backend/test/qa_expert/test_related_docs_access.py
@@ -1,0 +1,82 @@
+# ruff: noqa: RUF002
+"""关联文档走 PermissionService.check(can_read, knowledge_space)，不扫 list_accessible_ids。"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from bisheng.qa_expert.domain import related_docs_access
+
+
+async def test_missing_file_returns_none(monkeypatch):
+    monkeypatch.setattr(related_docs_access, "_file_belongs_to_space", AsyncMock(return_value=False))
+    space_read = AsyncMock(return_value=True)
+    monkeypatch.setattr(related_docs_access, "_space_can_read", space_read)
+    result = await related_docs_access.check_related_doc_access(
+        SimpleNamespace(user_id=2, is_admin=lambda: False), 8, 15
+    )
+    assert result is None
+    space_read.assert_not_awaited()
+
+
+async def test_existing_file_without_space_read_returns_false(monkeypatch):
+    monkeypatch.setattr(related_docs_access, "_file_belongs_to_space", AsyncMock(return_value=True))
+    monkeypatch.setattr(related_docs_access, "_space_can_read", AsyncMock(return_value=False))
+    result = await related_docs_access.check_related_doc_access(
+        SimpleNamespace(user_id=2, is_admin=lambda: False), 8, 15
+    )
+    assert result is False
+
+
+async def test_existing_file_with_space_read_returns_true(monkeypatch):
+    monkeypatch.setattr(related_docs_access, "_file_belongs_to_space", AsyncMock(return_value=True))
+    monkeypatch.setattr(related_docs_access, "_space_can_read", AsyncMock(return_value=True))
+    result = await related_docs_access.check_related_doc_access(
+        SimpleNamespace(user_id=9, is_admin=lambda: False), 8, 15
+    )
+    assert result is True
+
+
+async def test_same_space_permission_is_cached(monkeypatch):
+    monkeypatch.setattr(related_docs_access, "_file_belongs_to_space", AsyncMock(return_value=True))
+    space_read = AsyncMock(return_value=True)
+    monkeypatch.setattr(related_docs_access, "_space_can_read", space_read)
+    cache: dict[int, bool] = {}
+    user = SimpleNamespace(user_id=9, is_admin=lambda: False)
+    first = await related_docs_access.check_related_doc_access(user, 8, 15, space_cache=cache)
+    second = await related_docs_access.check_related_doc_access(user, 8, 16, space_cache=cache)
+    assert first is True
+    assert second is True
+    space_read.assert_awaited_once()
+
+
+async def test_space_can_read_uses_permission_check_not_list(monkeypatch):
+    calls: list[dict] = []
+
+    async def fake_check(*, user_id, relation, object_type, object_id, login_user=None):
+        calls.append(
+            {
+                "user_id": user_id,
+                "relation": relation,
+                "object_type": object_type,
+                "object_id": object_id,
+                "login_user": login_user,
+            }
+        )
+        return True
+
+    monkeypatch.setattr(
+        "bisheng.permission.domain.services.permission_service.PermissionService.check",
+        fake_check,
+    )
+    user = SimpleNamespace(user_id=9, is_admin=lambda: False)
+    assert await related_docs_access._space_can_read(user, 8) is True
+    assert calls == [
+        {
+            "user_id": 9,
+            "relation": "can_read",
+            "object_type": "knowledge_space",
+            "object_id": "8",
+            "login_user": user,
+        }
+    ]
+    assert not any("list_accessible" in str(item) for item in calls)

--- a/src/frontend/client/src/locales/ja/translation.json
+++ b/src/frontend/client/src/locales/ja/translation.json
@@ -2155,7 +2155,7 @@
   "com_approval_field_duration_days": "有効期間（日）",
   "com_notifications_action_qa_expert_invited": "専門家Q&A「{{target}}」への回答に招待されました",
   "com_notifications_action_qa_expert_answered": "専門家Q&A「{{target}}」に回答しました",
-  "com_notifications_action_qa_answer_commented": "専門家Q&A「{{target}}」のあなたの回答にコメントしました",
+  "com_notifications_action_qa_answer_commented": "専門家Q&A「{{target}}」の回答にコメントしました",
   "com_notifications_action_qa_answer_accepted": "専門家Q&A「{{target}}」のあなたの回答を採用しました",
   "com_notifications_action_qa_expert_publish_started": "専門家Q&A「{{target}}」の公開申請を開始しました。承認管理の未処理から対応してください",
   "com_notifications_action_qa_expert_publish_approver_added": "専門家Q&A「{{target}}」の公開承認者が更新されました",

--- a/src/frontend/client/src/locales/zh-Hans/translation.json
+++ b/src/frontend/client/src/locales/zh-Hans/translation.json
@@ -2193,7 +2193,7 @@
   "com_approval_search_placeholder": "搜索申请人、场景或文件",
   "com_notifications_action_qa_expert_invited": "邀请你回答专家问答问题「{{target}}」",
   "com_notifications_action_qa_expert_answered": "回答了你在专家问答提出的「{{target}}」",
-  "com_notifications_action_qa_answer_commented": "评论了你在专家问答「{{target}}」问题中做出的回答",
+  "com_notifications_action_qa_answer_commented": "评论了专家问答「{{target}}」中的回答",
   "com_notifications_action_qa_answer_accepted": "采纳了你在专家问答「{{target}}」问题中做出的回答",
   "com_notifications_action_qa_expert_publish_started": "发起了专家问答「{{target}}」的转公开申请，请到待办-我的审批处理",
   "com_notifications_action_qa_expert_publish_approver_added": "专家问答「{{target}}」的转公开审批人已更新",


### PR DESCRIPTION
## Summary
- 作者删除未采纳回答时，先对最新转公开申请做 lazy expire；待审中禁止删除（18312），过期/驳回/提问者停用后可删，评论级联硬删。
- 关联知识文档不再按提问者身份放行，统一按知识空间 `PermissionService.check(can_read)`；看得到问答不等于能打开知识文件。
- 评论站内信中文/日文改为「评论了专家问答「{{target}}」中的回答」；`can_delete` 随列表下发。

## Test plan
- [ ] 作者删除未采纳回答：列表消失，评论级联删除
- [ ] 待审转公开未结束：删除返回 18312，落库 `qa_answer` 未改
- [ ] 转公开过期/驳回/提问者停用后：未采纳回答可删
- [ ] 已采纳回答始终不可删
- [ ] 关联文档：提问者无空间读权限时 `accessible=false`；陌生人有 `can_read` 时可访问
- [ ] pytest：`test/qa_expert/test_delete_answer.py`、`test_data_flow.py`、`test_related_docs*.py`


Made with [Cursor](https://cursor.com)