### PR TITLE
fix(qa-expert): 关联文档详情回填 knowledgefile 文件名

### DIFF
--- a/src/backend/bisheng/qa_expert/domain/related_docs_access.py
+++ b/src/backend/bisheng/qa_expert/domain/related_docs_access.py
@@ -8,24 +8,49 @@ from typing import Any
 RELATED_DOC_ACCESS_TIMEOUT_SEC = 3.0
 
 
-async def _file_belongs_to_space(space_id: int, file_id: int) -> bool:
-    """knowledgefile 是否存在且归属该知识空间。"""
+def related_doc_display_title(row: Any | None) -> str | None:
+    """展示名与提问选择器一致：优先 file_name，没有再退 alias_name。"""
+    if row is None:
+        return None
+    name = str(getattr(row, "file_name", None) or "").strip()
+    alias = str(getattr(row, "alias_name", None) or "").strip()
+    return name or alias or None
+
+
+async def _load_related_doc_file(space_id: int, file_id: int) -> Any | None:
+    """取出 knowledgefile；无记录或空间不匹配则 None。"""
     try:
         from sqlmodel import select
 
         from bisheng.core.database import get_async_db_session
         from bisheng.knowledge.domain.models.knowledge_file import KnowledgeFile
     except Exception:
-        return False
+        return None
 
     async with get_async_db_session() as session:
         stmt = select(KnowledgeFile).where(KnowledgeFile.id == int(file_id))
         result = await session.exec(stmt)
         row = result.first()
     if row is None:
-        return False
+        return None
     knowledge_id = int(getattr(row, "knowledge_id", 0) or 0)
-    return (not knowledge_id) or knowledge_id == int(space_id)
+    if knowledge_id and knowledge_id != int(space_id):
+        return None
+    return row
+
+
+async def _file_belongs_to_space(space_id: int, file_id: int) -> bool:
+    """knowledgefile 是否存在且归属该知识空间。"""
+    return await _load_related_doc_file(space_id, file_id) is not None
+
+
+async def load_related_doc_title(space_id: int, file_id: int) -> str | None:
+    """读取 knowledgefile 展示名；找不到则 None。不鉴权，由 hydrate 决定是否下发。"""
+    try:
+        row = await _load_related_doc_file(int(space_id), int(file_id))
+    except Exception:
+        return None
+    return related_doc_display_title(row)
 
 
 async def _space_can_read(user: Any, space_id: int) -> bool:

--- a/src/backend/bisheng/qa_expert/domain/services.py
+++ b/src/backend/bisheng/qa_expert/domain/services.py
@@ -790,6 +790,8 @@ class QuestionService:
             return await check_related_doc_access(_user, space_id, file_id, space_cache=space_cache)
 
         checker = injected if callable(injected) else _default_checker
+        from bisheng.qa_expert.domain.related_docs_access import load_related_doc_title
+
         for token in parse_related_doc_tokens(related_docs):
             parsed = parse_related_doc_ref(token)
             if parsed is None:
@@ -827,12 +829,17 @@ class QuestionService:
             else:
                 accessible = True
                 reason = None
+            title = None
+            try:
+                title = await load_related_doc_title(space_id, file_id)
+            except Exception:
+                title = None
             views.append(
                 {
                     "id": doc_id,
                     "space_id": space_id,
                     "file_id": file_id,
-                    "title": None,
+                    "title": title,
                     "accessible": accessible,
                     "unavailable_reason": reason,
                 }

--- a/src/backend/test/qa_expert/test_related_docs.py
+++ b/src/backend/test/qa_expert/test_related_docs.py
@@ -166,3 +166,23 @@ async def test_hung_access_check_is_forbidden_not_500(monkeypatch):
     views = await svc.hydrate_related_docs("8-15")
     assert views[0]["accessible"] is False
     assert views[0]["unavailable_reason"] == "forbidden"
+
+
+async def test_hydrate_fills_title_from_knowledge_file(monkeypatch):
+    """关联文档展示名走 knowledgefile.file_name，不能只回 space-file id。"""
+    from bisheng.qa_expert.domain import related_docs_access
+
+    monkeypatch.setattr(
+        related_docs_access,
+        "load_related_doc_title",
+        AsyncMock(return_value="炼钢规程.pdf"),
+    )
+    svc = _service()
+
+    async def checker(_user, _s, _f):
+        return True
+
+    svc.related_docs_access_checker = checker
+    views = await svc.hydrate_related_docs("8-15")
+    assert views[0]["id"] == "8-15"
+    assert views[0]["title"] == "炼钢规程.pdf"

--- a/src/backend/test/qa_expert/test_related_docs_access.py
+++ b/src/backend/test/qa_expert/test_related_docs_access.py
@@ -80,3 +80,22 @@ async def test_space_can_read_uses_permission_check_not_list(monkeypatch):
         }
     ]
     assert not any("list_accessible" in str(item) for item in calls)
+
+
+def test_related_doc_display_title_prefers_file_name():
+    row = SimpleNamespace(file_name="炼钢规程.pdf", alias_name="规范名称.pdf")
+    assert related_docs_access.related_doc_display_title(row) == "炼钢规程.pdf"
+    assert (
+        related_docs_access.related_doc_display_title(SimpleNamespace(file_name="", alias_name="规范名称.pdf"))
+        == "规范名称.pdf"
+    )
+    assert related_docs_access.related_doc_display_title(None) is None
+
+
+async def test_load_related_doc_title_returns_file_name(monkeypatch):
+    monkeypatch.setattr(
+        related_docs_access,
+        "_load_related_doc_file",
+        AsyncMock(return_value=SimpleNamespace(file_name="工艺说明.docx", alias_name=None)),
+    )
+    assert await related_docs_access.load_related_doc_title(8, 15) == "工艺说明.docx"


### PR DESCRIPTION
## Summary
- 关联文档 hydrate 从 `knowledgefile.file_name` 回填 `related_doc_views.title`，不再把 title 留空导致详情只显示 `spaceId-fileId`。
- 展示名与提问选择器一致：优先 `file_name`，没有再退 `alias_name`。

## Test plan
- [ ] 提问/回答关联知识库文档后，详情显示真实文件名而不是 `8-15`
- [ ] 无权文档仍 forbidden，不把无权写成 not_found
- [ ] pytest：`test/qa_expert/test_related_docs.py`、`test_related_docs_access.py`


Made with [Cursor](https://cursor.com)