### PR TITLE
fix(qa-expert): 管理员看匿名回答时下发部门与统计

### DIFF
--- a/src/backend/bisheng/qa_expert/api/endpoints.py
+++ b/src/backend/bisheng/qa_expert/api/endpoints.py
@@ -414,6 +414,11 @@ def answer_payload(answer) -> dict:
         payload["author"] = author
     if isinstance(author, dict) and author.get("anonymous") and "real_name" not in author:
         payload["expert_name"] = author.get("display_name")
+    expert = payload.get("expert") if isinstance(answer, dict) else getattr(answer, "expert", payload.get("expert"))
+    if expert is not None:
+        payload["expert"] = expert
+    else:
+        payload.pop("expert", None)
     can_delete = getattr(answer, "can_delete", payload.get("can_delete"))
     if can_delete is not None:
         payload["can_delete"] = bool(can_delete)

--- a/src/backend/bisheng/qa_expert/domain/services.py
+++ b/src/backend/bisheng/qa_expert/domain/services.py
@@ -1337,13 +1337,69 @@ class AnswerService:
             object.__setattr__(row, name, value)
         return row
 
-    async def _attach_answer_author(self, viewer, answer: Answer, question: Question) -> Answer:
-        """列表/详情挂脱敏后的回答者身份；不改表列 expert_name，避免别名被写回库。"""
+    @staticmethod
+    def _expert_card(expert: Expert) -> dict:
+        """回答卡用的专家档案：部门展示名 + 回答/采纳数。不改 qa_expert 表。"""
+        raw = getattr(expert, "depart_ment", None)
+        department = None
+        if raw not in (None, ""):
+            try:
+                try:
+                    department = DepartmentDao.get_by_id(int(raw))
+                except (TypeError, ValueError):
+                    department = DepartmentDao.get_by_dept_id(str(raw))
+            except Exception:
+                # 展示用部门名；反查失败回退档案原文，不能让回答列表 500。
+                logger.warning("qa.answer.department_lookup_failed expert_id={}", getattr(expert, "id", None))
+                department = None
+        profile = ExpertService._with_department_projection(expert, department)
+        for key in ("created_at", "updated_at"):
+            value = profile.get(key)
+            if hasattr(value, "isoformat"):
+                profile[key] = value.isoformat()
+        display = str(profile.get("department_display_name") or profile.get("depart_ment") or "").strip()
+        if not display:
+            raw_text = str(raw).strip() if raw not in (None, "") else ""
+            # 部门表未命中且档案里是名称（非纯数字 ID）时，仍给管理员展示，避免「未知」。
+            if raw_text and not raw_text.isdigit():
+                display = raw_text
+        if display:
+            profile["depart_ment"] = display
+        return profile
+
+    async def _resolve_answer_expert(self, answer: Answer, experts: dict[int, Expert] | None = None) -> Expert | None:
+        """优先用本页批量结果，缺则按 expert_id / user_id 回表。"""
+        expert_id = getattr(answer, "expert_id", None)
+        if expert_id not in (None, ""):
+            eid = int(expert_id)
+            if experts is not None and eid in experts:
+                return experts[eid]
+            found = await self.expert_repo.get_by_id(eid)
+            if found is not None:
+                return found
+        user_id = getattr(answer, "user_id", None)
+        if user_id not in (None, ""):
+            return await self.expert_repo.get_by_user_id(int(user_id))
+        return None
+
+    async def _attach_answer_author(
+        self,
+        viewer,
+        answer: Answer,
+        question: Question,
+        experts: dict[int, Expert] | None = None,
+    ) -> Answer:
+        """列表/详情挂脱敏后的回答者身份；管理员另挂专家档案。不改表列 expert_name。"""
         identity = await self._identity()
         real_name = str(getattr(answer, "expert_name", "") or "")
         anonymous = bool(int(getattr(answer, "anonymous", 0) or 0))
         user_id = int(getattr(answer, "user_id", 0) or 0)
         can_view_real = is_expert_library_admin(viewer)
+        expert = await self._resolve_answer_expert(answer, experts)
+        expert_payload = self._expert_card(expert) if expert is not None else None
+        department_name = None
+        if isinstance(expert_payload, dict):
+            department_name = str(expert_payload.get("depart_ment") or "").strip() or None
         if anonymous and user_id:
             view = await identity.mask_identity(
                 viewer,
@@ -1354,6 +1410,7 @@ class AnswerService:
                 question_type=str(getattr(question, "question_type", "") or QUESTION_TYPE_PUBLIC),
                 reveal_on_public=getattr(answer, "reveal_on_public", None),
                 tenant_id=int(getattr(question, "tenant_id", 1) or 1),
+                department=department_name,
             )
             payload = view.to_dict(can_view_real_identity=can_view_real)
         else:
@@ -1362,7 +1419,14 @@ class AnswerService:
                 "avatar_url": None,
                 "anonymous": False,
             }
-        return self._annotate(answer, author=payload)
+            if department_name:
+                payload["department"] = department_name
+        shown_anonymous = bool(payload.get("anonymous"))
+        # 仍匿名且非管理员：不挂 expert，避免部门/回答数反推真人。
+        attach_expert = (
+            expert_payload if expert_payload is not None and (not shown_anonymous or can_view_real) else None
+        )
+        return self._annotate(answer, author=payload, expert=attach_expert)
 
     async def attach_author(self, answer: Answer, viewer) -> Answer:
         """写接口返回前挂 author；缺题则原样返回。"""
@@ -1544,10 +1608,14 @@ class AnswerService:
         pending_publish = pending is not None
         question_svc = QuestionService()
         question_svc.related_docs_access_checker = getattr(self, "related_docs_access_checker", None)
+        expert_ids = [int(item.expert_id) for item in answers if getattr(item, "expert_id", None) not in (None, "")]
+        expert_map = {
+            int(row.id): row for row in await self.expert_repo.get_by_ids(expert_ids) if getattr(row, "id", None)
+        }
         resolved: list[Answer] = []
         for answer in answers:
             item = await self._resolve_answer(answer)
-            item = await self._attach_answer_author(viewer, item, question)
+            item = await self._attach_answer_author(viewer, item, question, experts=expert_map)
             can_delete = await self._can_author_delete(item, viewer_id, pending_publish=pending_publish)
             related_doc_views = await question_svc.hydrate_related_docs(
                 getattr(item, "related_docs", None),

--- a/src/backend/test/qa_expert/test_data_flow.py
+++ b/src/backend/test/qa_expert/test_data_flow.py
@@ -685,6 +685,57 @@ async def test_df16_list_hides_anonymous_asker_name(flow_env):
     assert stored_again.created_by == "asker"
 
 
+async def test_df26_admin_list_shows_anonymous_asker_real_name(flow_env):
+    """管理员看问题列表：asker.real_name 为库内真名；路人仍无 real_name。无 DDL。"""
+    env = flow_env
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df26列表破匿名",
+            "description": "匿名正文",
+            "business_domain": "营销",
+            "question_type": "public",
+            "asker_anonymous": True,
+        },
+    )
+    stored = await env.reload_row(Question, id=qid)
+    assert int(stored.asker_anonymous) == 1
+    assert stored.created_by == "asker"
+
+    env.as_user(env.stranger)
+    stranger_body = _ok(
+        await env.client.get(
+            f"{PREFIX}/questions",
+            params={"page": 1, "page_size": 50, "keyword": env.t("df26列表破匿名")},
+        )
+    )
+    stranger_items = (stranger_body.get("data") or {}).get("questions") or []
+    stranger_hit = next((item for item in stranger_items if int(item.get("id")) == qid), None)
+    assert stranger_hit is not None
+    stranger_asker = stranger_hit.get("asker") or {}
+    assert stranger_asker.get("anonymous") is True
+    assert "real_name" not in stranger_asker
+    assert str(stranger_asker.get("display_name") or "").startswith("匿名同事")
+
+    env.as_user(env.portal_admin)
+    admin_body = _ok(
+        await env.client.get(
+            f"{PREFIX}/questions",
+            params={"page": 1, "page_size": 50, "keyword": env.t("df26列表破匿名")},
+        )
+    )
+    admin_items = (admin_body.get("data") or {}).get("questions") or []
+    admin_hit = next((item for item in admin_items if int(item.get("id")) == qid), None)
+    assert admin_hit is not None
+    admin_asker = admin_hit.get("asker") or {}
+    assert admin_asker.get("anonymous") is True
+    assert admin_asker.get("display_name", "").startswith("匿名同事")
+    assert admin_asker.get("real_name") == "asker"
+    stored_again = await env.reload_row(Question, id=qid)
+    assert stored_again.created_by == "asker"
+
+
 async def test_df17_directed_anonymous_masks_invited_viewer(flow_env):
     """定向匿名：库内仍是真名；受邀专家详情只见别名，且须预存转公开选项。"""
     env = flow_env
@@ -851,6 +902,8 @@ async def test_df19_followup_and_comment_anonymous_inheritance(flow_env):
     assert str(ans_hit.get("expert_name") or "").startswith("匿名同事")
     assert ans_hit.get("expert_name") != expert.expert_name
     assert (ans_hit.get("author") or {}).get("anonymous") is True
+    assert "real_name" not in (ans_hit.get("author") or {})
+    assert not ans_hit.get("expert")
     answer_again = await env.reload_row(Answer, id=aid)
     assert answer_again.expert_name == expert.expert_name
 
@@ -1288,3 +1341,63 @@ async def test_df25_expired_publish_allows_unadopted_delete(flow_env):
     if isinstance(again, dict):
         again = again.get("answers") or []
     assert all(int(item.get("id")) != other_aid for item in again)
+
+
+async def test_df25_admin_sees_anonymous_answer_expert_meta(flow_env):
+    """管理员看匿名回答：接口给真名+部门+计数；路人仍无档案。qa_expert 只读后写计数，无 DDL。"""
+    env = flow_env
+    expert = await env.seed_expert(user_id=201, name="专家甲")
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df25匿名答档案",
+            "description": "公开",
+            "business_domain": "steel",
+            "question_type": "public",
+        },
+    )
+    env.as_user(env.user(201, name=expert.expert_name))
+    aid = await _create_answer_anonymous(env, qid, "匿名首答")
+    async with AsyncSession(env.engine, expire_on_commit=False) as session:
+        await session.execute(
+            text("UPDATE qa_expert SET answer_count = :ac, adoption_count = :ad, depart_ment = :d WHERE id = :id"),
+            {"ac": 109, "ad": 53, "d": "测试2-2设备", "id": int(expert.id)},
+        )
+        await session.commit()
+    stored = await env.reload_row(Expert, id=int(expert.id))
+    assert int(stored.answer_count) == 109
+    assert int(stored.adoption_count) == 53
+    assert stored.depart_ment == "测试2-2设备"
+
+    env.as_user(env.stranger)
+    stranger_body = _ok(await env.client.get(f"{PREFIX}/answers/{qid}"))
+    assert stranger_body["status_code"] == 200
+    stranger_answers = (stranger_body.get("data") or {}).get("answers") or []
+    stranger_hit = next((item for item in stranger_answers if int(item.get("id")) == aid), None)
+    assert stranger_hit is not None
+    stranger_author = stranger_hit.get("author") or {}
+    assert stranger_author.get("anonymous") is True
+    assert "real_name" not in stranger_author
+    assert "department" not in stranger_author
+    assert not stranger_hit.get("expert")
+    stored_again = await env.reload_row(Expert, id=int(expert.id))
+    assert int(stored_again.answer_count) == 109
+
+    env.as_user(env.portal_admin)
+    admin_body = _ok(await env.client.get(f"{PREFIX}/answers/{qid}"))
+    assert admin_body["status_code"] == 200
+    admin_answers = (admin_body.get("data") or {}).get("answers") or []
+    admin_hit = next((item for item in admin_answers if int(item.get("id")) == aid), None)
+    assert admin_hit is not None
+    admin_author = admin_hit.get("author") or {}
+    assert admin_author.get("anonymous") is True
+    assert admin_author.get("real_name") == expert.expert_name
+    assert admin_author.get("department") == "测试2-2设备"
+    admin_expert = admin_hit.get("expert") or {}
+    assert int(admin_expert.get("answer_count") or 0) == 109
+    assert int(admin_expert.get("adoption_count") or 0) == 53
+    assert admin_expert.get("depart_ment") == "测试2-2设备"
+    answer_row = await env.reload_row(Answer, id=aid)
+    assert int(answer_row.anonymous) == 1
+    assert answer_row.expert_name == expert.expert_name


### PR DESCRIPTION
## Summary
- 管理员查看匿名回答时，接口下发部门与回答/采纳统计，详情可展示「部门 · 回答 N · 解决率」。
- 问题列表给管理员 `asker.real_name`；路人仍只见别名，且匿名回答不挂 `expert`，避免用部门/计数反推真人。

## Test plan
- [ ] 管理员打开匿名回答：副标题为部门与统计，不是「未知」
- [ ] 管理员看问题列表：匿名提问显示「匿名同事A（真名）」
- [ ] 普通用户看匿名回答：只有别名，无部门/统计行，接口无 `real_name` / `expert`
- [ ] `pytest src/backend/test/qa_expert/test_data_flow.py -k 'df19 or df25_admin or df26'`


Made with [Cursor](https://cursor.com)