### PR TITLE
fix(permission): seed initial F048 catalog on fresh install

### DIFF
--- a/src/backend/bisheng/permission/application/catalog_bootstrap.py
+++ b/src/backend/bisheng/permission/application/catalog_bootstrap.py
@@ -1,0 +1,357 @@
+"""Fresh-install bootstrap for the F048 permission Catalog.
+
+Two deployment paths create the F048 permission tables, and they need different
+initialization:
+
+* Upgrade from a pre-F048 release: the environment already carries legacy
+  permission data (roles, resource grants, an older OpenFGA model). Its initial
+  CURRENT ``permission_catalog_release`` is produced by the forward-only data
+  migration (``scripts/migrate_f048_permission_data.py`` ->
+  ``F048MigrationCoordinator``). The OpenFGA manager latches
+  ``migration_required`` until an operator runs it, so this module never touches
+  such an environment.
+
+* Fresh deployment: a brand-new install has no legacy data. The OpenFGA manager
+  bootstraps the F048 model directly (``migration_required`` is False), but
+  nothing ever runs the data migration, so no CURRENT release is created and the
+  permission runtime fails to start with "Permission Catalog must have exactly
+  one CURRENT release".
+
+This module closes that gap. It seeds the initial CURRENT release exactly once,
+idempotently, reusing the same canonical action/model derivation the migration
+writer uses so the fresh-install Catalog is identical to a migrated one minus
+legacy grants. It is a no-op once ``f048-initial`` exists (already seeded, or
+produced by the upgrade migration).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from hashlib import sha256
+
+from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import select
+
+from bisheng.core.context.tenant import bypass_tenant_filter
+from bisheng.core.database import get_async_db_session
+from bisheng.core.openfga.authorization_model_f048 import (
+    MODEL_VERSION,
+    get_authorization_model_f048,
+    required_relations_checksum,
+)
+from bisheng.core.openfga.client import FGAClient
+from bisheng.permission.domain.models import (
+    AuthorizationModelRelease,
+    AuthorizationModelReleaseStatus,
+    CatalogReleaseStatus,
+    PermissionAction,
+    PermissionActionResourceScope,
+    PermissionCatalogRelease,
+    PermissionModel,
+    PermissionModelAction,
+)
+from bisheng.permission.domain.services.model_policy import (
+    PermissionModelRelease,
+    derive_permission_models,
+)
+from bisheng.permission.migration.f048_coordinator import (
+    INITIAL_CATALOG_RELEASE_KEY,
+)
+from bisheng.permission.migration.f048_model_mapper import (
+    build_initial_action_release,
+)
+
+logger = logging.getLogger(__name__)
+
+# Mirrors OPENFGA_RELEASE_VERSION in f048_runtime_storage. Kept local so the
+# hot startup path does not import the whole migration writer stack; the value
+# is an audit-only column and is not validated by runtime readiness.
+_OPENFGA_RELEASE_VERSION = "1.15.1"
+
+# A stable, unique idempotency key so a concurrent second starter collides on
+# the unique constraint instead of inserting a duplicate release.
+_BOOTSTRAP_IDEMPOTENCY_KEY = "f048-initial-bootstrap"
+
+# OpenFGA caps a single Write at 100 tuple operations; stay under it.
+_FGA_WRITE_BATCH = 90
+
+
+def _checksum(value: object) -> str:
+    """Match the canonical checksum used by the migration writer."""
+
+    payload = json.dumps(
+        value,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _catalog_tuples(
+    release_key: str,
+    model_release: PermissionModelRelease,
+) -> list[dict[str, str]]:
+    """Build the OpenFGA catalog graph for one release.
+
+    Identical to ``catalog_api._expected_tuples`` /
+    ``f048_coordinator._compile_target_tuples`` so a fresh install writes the
+    same catalog/model markers a publish or migration would.
+    """
+
+    catalog = f"permission_catalog_release:{release_key}"
+    tuples: dict[tuple[str, str, str], dict[str, str]] = {}
+
+    def add(user: str, relation: str, object_key: str) -> None:
+        tuples[(user, relation, object_key)] = {
+            "user": user,
+            "relation": relation,
+            "object": object_key,
+        }
+
+    add("user:*", "active", catalog)
+    for model in model_release.models:
+        release = f"permission_model_release:{release_key}~{model.model_key}"
+        add(release, "release", f"permission_model:{model.model_key}")
+        add(catalog, "catalog", release)
+        add("user:*", "enabled_marker", release)
+        for action_code in model.action_codes:
+            add("user:*", f"{action_code}_marker", release)
+        if "manage_permission" in model.action_codes and model.derived_level is not None:
+            upper = model.derived_level if model.allow_same_level else model.derived_level - 1
+            for level in range(1, max(upper, 0) + 1):
+                add("user:*", f"grant_level_{level}_marker", release)
+    return list(tuples.values())
+
+
+async def _write_catalog_tuples(
+    client: FGAClient,
+    release_key: str,
+    model_release: PermissionModelRelease,
+) -> None:
+    tuples = _catalog_tuples(release_key, model_release)
+    for index in range(0, len(tuples), _FGA_WRITE_BATCH):
+        await client.write_tuples(
+            writes=tuples[index : index + _FGA_WRITE_BATCH],
+            ignore_duplicate_writes=True,
+        )
+
+
+async def _initial_release_exists() -> bool:
+    with bypass_tenant_filter():
+        async with get_async_db_session() as session:
+            existing = (
+                await session.execute(
+                    select(PermissionCatalogRelease.id)
+                    .where(PermissionCatalogRelease.release_key == INITIAL_CATALOG_RELEASE_KEY)
+                    .limit(1)
+                )
+            ).scalar_one_or_none()
+    return existing is not None
+
+
+async def _seed_control_plane(
+    *,
+    store_id: str,
+    model_id: str,
+    model_checksum: str,
+    environment: str,
+    catalog_checksum: str,
+    relations_checksum: str,
+    action_release,
+    model_release: PermissionModelRelease,
+) -> None:
+    now = datetime.now(UTC)
+    with bypass_tenant_filter():
+        async with get_async_db_session() as session:
+            async with session.begin():
+                # Re-check inside the transaction so the common concurrent case
+                # is a clean skip rather than an IntegrityError.
+                if (
+                    await session.execute(
+                        select(PermissionCatalogRelease.id)
+                        .where(PermissionCatalogRelease.release_key == INITIAL_CATALOG_RELEASE_KEY)
+                        .limit(1)
+                    )
+                ).scalar_one_or_none() is not None:
+                    return
+
+                auth_release = (
+                    await session.execute(
+                        select(AuthorizationModelRelease).where(
+                            AuthorizationModelRelease.environment == environment,
+                            AuthorizationModelRelease.store_id == store_id,
+                            AuthorizationModelRelease.model_id == model_id,
+                        )
+                    )
+                ).scalars().first()
+                if auth_release is None:
+                    auth_release = AuthorizationModelRelease(
+                        environment=environment,
+                        store_id=store_id,
+                        model_version=MODEL_VERSION,
+                        model_id=model_id,
+                        predecessor_model_id=None,
+                        model_checksum=model_checksum,
+                        required_relations_checksum=relations_checksum,
+                        openfga_version=_OPENFGA_RELEASE_VERSION,
+                        status=AuthorizationModelReleaseStatus.ACTIVE.value,
+                        activated_at=now,
+                    )
+                    session.add(auth_release)
+                    await session.flush()
+                elif auth_release.status != AuthorizationModelReleaseStatus.ACTIVE.value:
+                    auth_release.status = AuthorizationModelReleaseStatus.ACTIVE.value
+                    auth_release.activated_at = now
+                if auth_release.id is None:
+                    raise RuntimeError("Authorization model release was not flushed")
+
+                release = PermissionCatalogRelease(
+                    release_key=INITIAL_CATALOG_RELEASE_KEY,
+                    version=1,
+                    status=CatalogReleaseStatus.CURRENT.value,
+                    write_fenced=False,
+                    predecessor_id=None,
+                    required_authorization_model_release_id=int(auth_release.id),
+                    draft_owner_id=0,
+                    idempotency_key=_BOOTSTRAP_IDEMPOTENCY_KEY,
+                    checksum=catalog_checksum,
+                    commit_checksum=catalog_checksum,
+                    published_at=now,
+                )
+                session.add(release)
+                await session.flush()
+                if release.id is None:
+                    raise RuntimeError("Catalog release was not flushed")
+
+                action_ids: dict[str, int] = {}
+                for action in action_release.actions:
+                    action_row = PermissionAction(
+                        catalog_release_id=release.id,
+                        code=action.code,
+                        name=action.name,
+                        level=action.level,
+                        active=action.active,
+                        sort_order=action.sort_order,
+                    )
+                    session.add(action_row)
+                    await session.flush()
+                    if action_row.id is None:
+                        raise RuntimeError("Action row was not flushed")
+                    action_ids[action.code] = int(action_row.id)
+                    for resource_type in sorted(action.resource_types):
+                        session.add(
+                            PermissionActionResourceScope(
+                                action_id=action_row.id,
+                                resource_type=resource_type,
+                            )
+                        )
+
+                for model in model_release.models:
+                    model_row = PermissionModel(
+                        catalog_release_id=release.id,
+                        model_key=model.model_key,
+                        normalized_name=model.name.casefold(),
+                        name=model.name,
+                        kind=model.kind,
+                        config_scope=model.config_scope,
+                        derived_level=model.derived_level,
+                        active=model.active,
+                        allow_same_level=model.allow_same_level,
+                        legacy_source_key=None,
+                    )
+                    session.add(model_row)
+                    await session.flush()
+                    if model_row.id is None:
+                        raise RuntimeError("Model row was not flushed")
+                    for action_code in model.action_codes:
+                        action_id = action_ids.get(action_code)
+                        if action_id is None:
+                            raise RuntimeError(f"Model references unknown action: {action_code}")
+                        session.add(
+                            PermissionModelAction(
+                                model_id=model_row.id,
+                                action_id=action_id,
+                            )
+                        )
+
+
+def normalize_environment(value: object) -> str:
+    """Mirror scripts.f048_migration_runtime._environment_name."""
+
+    if isinstance(value, dict):
+        value = next(
+            (value[key] for key in ("name", "environment", "env", "mode") if value.get(key)),
+            "dev",
+        )
+    return str(value or "dev")[:64]
+
+
+async def seed_initial_permission_catalog(
+    client: FGAClient,
+    *,
+    store_id: str,
+    model_id: str,
+    model_checksum: str,
+    environment: object,
+) -> bool:
+    """Seed the initial CURRENT Catalog for a fresh install, idempotently.
+
+    Returns True when this call created the release, False when it was already
+    present (already seeded, or produced by the upgrade migration). Never raises
+    ``PermissionPublishNotReadyError`` / ``AuthorizationModelMismatchError`` so a
+    transient failure does not latch the process migration gate; on any error it
+    logs and returns False, leaving the caller's own readiness check to surface
+    the still-missing Catalog.
+    """
+
+    if not store_id or not model_id or not model_checksum:
+        return False
+
+    env = normalize_environment(environment)
+    action_release = build_initial_action_release()
+    model_release = derive_permission_models(action_release)
+    catalog_checksum = _checksum(
+        {
+            "actions": action_release.checksum,
+            "models": model_release.checksum,
+        }
+    )
+    relations_checksum = required_relations_checksum(get_authorization_model_f048())
+
+    try:
+        if await _initial_release_exists():
+            return False
+
+        # Write the OpenFGA catalog graph before the CURRENT release becomes
+        # visible so no process can read a CURRENT Catalog without its
+        # authorization tuples. Idempotent via ignore_duplicate_writes.
+        await _write_catalog_tuples(client, INITIAL_CATALOG_RELEASE_KEY, model_release)
+
+        await _seed_control_plane(
+            store_id=store_id,
+            model_id=model_id,
+            model_checksum=model_checksum,
+            environment=env,
+            catalog_checksum=catalog_checksum,
+            relations_checksum=relations_checksum,
+            action_release=action_release,
+            model_release=model_release,
+        )
+    except IntegrityError:
+        # Another starting process seeded concurrently; its rows win.
+        logger.info("F048 initial permission Catalog already seeded by a concurrent process")
+        return False
+    except Exception:
+        logger.exception("F048 initial permission Catalog bootstrap failed")
+        return False
+
+    logger.info(
+        "Seeded initial F048 permission Catalog for fresh install: store=%s model=%s",
+        store_id,
+        model_id,
+    )
+    return True

--- a/src/backend/bisheng/permission/application/process_runtime.py
+++ b/src/backend/bisheng/permission/application/process_runtime.py
@@ -86,6 +86,23 @@ def register_f048_permission_runtime_context(
             raise PermissionPublishNotReadyError(
                 msg=str(readiness.get("error") or "Permission data migration is required")
             )
+        # Fresh install has no legacy data and never runs the forward-only data
+        # migration, so nothing else would create the initial CURRENT Catalog.
+        # Seed it here (idempotent no-op once present). Reaching this point means
+        # migration is not required, so this only ever fires on a brand-new
+        # deployment; an upgrade raised above until the operator migrates.
+        from bisheng.common.services.config_service import settings
+        from bisheng.permission.application.catalog_bootstrap import (
+            seed_initial_permission_catalog,
+        )
+
+        await seed_initial_permission_catalog(
+            client,
+            store_id=str(readiness.get("store_id") or ""),
+            model_id=str(readiness.get("model_id") or ""),
+            model_checksum=str(readiness.get("model_checksum") or ""),
+            environment=settings.environment,
+        )
         try:
             runtime = await initializer(client)
         except (

--- a/src/backend/test/permission/test_f048_catalog_bootstrap.py
+++ b/src/backend/test/permission/test_f048_catalog_bootstrap.py
@@ -1,0 +1,268 @@
+"""Fresh-install seeding contract for the F048 permission Catalog.
+
+Covers the gap where a brand-new deployment (no legacy data, so the forward-only
+data migration never runs) would otherwise start with zero CURRENT
+``permission_catalog_release`` rows and fail the permission runtime with
+"Permission Catalog must have exactly one CURRENT release".
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.pool import StaticPool
+from sqlmodel import SQLModel, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from bisheng.permission.application import catalog_bootstrap
+from bisheng.permission.application import control_state as control_state_module
+from bisheng.permission.application import sql_runtime as sql_runtime_module
+from bisheng.permission.application.catalog_bootstrap import (
+    normalize_environment,
+    seed_initial_permission_catalog,
+)
+from bisheng.permission.application.sql_runtime import SqlCatalogDecisionState
+from bisheng.permission.domain.models import (
+    AuthorizationModelRelease,
+    PermissionAction,
+    PermissionCatalogRelease,
+    PermissionModel,
+    PermissionModelAction,
+)
+from bisheng.permission.migration.f048_coordinator import (
+    INITIAL_CATALOG_RELEASE_KEY,
+)
+
+TABLE_NAMES = (
+    "authorization_model_release",
+    "permission_catalog_release",
+    "permission_action",
+    "permission_action_resource_scope",
+    "permission_model",
+    "permission_model_action",
+)
+
+STORE_ID = "store-fresh"
+MODEL_ID = "model-fresh"
+MODEL_CHECKSUM = "a" * 64
+
+
+class FakeFGA:
+    """Minimal OpenFGA write surface with the seeder's exact call shape."""
+
+    store_id = STORE_ID
+    model_id = MODEL_ID
+
+    def __init__(self) -> None:
+        self.tuples: set[tuple[str, str, str]] = set()
+        self.write_calls = 0
+
+    async def write_tuples(
+        self,
+        writes: list[dict] | None = None,
+        deletes: list[dict] | None = None,
+        *,
+        ignore_duplicate_writes: bool = False,
+    ) -> None:
+        assert ignore_duplicate_writes is True
+        self.write_calls += 1
+        for row in writes or ():
+            self.tuples.add((row["user"], row["relation"], row["object"]))
+
+
+@pytest.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    metadata = sa.MetaData()
+    for name in TABLE_NAMES:
+        cloned = SQLModel.metadata.tables[name].to_metadata(metadata)
+        # BigInteger does not autoincrement on sqlite; use Integer for the PK.
+        cloned.c.id.type = sa.Integer()
+    async with engine.begin() as connection:
+        await connection.run_sync(metadata.create_all)
+
+    @asynccontextmanager
+    async def factory() -> AsyncIterator[AsyncSession]:
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            yield session
+
+    yield factory
+    await engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _bind_session(session_factory, monkeypatch):
+    for module in (catalog_bootstrap, control_state_module, sql_runtime_module):
+        monkeypatch.setattr(module, "get_async_db_session", session_factory)
+    return session_factory
+
+
+async def _count(session_factory, model) -> int:
+    async with session_factory() as session:
+        rows = (await session.execute(select(model))).scalars().all()
+    return len(rows)
+
+
+@pytest.mark.asyncio
+async def test_seed_creates_single_current_catalog_on_fresh_install(session_factory):
+    fga = FakeFGA()
+
+    seeded = await seed_initial_permission_catalog(
+        fga,
+        store_id=STORE_ID,
+        model_id=MODEL_ID,
+        model_checksum=MODEL_CHECKSUM,
+        environment="prod",
+    )
+
+    assert seeded is True
+
+    async with session_factory() as session:
+        releases = (await session.execute(select(PermissionCatalogRelease))).scalars().all()
+        auth = (await session.execute(select(AuthorizationModelRelease))).scalars().all()
+
+    assert len(releases) == 1
+    release = releases[0]
+    assert release.release_key == INITIAL_CATALOG_RELEASE_KEY
+    assert release.status == "CURRENT"
+    assert release.write_fenced is False
+
+    assert len(auth) == 1
+    assert auth[0].status == "ACTIVE"
+    assert auth[0].store_id == STORE_ID
+    assert auth[0].model_id == MODEL_ID
+    assert auth[0].activated_at is not None
+    assert release.required_authorization_model_release_id == auth[0].id
+
+    # 12 registered actions, 4 standard models, and the catalog graph in FGA.
+    assert await _count(session_factory, PermissionAction) == 12
+    assert await _count(session_factory, PermissionModel) == 4
+    assert await _count(session_factory, PermissionModelAction) > 0
+    assert ("user:*", "active", f"permission_catalog_release:{INITIAL_CATALOG_RELEASE_KEY}") in fga.tuples
+
+
+@pytest.mark.asyncio
+async def test_seed_makes_runtime_ready(session_factory):
+    """The seeded state satisfies the exact checks that raised at startup."""
+
+    await seed_initial_permission_catalog(
+        FakeFGA(),
+        store_id=STORE_ID,
+        model_id=MODEL_ID,
+        model_checksum=MODEL_CHECKSUM,
+        environment="prod",
+    )
+
+    decision = SqlCatalogDecisionState(
+        expected_store_id=STORE_ID,
+        expected_model_id=MODEL_ID,
+    )
+    # Previously raised PermissionPublishNotReadyError("... exactly one CURRENT release").
+    await decision.ensure_runtime_ready()
+
+    snapshot = await control_state_module.SqlPermissionControlState().current_catalog()
+    assert snapshot.store_id == STORE_ID
+    assert snapshot.model_id == MODEL_ID
+
+
+@pytest.mark.asyncio
+async def test_seed_is_idempotent(session_factory):
+    fga = FakeFGA()
+    first = await seed_initial_permission_catalog(
+        fga,
+        store_id=STORE_ID,
+        model_id=MODEL_ID,
+        model_checksum=MODEL_CHECKSUM,
+        environment="prod",
+    )
+    second = await seed_initial_permission_catalog(
+        fga,
+        store_id=STORE_ID,
+        model_id=MODEL_ID,
+        model_checksum=MODEL_CHECKSUM,
+        environment="prod",
+    )
+
+    assert first is True
+    assert second is False
+    # No duplicate control-plane rows after the second run.
+    assert await _count(session_factory, PermissionCatalogRelease) == 1
+    assert await _count(session_factory, AuthorizationModelRelease) == 1
+    assert await _count(session_factory, PermissionAction) == 12
+    assert await _count(session_factory, PermissionModel) == 4
+
+
+@pytest.mark.asyncio
+async def test_seed_skips_when_release_already_present(session_factory):
+    """An upgrade-migrated environment already has the release: no-op, no writes."""
+
+    async with session_factory() as session:
+        async with session.begin():
+            auth = AuthorizationModelRelease(
+                environment="prod",
+                store_id=STORE_ID,
+                model_version="f048-v2",
+                model_id=MODEL_ID,
+                model_checksum=MODEL_CHECKSUM,
+                required_relations_checksum="b" * 64,
+                openfga_version="1.15.1",
+                status="ACTIVE",
+            )
+            session.add(auth)
+            await session.flush()
+            session.add(
+                PermissionCatalogRelease(
+                    release_key=INITIAL_CATALOG_RELEASE_KEY,
+                    version=1,
+                    status="CURRENT",
+                    write_fenced=False,
+                    required_authorization_model_release_id=int(auth.id),
+                    draft_owner_id=0,
+                    idempotency_key="f048-migration-1",
+                    checksum="c" * 64,
+                )
+            )
+
+    fga = FakeFGA()
+    seeded = await seed_initial_permission_catalog(
+        fga,
+        store_id=STORE_ID,
+        model_id=MODEL_ID,
+        model_checksum=MODEL_CHECKSUM,
+        environment="prod",
+    )
+
+    assert seeded is False
+    assert fga.write_calls == 0
+    assert await _count(session_factory, PermissionCatalogRelease) == 1
+
+
+@pytest.mark.asyncio
+async def test_seed_returns_false_without_a_valid_pin(session_factory):
+    fga = FakeFGA()
+    seeded = await seed_initial_permission_catalog(
+        fga,
+        store_id="",
+        model_id=MODEL_ID,
+        model_checksum=MODEL_CHECKSUM,
+        environment="prod",
+    )
+    assert seeded is False
+    assert fga.write_calls == 0
+    assert await _count(session_factory, PermissionCatalogRelease) == 0
+
+
+def test_normalize_environment_matches_migration_runtime():
+    assert normalize_environment({"name": "prod"}) == "prod"
+    assert normalize_environment({"mode": "staging"}) == "staging"
+    assert normalize_environment(None) == "dev"
+    assert normalize_environment("") == "dev"
+    assert len(normalize_environment("x" * 200)) == 64


### PR DESCRIPTION
A fresh deployment has no legacy data and never runs the forward-only F048 data migration, so no CURRENT permission_catalog_release was ever created and the permission runtime failed to start with 'Permission Catalog must have exactly one CURRENT release'.

Add an idempotent seeder (catalog_bootstrap.seed_initial_permission_catalog) that creates the ACTIVE authorization_model_release, the CURRENT f048-initial catalog release with standard actions/models, and the OpenFGA catalog tuples, reusing the migration's canonical derivation. Wire it into process_runtime.initialize() after the migration_required gate, so it only fires on fresh installs and stays a no-op on upgrade-migrated environments.

## What

简要描述做了什么改动。

## Why

为什么需要这个改动？

## How

实现方式、设计决策（如有）。

## Test

- [ ] 本地测试通过
- [ ] 114 测试服务器验证通过

## Related

- Issue/ticket:
