### PR TITLE
fix(qa-expert): 关联文档个人库权限与隐藏转公开场景

### DIFF
--- a/src/backend/bisheng/approval/domain/services/approval_scenario_admin_service.py
+++ b/src/backend/bisheng/approval/domain/services/approval_scenario_admin_service.py
@@ -24,10 +24,18 @@ from bisheng.database.models.audit_log import AuditLogDao
 class ApprovalScenarioAdminService:
     SYSTEM_SCENARIO_CODES = frozenset({"department_file_view_request"})
     FIXED_SCENARIO_CODES = frozenset()
+    # 流程管理不展示：业务自建流程，管理员不可配置。运行时仍走 registry / repository。
+    ADMIN_CONFIG_HIDDEN_SCENARIO_CODES = frozenset({"qa_question_publish"})
 
     @classmethod
     def _is_fixed_scenario(cls, scenario) -> bool:
         return bool(scenario and getattr(scenario, "scenario_code", None) in cls.FIXED_SCENARIO_CODES)
+
+    @classmethod
+    def _is_admin_config_hidden(cls, scenario) -> bool:
+        """流程管理是否隐藏该场景。可传 ORM 行或 scenario_code。"""
+        code = scenario if isinstance(scenario, str) else getattr(scenario, "scenario_code", None)
+        return code in cls.ADMIN_CONFIG_HIDDEN_SCENARIO_CODES
 
     @classmethod
     async def _assert_scenario_structure_mutable(
@@ -39,7 +47,7 @@ class ApprovalScenarioAdminService:
         scenario = await ApprovalScenarioRepository.get_scenario(scenario_id)
         if scenario is None or scenario.tenant_id != tenant_id:
             raise ValueError(f"scenario not found: {scenario_id}")
-        if cls._is_fixed_scenario(scenario):
+        if cls._is_fixed_scenario(scenario) or cls._is_admin_config_hidden(scenario):
             raise ApprovalFixedScenarioStructureLockedError()
         return scenario
 
@@ -77,7 +85,11 @@ class ApprovalScenarioAdminService:
 
     @classmethod
     async def list_presets(cls):
-        return [item.model_dump() for item in ApprovalRegistry.with_default_presets().list_presets()]
+        return [
+            item.model_dump()
+            for item in ApprovalRegistry.with_default_presets().list_presets()
+            if not cls._is_admin_config_hidden(item.scenario_code)
+        ]
 
     @classmethod
     async def list_scenarios(cls, *, tenant_id: int):
@@ -89,6 +101,7 @@ class ApprovalScenarioAdminService:
                 "structure_locked": cls._is_fixed_scenario(row),
             }
             for row in rows
+            if not cls._is_admin_config_hidden(row)
         ]
 
     @classmethod
@@ -101,7 +114,7 @@ class ApprovalScenarioAdminService:
         operator_user_name: str | None = None,
     ):
         scenario_code = str(payload["scenario_code"])
-        if scenario_code in cls.SYSTEM_SCENARIO_CODES:
+        if scenario_code in cls.SYSTEM_SCENARIO_CODES or cls._is_admin_config_hidden(scenario_code):
             raise ApprovalFixedScenarioStructureLockedError()
         existing = await ApprovalScenarioRepository.get_scenario_by_code(tenant_id, scenario_code)
         if existing:
@@ -142,6 +155,8 @@ class ApprovalScenarioAdminService:
         row = await ApprovalScenarioRepository.get_scenario(scenario_id)
         if row is None or row.tenant_id != tenant_id:
             raise ValueError(f"scenario not found: {scenario_id}")
+        if cls._is_admin_config_hidden(row):
+            raise ApprovalFixedScenarioStructureLockedError()
         if cls._is_fixed_scenario(row):
             extra_fields = set(payload) - {"enabled", "toggle_reason"}
             if extra_fields:

--- a/src/backend/bisheng/qa_expert/domain/related_docs_access.py
+++ b/src/backend/bisheng/qa_expert/domain/related_docs_access.py
@@ -53,6 +53,36 @@ async def load_related_doc_title(space_id: int, file_id: int) -> str | None:
     return related_doc_display_title(row)
 
 
+async def _personal_space_owner_id(space_id: int) -> int | None:
+    """个人知识库返回 owner 的 user_id；部门/公开等返回 None。"""
+    try:
+        from bisheng.knowledge.domain.models.knowledge import KnowledgeDao
+        from bisheng.knowledge.domain.models.knowledge_space_scope import (
+            KnowledgeSpaceLevelEnum,
+            KnowledgeSpaceScopeDao,
+        )
+
+        scope = await KnowledgeSpaceScopeDao.aget_by_space_id(int(space_id))
+        if scope is not None:
+            level = getattr(scope.level, "value", scope.level)
+            if level != KnowledgeSpaceLevelEnum.PERSONAL.value:
+                return None
+            owner_id = int(getattr(scope, "owner_id", 0) or 0)
+            if owner_id:
+                return owner_id
+        space = await KnowledgeDao.aquery_by_id(int(space_id))
+        if space is None:
+            return None
+        if scope is None:
+            # 无 scope 行时与知识空间列表一致：按个人库 + knowledge.user_id 推断
+            owner_id = int(getattr(space, "user_id", 0) or 0)
+            return owner_id if owner_id else None
+        owner_id = int(getattr(space, "user_id", 0) or 0)
+        return owner_id if owner_id else None
+    except Exception:
+        return None
+
+
 async def _space_can_read(user: Any, space_id: int) -> bool:
     """单点 PermissionService.check，禁止 list_accessible_ids。"""
     user_id = getattr(user, "user_id", None) if user is not None else None
@@ -88,6 +118,19 @@ async def check_related_doc_access(
     if not await _file_belongs_to_space(int(space_id), int(file_id)):
         return None
     cache_key = int(space_id)
+    viewer_id = getattr(user, "user_id", None) if user is not None else None
+    is_admin = bool(callable(getattr(user, "is_admin", None)) and user.is_admin())
+    personal_owner_id = await _personal_space_owner_id(cache_key)
+    if (
+        not is_admin
+        and personal_owner_id is not None
+        and viewer_id is not None
+        and int(personal_owner_id) != int(viewer_id)
+    ):
+        # 非管理员看他人个人库：不走 can_read（避免误共享）；系统管理员仍走下方鉴权。
+        if space_cache is not None:
+            space_cache[cache_key] = False
+        return False
     if space_cache is not None and cache_key in space_cache:
         return space_cache[cache_key]
     allowed = await _space_can_read(user, cache_key)

--- a/src/backend/test/approval/test_qa_publish_admin_hidden.py
+++ b/src/backend/test/approval/test_qa_publish_admin_hidden.py
@@ -1,0 +1,88 @@
+"""流程管理隐藏「专家问答转公开」：列表/预置不返回，管理员不可新建或改结构。无 DDL。"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from bisheng.approval.domain.services.approval_scenario_admin_service import (
+    ApprovalScenarioAdminService,
+)
+from bisheng.common.errcode.approval import ApprovalFixedScenarioStructureLockedError
+
+
+def _row(scenario_code: str, *, scenario_id: int = 1, name: str = "") -> SimpleNamespace:
+    payload = {
+        "id": scenario_id,
+        "tenant_id": 1,
+        "scenario_code": scenario_code,
+        "scenario_name": name or scenario_code,
+        "enabled": True,
+    }
+    return SimpleNamespace(
+        id=scenario_id,
+        tenant_id=1,
+        scenario_code=scenario_code,
+        scenario_name=payload["scenario_name"],
+        enabled=True,
+        model_dump=lambda: payload.copy(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_admin_presets_hide_qa_question_publish() -> None:
+    """预置列表不含转公开；registry 里仍有该码，运行时可用。"""
+    presets = await ApprovalScenarioAdminService.list_presets()
+    codes = {item["scenario_code"] for item in presets}
+    assert "qa_question_publish" not in codes
+    assert "menu_access_request" in codes
+
+
+@pytest.mark.asyncio
+async def test_admin_scenario_list_hides_qa_question_publish_but_keeps_row() -> None:
+    """库内仍有 qa_question_publish 行时，流程管理列表不返回。"""
+    visible = _row("menu_access_request", scenario_id=1, name="菜单权限申请")
+    hidden = _row("qa_question_publish", scenario_id=88, name="专家问答转公开")
+    with patch(
+        "bisheng.approval.domain.services.approval_scenario_admin_service.ApprovalScenarioRepository.list_scenarios",
+        new=AsyncMock(return_value=[visible, hidden]),
+    ):
+        listed = await ApprovalScenarioAdminService.list_scenarios(tenant_id=1)
+
+    codes = [item["scenario_code"] for item in listed]
+    assert codes == ["menu_access_request"]
+    assert hidden.scenario_code == "qa_question_publish"
+    assert hidden.enabled is True
+
+
+@pytest.mark.asyncio
+async def test_admin_cannot_create_or_mutate_qa_question_publish() -> None:
+    """管理员不能通过流程管理新建、改启停或删转公开场景。"""
+    hidden = _row("qa_question_publish", scenario_id=88, name="专家问答转公开")
+    with pytest.raises(ApprovalFixedScenarioStructureLockedError):
+        await ApprovalScenarioAdminService.create_scenario(
+            tenant_id=1,
+            payload={
+                "scenario_code": "qa_question_publish",
+                "scenario_name": "专家问答转公开",
+                "enabled": True,
+            },
+        )
+
+    with patch(
+        "bisheng.approval.domain.services.approval_scenario_admin_service.ApprovalScenarioRepository.get_scenario",
+        new=AsyncMock(return_value=hidden),
+    ):
+        with pytest.raises(ApprovalFixedScenarioStructureLockedError):
+            await ApprovalScenarioAdminService.update_scenario(
+                tenant_id=1,
+                scenario_id=88,
+                payload={"enabled": False},
+            )
+        with pytest.raises(ApprovalFixedScenarioStructureLockedError):
+            await ApprovalScenarioAdminService.delete_scenario(
+                tenant_id=1,
+                scenario_id=88,
+            )

--- a/src/backend/test/qa_expert/test_related_docs_access.py
+++ b/src/backend/test/qa_expert/test_related_docs_access.py
@@ -99,3 +99,45 @@ async def test_load_related_doc_title_returns_file_name(monkeypatch):
         AsyncMock(return_value=SimpleNamespace(file_name="工艺说明.docx", alias_name=None)),
     )
     assert await related_docs_access.load_related_doc_title(8, 15) == "工艺说明.docx"
+
+
+async def test_other_user_personal_space_allowed_for_admin(monkeypatch):
+    """他人个人库：系统管理员仍走 can_read，与全局数据可见一致。"""
+    monkeypatch.setattr(related_docs_access, "_file_belongs_to_space", AsyncMock(return_value=True))
+    monkeypatch.setattr(related_docs_access, "_personal_space_owner_id", AsyncMock(return_value=100))
+    space_read = AsyncMock(return_value=True)
+    monkeypatch.setattr(related_docs_access, "_space_can_read", space_read)
+    admin = SimpleNamespace(user_id=1, is_admin=lambda: True)
+    assert await related_docs_access.check_related_doc_access(admin, 8, 15) is True
+    space_read.assert_awaited_once()
+
+
+async def test_other_user_personal_space_denied_for_non_admin(monkeypatch):
+    """他人个人库：普通用户不调用 can_read，直接 forbidden。"""
+    monkeypatch.setattr(related_docs_access, "_file_belongs_to_space", AsyncMock(return_value=True))
+    monkeypatch.setattr(related_docs_access, "_personal_space_owner_id", AsyncMock(return_value=100))
+    space_read = AsyncMock(return_value=True)
+    monkeypatch.setattr(related_docs_access, "_space_can_read", space_read)
+    stranger = SimpleNamespace(user_id=2, is_admin=lambda: False)
+    assert await related_docs_access.check_related_doc_access(stranger, 8, 15) is False
+    space_read.assert_not_awaited()
+
+
+async def test_owner_personal_space_still_uses_space_read(monkeypatch):
+    monkeypatch.setattr(related_docs_access, "_file_belongs_to_space", AsyncMock(return_value=True))
+    monkeypatch.setattr(related_docs_access, "_personal_space_owner_id", AsyncMock(return_value=100))
+    space_read = AsyncMock(return_value=True)
+    monkeypatch.setattr(related_docs_access, "_space_can_read", space_read)
+    owner = SimpleNamespace(user_id=100, is_admin=lambda: False)
+    assert await related_docs_access.check_related_doc_access(owner, 8, 15) is True
+    space_read.assert_awaited_once()
+
+
+async def test_non_personal_space_admin_still_uses_space_read(monkeypatch):
+    monkeypatch.setattr(related_docs_access, "_file_belongs_to_space", AsyncMock(return_value=True))
+    monkeypatch.setattr(related_docs_access, "_personal_space_owner_id", AsyncMock(return_value=None))
+    space_read = AsyncMock(return_value=True)
+    monkeypatch.setattr(related_docs_access, "_space_can_read", space_read)
+    admin = SimpleNamespace(user_id=1, is_admin=lambda: True)
+    assert await related_docs_access.check_related_doc_access(admin, 8, 15) is True
+    space_read.assert_awaited_once()

--- a/src/frontend/platform/src/controllers/API/approval.ts
+++ b/src/frontend/platform/src/controllers/API/approval.ts
@@ -134,6 +134,17 @@ export interface ApprovalInstanceDetail {
   }[];
 }
 
+/** 流程管理不展示的场景码：业务自建流程，管理员不可配置。 */
+export const ADMIN_HIDDEN_SCENARIO_CODES = new Set(["qa_question_publish"]);
+
+/**
+ * 流程管理列表/新增预置是否隐藏该场景。
+ * @param scenarioCode 审批场景码，可空
+ */
+export function isAdminHiddenApprovalScenario(scenarioCode?: string | null): boolean {
+  return Boolean(scenarioCode && ADMIN_HIDDEN_SCENARIO_CODES.has(scenarioCode));
+}
+
 export async function listApprovalScenarioPresetsApi(): Promise<ApprovalScenarioPreset[]> {
   return await axios.get("/api/v1/approval/admin/scenario-presets");
 }

--- a/src/frontend/platform/src/pages/ApprovalPage/index.tsx
+++ b/src/frontend/platform/src/pages/ApprovalPage/index.tsx
@@ -24,6 +24,7 @@ import {
   listApprovalExceptionsApi,
   listApprovalNodesApi,
   listApprovalRoutesApi,
+  isAdminHiddenApprovalScenario,
   listApprovalScenarioPresetsApi,
   listApprovalScenariosApi,
   reorderApprovalRoutesApi,
@@ -1920,10 +1921,15 @@ export default function ApprovalPage() {
       listApprovalScenariosApi(),
       listApprovalExceptionsApi(),
     ]);
-    setPresets(presetList);
-    setScenarios(scenarioList);
+    const visiblePresets = presetList.filter((p) => !isAdminHiddenApprovalScenario(p.scenario_code));
+    const visibleScenarios = scenarioList.filter((s) => !isAdminHiddenApprovalScenario(s.scenario_code));
+    setPresets(visiblePresets);
+    setScenarios(visibleScenarios);
     setExceptions(exceptionList);
-    const initId = selectedScenarioId ?? scenarioList[0]?.id ?? null;
+    const initId =
+      selectedScenarioId && visibleScenarios.some((s) => s.id === selectedScenarioId)
+        ? selectedScenarioId
+        : (visibleScenarios[0]?.id ?? null);
     if (initId) {
       setSelectedScenarioId(initId);
       await Promise.all([loadRoutes(initId), loadFlows(initId, selectedFlowId)]);

--- a/src/frontend/platform/src/test/approvalPage.test.tsx
+++ b/src/frontend/platform/src/test/approvalPage.test.tsx
@@ -150,6 +150,7 @@ vi.mock("@/controllers/API/user", () => ({
 }));
 
 vi.mock("@/controllers/API/approval", () => ({
+  isAdminHiddenApprovalScenario: (code?: string | null) => code === "qa_question_publish",
   listApprovalScenarioPresetsApi: (...a: any[]) => listApprovalScenarioPresetsApi(...a),
   listApprovalScenariosApi: (...a: any[]) => listApprovalScenariosApi(...a),
   listApprovalExceptionsApi: (...a: any[]) => listApprovalExceptionsApi(...a),
@@ -308,6 +309,38 @@ describe("ApprovalPage", () => {
     expect(listApprovalRoutesApi).toHaveBeenCalledWith(1);
     expect(listApprovalFlowsApi).toHaveBeenCalledWith(1);
     expect(listApprovalNodesApi).toHaveBeenCalledWith(12);
+  });
+
+  it("hides expert QA publish scenario from flow list and add dialog", async () => {
+    const user = userEvent.setup();
+    listApprovalScenarioPresetsApi.mockResolvedValue([
+      PRESET,
+      {
+        scenario_code: "qa_question_publish",
+        scenario_name: "专家问答转公开",
+        handler_key: "qa_question_publish",
+        condition_fields: ["applicant_role"],
+        approver_source_types: ["direct_user"],
+      },
+    ]);
+    listApprovalScenariosApi.mockResolvedValue([
+      SCENARIO,
+      {
+        id: 88,
+        scenario_code: "qa_question_publish",
+        scenario_name: "专家问答转公开",
+        enabled: true,
+      },
+    ]);
+
+    render(<ApprovalPage />);
+
+    expect((await screen.findAllByText("菜单权限申请")).length).toBeGreaterThan(0);
+    expect(screen.queryByText("专家问答转公开")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "新增" }));
+    expect(await screen.findByText("新增审批场景")).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "专家问答转公开" })).not.toBeInTheDocument();
   });
 
   it("shows applicant department route condition with department name", async () => {


### PR DESCRIPTION
## Summary
- 关联文档鉴权：他人个人库仅拦截非管理员；系统管理员仍走 `PermissionService.can_read`，与全站可读策略一致。
- 审批流程管理：列表与预置场景隐藏 `qa_question_publish`（专家问答转公开），禁止通过管理端新建/改结构；运行时转公开逻辑不变。

## Test plan
- [x] `pytest test/qa_expert/test_related_docs_access.py`
- [x] `pytest test/approval/test_qa_publish_admin_hidden.py`
- [x] platform `approvalPage.test.tsx`
- [ ] 系统管理员可点专家问答他人个人库关联文档（门户深链需配合门户 PR #64）
- [ ] 普通用户他人个人库关联文档为 forbidden，非 not_found
- [ ] 审批流程管理页不展示「专家问答转公开」场景


Made with [Cursor](https://cursor.com)