### PR TITLE
fix(qa-expert): 转公开审批隐藏匿名身份，提问图上限改为 3 张

### DIFF
--- a/src/backend/bisheng/approval/domain/services/approval_center_service.py
+++ b/src/backend/bisheng/approval/domain/services/approval_center_service.py
@@ -89,6 +89,108 @@ class ApprovalCenterService:
             result["department_short_name"] = projection.short_name
         return result
 
+    @staticmethod
+    def _clear_applicant_department(payload: dict) -> None:
+        """匿名申请人: 审批接口不下发部门, 避免列表拼出姓名与部门。"""
+        payload["applicant_department_id"] = None
+        payload["applicant_department_name"] = None
+        payload["applicant_department_short_name"] = None
+        payload["applicant_department_display_name"] = None
+
+    @classmethod
+    def _apply_qa_publish_identity_to_payload(
+        cls,
+        payload: dict,
+        *,
+        applicant_user_id: int | None,
+        identities: dict,
+        pending_approver_ids: list[int] | None = None,
+        fallback_names: dict[int, str] | None = None,
+    ) -> None:
+        """把 qa_question_publish 响应里的真名/部门换成展示身份。"""
+        fallback_names = fallback_names or {}
+        applicant_id = int(applicant_user_id or 0)
+        applicant = identities.get(applicant_id) if applicant_id else None
+        if applicant is not None and applicant.anonymous:
+            payload["applicant_user_name"] = applicant.display_name
+            cls._clear_applicant_department(payload)
+        for task in payload.get("tasks") or []:
+            uid = int(task.get("approver_user_id") or 0)
+            view = identities.get(uid)
+            if view is not None and view.anonymous:
+                task["approver_user_name"] = view.display_name
+        for node in payload.get("flow_nodes") or []:
+            for approver in node.get("approvers") or []:
+                uid = int(approver.get("user_id") or 0)
+                view = identities.get(uid)
+                if view is not None and view.anonymous:
+                    approver["user_name"] = view.display_name
+        for log in payload.get("action_logs") or []:
+            uid = int(log.get("operator_user_id") or 0)
+            view = identities.get(uid)
+            if view is not None and view.anonymous:
+                log["operator_user_name"] = view.display_name
+        if pending_approver_ids is None:
+            return
+        names: list[str] = []
+        for uid in pending_approver_ids:
+            view = identities.get(int(uid))
+            if view is not None and view.anonymous:
+                names.append(view.display_name)
+            else:
+                fallback = fallback_names.get(int(uid))
+                if fallback:
+                    names.append(fallback)
+        if names:
+            payload["current_approver_names"] = "、".join(names)
+
+    @classmethod
+    async def _overlay_qa_publish_identities(
+        cls,
+        *,
+        instances: list,
+        payloads: list[dict],
+        extra_user_ids_by_instance: dict[int, list[int]] | None = None,
+        pending_approver_ids_by_instance: dict[int, list[int]] | None = None,
+        fallback_names: dict[int, str] | None = None,
+    ) -> None:
+        """仅处理转公开场景, 其它审批 payload 原样返回。"""
+        extra_user_ids_by_instance = extra_user_ids_by_instance or {}
+        pending_approver_ids_by_instance = pending_approver_ids_by_instance or {}
+        fallback_names = fallback_names or {}
+        qa_instances = [
+            inst
+            for inst in instances
+            if inst is not None and getattr(inst, "scenario_code", None) == _QA_QUESTION_PUBLISH_SCENARIO
+        ]
+        if not qa_instances:
+            return
+        from bisheng.qa_expert.domain.publish_approval_identity import load_identities_for_instances
+
+        merged_extra: dict[int, list[int]] = {
+            int(inst.id): list(extra_user_ids_by_instance.get(int(inst.id), [])) for inst in qa_instances
+        }
+        for inst in qa_instances:
+            merged_extra[int(inst.id)].extend(pending_approver_ids_by_instance.get(int(inst.id), []))
+        identities_by_instance = await load_identities_for_instances(
+            qa_instances,
+            extra_user_ids_by_instance=merged_extra,
+            real_name_map=fallback_names,
+        )
+        instance_by_id = {int(inst.id): inst for inst in qa_instances}
+        for payload in payloads:
+            instance_id = int(payload.get("instance_id") or 0)
+            instance = instance_by_id.get(instance_id)
+            if instance is None:
+                continue
+            cls._apply_qa_publish_identity_to_payload(
+                payload,
+                applicant_user_id=instance.applicant_user_id,
+                identities=identities_by_instance.get(instance_id, {}),
+                pending_approver_ids=pending_approver_ids_by_instance.get(instance_id),
+                fallback_names=fallback_names,
+            )
+
     @classmethod
     async def list_my_tasks(cls, *, tenant_id: int, approver_user_id: int):
         tasks = await ApprovalQueryRepository.list_tasks_by_approver(tenant_id, approver_user_id)
@@ -145,6 +247,13 @@ class ApprovalCenterService:
                     "update_time": task.update_time,
                 }
             )
+        await cls._overlay_qa_publish_identities(
+            instances=list(instance_map.values()),
+            payloads=data,
+            fallback_names={
+                int(inst.applicant_user_id): str(inst.applicant_user_name or "") for inst in instance_map.values()
+            },
+        )
         return {"data": data, "total": len(data)}
 
     @classmethod
@@ -280,8 +389,6 @@ class ApprovalCenterService:
         all_task_uids = list({t.approver_user_id for t in all_tasks})
         task_user_name_map: dict[int, str] = {}
         if all_task_uids:
-            from bisheng.user.domain.models.user import UserDao
-
             task_users = await UserDao.aget_user_by_ids(all_task_uids)
             task_user_name_map = {u.user_id: u.user_name for u in (task_users or [])}
 
@@ -300,7 +407,15 @@ class ApprovalCenterService:
         elif instance.scenario_code == "department_file_view_request":
             grant_revoked = any(log.action == "revoke_grant" for log in action_logs)
 
-        return {
+        extra_user_ids = list(all_task_uids)
+        extra_user_ids.extend(int(log.operator_user_id) for log in action_logs if log.operator_user_id)
+        extra_user_ids.extend(
+            int(approver.get("user_id") or 0) for node in flow_nodes for approver in (node.get("approvers") or [])
+        )
+        pending_approver_ids = [
+            int(t.approver_user_id) for t in all_tasks if str(t.status) == ApprovalTaskStatus.PENDING
+        ]
+        payload = {
             "task_id": task.id,
             "instance_id": task.instance_id,
             "scenario_code": instance.scenario_code,
@@ -354,6 +469,17 @@ class ApprovalCenterService:
                 for log in action_logs
             ],
         }
+        await cls._overlay_qa_publish_identities(
+            instances=[instance],
+            payloads=[payload],
+            extra_user_ids_by_instance={int(instance.id): extra_user_ids},
+            pending_approver_ids_by_instance={int(instance.id): pending_approver_ids},
+            fallback_names={
+                **task_user_name_map,
+                int(instance.applicant_user_id): str(instance.applicant_user_name or ""),
+            },
+        )
+        return payload
 
     @classmethod
     async def decide_task_api(
@@ -394,14 +520,12 @@ class ApprovalCenterService:
         cls,
         instance_ids: list[int],
         dept_ids: list[int],
-    ) -> tuple[dict[int, str], dict[int, DepartmentNameProjection]]:
-        """Returns (approver_names_map, department_map).
+    ) -> tuple[dict[int, str], dict[int, DepartmentNameProjection], dict[int, list[int]]]:
+        """Returns (approver_names_map, department_map, pending_approver_ids_by_instance).
 
         approver_names_map: {instance_id -> comma-separated approver names}
         department_map: {dept_id -> department display projection}
         """
-        from bisheng.user.domain.models.user import UserDao
-
         pending_tasks = await ApprovalQueryRepository.list_pending_tasks_for_instances(instance_ids)
         inst_approver_map: dict[int, list[int]] = {}
         for task in pending_tasks:
@@ -420,7 +544,7 @@ class ApprovalCenterService:
                 approver_names_map[inst_id] = "、".join(names)
 
         department_map = await cls._load_department_projection_map(dept_ids)
-        return approver_names_map, department_map
+        return approver_names_map, department_map, inst_approver_map
 
     @classmethod
     async def list_my_requests(cls, *, tenant_id: int, applicant_user_id: int):
@@ -430,7 +554,9 @@ class ApprovalCenterService:
 
         instance_ids = [r.id for r in rows]
         dept_ids = [r.applicant_department_id for r in rows if r.applicant_department_id]
-        approver_names_map, department_map = await cls._enrich_with_approver_and_dept(instance_ids, dept_ids)
+        approver_names_map, department_map, pending_by_instance = await cls._enrich_with_approver_and_dept(
+            instance_ids, dept_ids
+        )
 
         # Batch-check which menu_access instances have had their grant revoked
         from bisheng.approval.domain.repositories.user_menu_access_repository import UserMenuAccessRepository
@@ -467,6 +593,17 @@ class ApprovalCenterService:
                     "update_time": row.update_time,
                 }
             )
+        fallback_names: dict[int, str] = {}
+        for row in rows:
+            fallback_names[int(row.applicant_user_id)] = str(row.applicant_user_name or "")
+        extra_user_ids = {int(inst_id): list(uids) for inst_id, uids in pending_by_instance.items()}
+        await cls._overlay_qa_publish_identities(
+            instances=list(rows),
+            payloads=data,
+            extra_user_ids_by_instance=extra_user_ids,
+            pending_approver_ids_by_instance=extra_user_ids,
+            fallback_names=fallback_names,
+        )
         return {"data": data, "total": len(data)}
 
     @classmethod
@@ -497,8 +634,6 @@ class ApprovalCenterService:
         task_user_name_map: dict[int, str] = {}
         current_approver_names: str | None = None
         if all_task_uids:
-            from bisheng.user.domain.models.user import UserDao
-
             task_users = await UserDao.aget_user_by_ids(all_task_uids)
             task_user_name_map = {u.user_id: u.user_name for u in (task_users or [])}
             pending_names = [
@@ -525,7 +660,15 @@ class ApprovalCenterService:
             revoked_ids = await UserMenuAccessRepository.get_revoked_instance_ids([instance.id])
             grant_revoked = instance.id in revoked_ids
 
-        return {
+        extra_user_ids = list(all_task_uids)
+        extra_user_ids.extend(int(log.operator_user_id) for log in action_logs if log.operator_user_id)
+        extra_user_ids.extend(
+            int(approver.get("user_id") or 0) for node in flow_nodes for approver in (node.get("approvers") or [])
+        )
+        pending_approver_ids = [
+            int(task.approver_user_id) for task in tasks if str(task.status) == ApprovalTaskStatus.PENDING
+        ]
+        payload = {
             "instance_id": instance.id,
             "scenario_code": instance.scenario_code,
             "scenario_name": instance.scenario_name,
@@ -577,6 +720,17 @@ class ApprovalCenterService:
                 for log in action_logs
             ],
         }
+        await cls._overlay_qa_publish_identities(
+            instances=[instance],
+            payloads=[payload],
+            extra_user_ids_by_instance={int(instance.id): extra_user_ids},
+            pending_approver_ids_by_instance={int(instance.id): pending_approver_ids},
+            fallback_names={
+                **task_user_name_map,
+                int(instance.applicant_user_id): str(instance.applicant_user_name or ""),
+            },
+        )
+        return payload
 
     @classmethod
     async def withdraw_instance(

--- a/src/backend/bisheng/common/errcode/qa_expert.py
+++ b/src/backend/bisheng/common/errcode/qa_expert.py
@@ -74,3 +74,9 @@ class QaExpertAnswerDeleteNotAllowedError(BaseErrorCode):
     """作者删答：已采纳，或存在有效转公开申请。"""
 
     Code, Msg = 18312, "当前不可删除该回答"
+
+
+class QaExpertAssetInvalidError(BaseErrorCode):
+    """提问/回答图片或附件引用不合法（数量、格式、路径等）。"""
+
+    Code, Msg = 18313, "问答图片或附件不合法"

--- a/src/backend/bisheng/qa_expert/domain/asset_service.py
+++ b/src/backend/bisheng/qa_expert/domain/asset_service.py
@@ -26,7 +26,13 @@ ATTACHMENT_FIELDS = {
     ("question", "attachments"),
     ("answer", "attachments"),
 }
-FIELD_LIMITS = {("question", "image_url"): 1, ("answer", "images_url"): 3}
+# 与门户提问/回答页一致: 最多 3 张. 列名虽是单数 image_url, 实际按分号拼接多值.
+QUESTION_IMAGE_LIMIT = 3
+ANSWER_IMAGE_LIMIT = 3
+FIELD_LIMITS = {
+    ("question", "image_url"): QUESTION_IMAGE_LIMIT,
+    ("answer", "images_url"): ANSWER_IMAGE_LIMIT,
+}
 ALLOWED_IMAGE_FORMATS = {"JPEG", "PNG", "WEBP"}
 GENERIC_CONTENT_TYPES = {"", "application/octet-stream", "binary/octet-stream"}
 ACTIVE_CONTENT_TYPES = {"image/svg+xml", "text/html"}
@@ -84,6 +90,16 @@ def inline_response_headers(object_name: str) -> dict[str, str]:
 
 class QaAssetError(ValueError):
     """QA 资源引用不可信、不可用或不符合字段策略。"""
+
+
+def qa_asset_user_message(exc: QaAssetError) -> str:
+    """把内部校验失败转成可返回前端的中文说明。"""
+    text = str(exc)
+    if "too many QA images for question" in text:
+        return f"提问最多上传 {QUESTION_IMAGE_LIMIT} 张图片"
+    if "too many QA images for answer" in text:
+        return f"回答最多上传 {ANSWER_IMAGE_LIMIT} 张图片"
+    return "问答图片或附件不合法"
 
 
 class AssetKind(str, Enum):

--- a/src/backend/bisheng/qa_expert/domain/publish_approval_bridge.py
+++ b/src/backend/bisheng/qa_expert/domain/publish_approval_bridge.py
@@ -196,6 +196,18 @@ async def sync_after_create(request, question, initiator, approvers: list[Any]) 
         return None
 
 
+async def _initiator_display(question, initiator) -> str:
+    """发起人写入审批实例的展示名：匿名则为同题别名。"""
+    from bisheng.qa_expert.domain.publish_approval_identity import display_name_for_publish_user
+
+    identity = await display_name_for_publish_user(
+        question,
+        user_id=int(initiator.user_id),
+        real_name=str(getattr(initiator, "user_name", "") or ""),
+    )
+    return identity.display_name
+
+
 async def _sync_after_create(request, question, initiator, approvers: list[Any]) -> ApprovalInstance | None:
     pending_ids = [int(row.user_id) for row in approvers if str(row.decision) == DECISION_PENDING]
     tenant_id = int(getattr(question, "tenant_id", 1) or 1)
@@ -209,6 +221,7 @@ async def _sync_after_create(request, question, initiator, approvers: list[Any])
     }
     instance = await _get_instance(request)
     if instance is None:
+        applicant_display_name = await _initiator_display(question, initiator)
         instance = await ApprovalInstanceRepository.create_instance(
             ApprovalInstance(
                 tenant_id=tenant_id,
@@ -220,7 +233,7 @@ async def _sync_after_create(request, question, initiator, approvers: list[Any])
                 business_resource_id=str(question.id),
                 business_name=str(question.title or ""),
                 applicant_user_id=int(initiator.user_id),
-                applicant_user_name=str(getattr(initiator, "user_name", "") or ""),
+                applicant_user_name=applicant_display_name,
                 flow_version_id=contract.flow_version_id,
                 route_rule_id=contract.route_rule_id,
                 status=ApprovalInstanceStatus.PENDING,
@@ -239,7 +252,7 @@ async def _sync_after_create(request, question, initiator, approvers: list[Any])
                 instance_id=int(instance.id),
                 action="submitted",
                 operator_user_id=int(initiator.user_id),
-                operator_user_name=str(getattr(initiator, "user_name", "") or ""),
+                operator_user_name=applicant_display_name,
                 detail={"request_id": int(request.id)},
             )
         )

--- a/src/backend/bisheng/qa_expert/domain/publish_approval_identity.py
+++ b/src/backend/bisheng/qa_expert/domain/publish_approval_identity.py
@@ -1,0 +1,172 @@
+# ruff: noqa: RUF002, RUF003
+"""转公开审批展示身份：匿名者用同题别名，且不带部门。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+from bisheng.qa_expert.domain.identity import IdentityService
+from bisheng.qa_expert.domain.repositories import AnswerRepository, QuestionRepository
+
+# 审批 UI 不破匿名，与站内信同一视角。
+_ANON_VIEWER = SimpleNamespace(user_id=0, is_admin=lambda: False, role=None)
+
+
+@dataclass(frozen=True)
+class PublishApprovalIdentity:
+    """审批展示用身份；anonymous 为真时部门字段必须清空。"""
+
+    display_name: str
+    anonymous: bool
+
+
+def question_id_from_instance(instance: Any) -> int | None:
+    """从审批实例快照或业务资源 ID 取出 qa_question.id。"""
+    payload = getattr(instance, "payload_snapshot", None) or {}
+    raw = payload.get("question_id") if isinstance(payload, dict) else None
+    if raw is None:
+        raw = getattr(instance, "business_resource_id", None)
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None
+
+
+def anonymous_choice_for_user(question: Any, answers: list[Any], user_id: int) -> tuple[bool, int | None]:
+    """按提问者预选项或该用户有效回答，取出匿名与 reveal_on_public。"""
+    anonymous = False
+    reveal: int | None = None
+    if int(getattr(question, "user_id", 0) or 0) == int(user_id):
+        anonymous = bool(int(getattr(question, "asker_anonymous", 0) or 0))
+        reveal = getattr(question, "asker_reveal_on_public", None)
+    for answer in answers:
+        if int(getattr(answer, "user_id", 0) or 0) != int(user_id):
+            continue
+        if not bool(int(getattr(answer, "anonymous", 0) or 0)):
+            continue
+        anonymous = True
+        reveal = getattr(answer, "reveal_on_public", None)
+        break
+    return anonymous, reveal
+
+
+async def display_name_for_publish_user(
+    question: Any,
+    *,
+    user_id: int,
+    real_name: str,
+    answers: list[Any] | None = None,
+    identity_service: IdentityService | None = None,
+) -> PublishApprovalIdentity:
+    """单人展示名；创建审批实例时给发起人用。"""
+    if answers is None:
+        answers = await AnswerRepository().list_all_by_question_id(int(question.id))
+    mapping = await build_publish_identity_map(
+        question,
+        user_ids=[int(user_id)],
+        real_name_map={int(user_id): real_name or ""},
+        answers=answers,
+        identity_service=identity_service,
+    )
+    found = mapping.get(int(user_id))
+    if found is not None:
+        return found
+    return PublishApprovalIdentity(display_name=real_name or "", anonymous=False)
+
+
+async def build_publish_identity_map(
+    question: Any,
+    *,
+    user_ids: list[int],
+    real_name_map: dict[int, str],
+    answers: list[Any],
+    identity_service: IdentityService | None = None,
+) -> dict[int, PublishApprovalIdentity]:
+    """本题内若干用户的审批展示名。"""
+    identity_svc = identity_service or IdentityService()
+    result: dict[int, PublishApprovalIdentity] = {}
+    question_type = str(getattr(question, "question_type", "") or "")
+    tenant_id = int(getattr(question, "tenant_id", 1) or 1)
+    question_id = int(question.id)
+    for raw_uid in user_ids:
+        user_id = int(raw_uid)
+        if user_id <= 0:
+            continue
+        anonymous, reveal = anonymous_choice_for_user(question, answers, user_id)
+        real_name = real_name_map.get(user_id) or ""
+        if not anonymous:
+            result[user_id] = PublishApprovalIdentity(display_name=real_name, anonymous=False)
+            continue
+        view = await identity_svc.mask_identity(
+            _ANON_VIEWER,
+            question_id=question_id,
+            user_id=user_id,
+            real_name=real_name,
+            anonymous=True,
+            question_type=question_type,
+            reveal_on_public=reveal,
+            tenant_id=tenant_id,
+        )
+        result[user_id] = PublishApprovalIdentity(display_name=view.display_name, anonymous=True)
+    return result
+
+
+async def load_identities_for_instances(
+    instances: list[Any],
+    *,
+    extra_user_ids_by_instance: dict[int, list[int]],
+    real_name_map: dict[int, str],
+) -> dict[int, dict[int, PublishApprovalIdentity]]:
+    """按审批实例批量加载展示身份；返回 instance_id → {user_id → identity}。"""
+    question_ids: list[int] = []
+    instance_question: dict[int, int] = {}
+    user_ids_by_question: dict[int, set[int]] = {}
+    for instance in instances:
+        if instance is None:
+            continue
+        instance_id = int(getattr(instance, "id", 0) or 0)
+        question_id = question_id_from_instance(instance)
+        if instance_id <= 0 or question_id is None:
+            continue
+        instance_question[instance_id] = question_id
+        question_ids.append(question_id)
+        wanted = user_ids_by_question.setdefault(question_id, set())
+        applicant_id = int(getattr(instance, "applicant_user_id", 0) or 0)
+        if applicant_id > 0:
+            wanted.add(applicant_id)
+        for uid in extra_user_ids_by_instance.get(instance_id, []):
+            if int(uid) > 0:
+                wanted.add(int(uid))
+    unique_qids = list(dict.fromkeys(question_ids))
+    if not unique_qids:
+        return {}
+
+    questions = await QuestionRepository().get_by_ids(unique_qids)
+    question_map = {int(row.id): row for row in questions}
+    answers = await AnswerRepository().list_all_by_question_ids(unique_qids)
+    answers_by_question: dict[int, list[Any]] = {}
+    for answer in answers:
+        answers_by_question.setdefault(int(answer.question_id), []).append(answer)
+
+    identity_svc = IdentityService()
+    await identity_svc.preload_for_questions(unique_qids)
+    by_question: dict[int, dict[int, PublishApprovalIdentity]] = {}
+    for question_id, user_ids in user_ids_by_question.items():
+        question = question_map.get(question_id)
+        if question is None:
+            continue
+        by_question[question_id] = await build_publish_identity_map(
+            question,
+            user_ids=list(user_ids),
+            real_name_map=real_name_map,
+            answers=answers_by_question.get(question_id, []),
+            identity_service=identity_svc,
+        )
+
+    result: dict[int, dict[int, PublishApprovalIdentity]] = {}
+    for instance_id, question_id in instance_question.items():
+        result[instance_id] = by_question.get(question_id, {})
+    return result

--- a/src/backend/bisheng/qa_expert/domain/repositories.py
+++ b/src/backend/bisheng/qa_expert/domain/repositories.py
@@ -300,6 +300,15 @@ class QuestionRepository:
             result = await session.exec(stmt)
             return result.first()
 
+    async def get_by_ids(self, question_ids: list[int]) -> list[Question]:
+        """按问题 ID 批量读取，供转公开审批展示名一次加载。"""
+        if not question_ids:
+            return []
+        async with get_async_db_session() as session:
+            stmt = select(Question).where(Question.id.in_(question_ids))
+            result = await session.exec(stmt)
+            return list(result.all())
+
     async def get_by_id_for_update(self, question_id: int) -> Question | None:
         """读取问题行。方法返回即结束事务，行锁不会保留；真正持锁写槽位用 apply_adopt_count_locked。"""
         async with get_async_db_session() as session:
@@ -667,6 +676,15 @@ class AnswerRepository:
         """列出该题全部回答（含软删），供公开题首次采纳写资格快照。"""
         async with get_async_db_session() as session:
             stmt = select(Answer).where(Answer.question_id == question_id)
+            result = await session.exec(stmt)
+            return list(result.all())
+
+    async def list_all_by_question_ids(self, question_ids: list[int]) -> list[Answer]:
+        """批量列出若干题的全部回答（含软删），供转公开审批展示名一次加载。"""
+        if not question_ids:
+            return []
+        async with get_async_db_session() as session:
+            stmt = select(Answer).where(Answer.question_id.in_(question_ids))
             result = await session.exec(stmt)
             return list(result.all())
 

--- a/src/backend/bisheng/qa_expert/domain/schemas.py
+++ b/src/backend/bisheng/qa_expert/domain/schemas.py
@@ -175,7 +175,10 @@ class QuestionCreateRequest(BaseModel):
     asker_anonymous: bool = Field(default=False, description="提问者是否匿名（公开/定向均可）")
     asker_reveal_on_public: bool | None = Field(default=None, description="定向且匿名时：转公开后是否公开姓名")
 
-    image_url: str | None = Field(default=None, max_length=1024, schema_extra={"comment": "图片URL"})
+    image_url: str | None = Field(
+        default=None,
+        description="分号分隔的图片 URL, 最多 3 张. 请求阶段可为预签名 URL, 落库为永久 key",
+    )
     file_url: str | None = Field(default=None, max_length=1024, schema_extra={"comment": "文件URL"})
     file_name: str | None = Field(default=None, max_length=512, schema_extra={"comment": "文件名"})
 
@@ -210,7 +213,10 @@ class QuestionUpdateRequest(BaseModel):
     related_docs: str | None = Field(default=None, description="关联文档ID")
     invited_experts: str | None = Field(default=None, description="邀请专家ID，多个用分号;分割")
     experts_names: str | None = Field(default=None, description="邀请专家名称，多个用分号;分割")
-    image_url: str | None = Field(default=None, max_length=1024, description="图片URL")
+    image_url: str | None = Field(
+        default=None,
+        description="分号分隔的图片 URL, 最多 3 张. 请求阶段可为预签名 URL, 落库为永久 key",
+    )
     file_url: str | None = Field(default=None, max_length=1024, description="文件URL")
     file_name: str | None = Field(default=None, max_length=512, description="文件名")
     status: int | str | None = Field(default=None, description="状态: unsolved/solved/closed/pending")

--- a/src/backend/bisheng/qa_expert/domain/services.py
+++ b/src/backend/bisheng/qa_expert/domain/services.py
@@ -21,6 +21,7 @@ from bisheng.common.errcode.qa_expert import (
     QaExpertAdoptLimitError,
     QaExpertAnswerDeleteNotAllowedError,
     QaExpertAnswerNotAllowedError,
+    QaExpertAssetInvalidError,
     QaExpertCommentNotAllowedError,
     QaExpertContentLockedError,
     QaExpertDisabledError,
@@ -47,7 +48,13 @@ from bisheng.department.domain.services.department_display_service import (
 from bisheng.dictionary.domain.repositories.implementations.system_dictionary_repository_impl import (
     SystemDictionaryRepositoryImpl,
 )
-from bisheng.qa_expert.domain.asset_service import QaAssetService, new_owner_stable_id
+from bisheng.qa_expert.domain.asset_service import (
+    PromotionResult,
+    QaAssetError,
+    QaAssetService,
+    new_owner_stable_id,
+    qa_asset_user_message,
+)
 from bisheng.qa_expert.domain.capability import (
     CapabilityResolver,
     CapabilitySnapshot,
@@ -147,6 +154,14 @@ class AdoptLimitExceededError(QaExpertAdoptLimitError):
 MAX_ADOPTED_ANSWERS_PER_QUESTION = 3
 ELIGIBILITY_SOURCE_INVITED = "invited"
 ELIGIBILITY_SOURCE_PRE_ADOPT_ANSWER = "pre_adopt_answer"
+
+
+async def _promote_asset_fields(assets: QaAssetService, **kwargs) -> PromotionResult:
+    """转正临时资源；校验失败转成 18313，避免冒成 HTTP 500。"""
+    try:
+        return await assets.promote_fields(**kwargs)
+    except QaAssetError as exc:
+        raise QaExpertAssetInvalidError(msg=qa_asset_user_message(exc)) from exc
 
 
 class QAExpertStatsService:
@@ -550,7 +565,8 @@ class QuestionService:
         }
         promotion = None
         if any(asset_values.values()):
-            promotion = await (await self._assets()).promote_fields(
+            promotion = await _promote_asset_fields(
+                await self._assets(),
                 tenant_id=tenant_id,
                 entity_type="question",
                 owner_stable_id=new_owner_stable_id(),
@@ -1240,7 +1256,8 @@ class QuestionService:
         requested_assets = {name: update_data[name] for name in asset_fields if name in update_data}
         promotion = None
         if any(value for value in requested_assets.values()):
-            promotion = await (await self._assets()).promote_fields(
+            promotion = await _promote_asset_fields(
+                await self._assets(),
                 tenant_id=tenant_id,
                 entity_type="question",
                 owner_stable_id=str(question_id),
@@ -1546,7 +1563,8 @@ class AnswerService:
         asset_values = {"attachments": request.attachments, "images_url": request.images_url}
         promotion = None
         if any(asset_values.values()):
-            promotion = await (await self._assets()).promote_fields(
+            promotion = await _promote_asset_fields(
+                await self._assets(),
                 tenant_id=tenant_id,
                 entity_type="answer",
                 owner_stable_id=new_owner_stable_id(),
@@ -1679,7 +1697,8 @@ class AnswerService:
             requested_assets["images_url"] = images_url
         promotion = None
         if any(value for value in requested_assets.values()):
-            promotion = await (await self._assets()).promote_fields(
+            promotion = await _promote_asset_fields(
+                await self._assets(),
                 tenant_id=tenant_id,
                 entity_type="answer",
                 owner_stable_id=str(answer_id),

--- a/src/backend/test/qa_expert/conftest.py
+++ b/src/backend/test/qa_expert/conftest.py
@@ -21,6 +21,7 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from bisheng.approval.api.endpoints.approval_user import router as approval_user_router
 from bisheng.common.dependencies.user_deps import UserPayload
 from bisheng.common.errcode.base import BaseErrorCode
 from bisheng.core.context.tenant import set_current_tenant_id
@@ -87,6 +88,7 @@ def _flow_app(auth: dict):
         )
 
     app.include_router(router, prefix="/api/v1")
+    app.include_router(approval_user_router, prefix="/api/v1")
     app.dependency_overrides[UserPayload.get_login_user] = lambda: auth["user"]
     return app
 
@@ -200,6 +202,14 @@ async def flow_env(monkeypatch):
     monkeypatch.setattr(
         "bisheng.approval.domain.repositories.approval_scenario_repository.get_async_db_session",
         patched_session,
+    )
+    monkeypatch.setattr(
+        "bisheng.approval.domain.repositories.approval_query_repository.get_async_db_session",
+        patched_session,
+    )
+    monkeypatch.setattr(
+        "bisheng.approval.domain.services.approval_center_service.UserDao.aget_user_by_ids",
+        AsyncMock(return_value=[]),
     )
     monkeypatch.setattr(QuestionService, "_send_expert_invitation_inbox_notice", AsyncMock())
     monkeypatch.setattr(QuestionService, "_send_adoption_notification", AsyncMock())

--- a/src/backend/test/qa_expert/test_asset_persistence.py
+++ b/src/backend/test/qa_expert/test_asset_persistence.py
@@ -13,6 +13,7 @@ from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.orm import Session
 from starlette.datastructures import Headers
 
+from bisheng.common.errcode.qa_expert import QaExpertAssetInvalidError
 from bisheng.core.storage.base import ObjectMetadata
 from bisheng.core.storage.minio.minio_storage import MinioStorage
 from bisheng.database.models.qa_expert import Answer, Expert, Question
@@ -393,6 +394,56 @@ async def test_image_count_is_rejected_before_object_io() -> None:
     assert storage.copy_calls == []
 
 
+async def test_question_image_count_allows_three_and_rejects_four() -> None:
+    """提问图片上限与门户一致为 3. 第 4 张在对象 IO 前拒绝."""
+    storage = FakeStorage()
+    for index in range(3):
+        storage.objects[("tmp-dir", f"{index}.png")] = (_png_bytes(), "image/png")
+    service = QaAssetService(storage)  # type: ignore[arg-type]
+
+    result = await service.promote_fields(
+        tenant_id=1,
+        entity_type="question",
+        owner_stable_id="owner",
+        values={"image_url": ";".join(f"tmp-dir/{index}.png" for index in range(3))},
+    )
+    assert result.values["image_url"]
+    assert len(result.values["image_url"].split(";")) == 3
+    assert len(storage.copy_calls) == 3
+
+    with pytest.raises(QaAssetError, match="too many"):
+        await service.promote_fields(
+            tenant_id=1,
+            entity_type="question",
+            owner_stable_id="owner",
+            values={"image_url": ";".join(f"tmp-dir/{index}.png" for index in range(4))},
+        )
+
+
+def test_question_create_request_accepts_three_presigned_image_urls() -> None:
+    """创建请求不再用 1024 截断三张预签名 URL。"""
+    urls = [
+        (
+            "http://minio:9000/tmp-dir/"
+            f"{index:032x}.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256"
+            "&X-Amz-Credential=minioadmin%2F20260818%2Fus-east-1%2Fs3%2Faws4_request"
+            "&X-Amz-Date=20260818T085017Z&X-Amz-Expires=604800"
+            "&X-Amz-SignedHeaders=host"
+            "&X-Amz-Signature=" + ("ab" * 64)
+        )
+        for index in range(3)
+    ]
+    joined = ";".join(urls)
+    assert len(joined) > 1024
+    request = QuestionCreateRequest(
+        title="t",
+        description="d",
+        business_domain="营销",
+        image_url=joined,
+    )
+    assert request.image_url == joined
+
+
 async def test_temporary_cleanup_failure_does_not_fail_committed_business_result() -> None:
     storage = FakeStorage()
     storage.fail_remove = True
@@ -518,6 +569,29 @@ async def test_question_create_persists_keys_cleans_tmp_and_returns_fresh_urls(m
     assert persisted.attachments.endswith(";file-9")
     assert response.image_url.endswith("?fresh")
     asset_service.cleanup_sources.assert_awaited_once_with(promotion)
+
+
+async def test_question_create_too_many_images_raises_18313_without_insert() -> None:
+    """超过 3 张提问图返回 18313, 不写 qa_question."""
+    service = QuestionService(asset_service=QaAssetService(FakeStorage()))  # type: ignore[arg-type]
+    service.repository = AsyncMock()
+
+    with pytest.raises(QaExpertAssetInvalidError) as exc_info:
+        await service.create_question(
+            8,
+            QuestionCreateRequest(
+                title="question",
+                description="description",
+                business_domain="domain",
+                image_url=";".join(f"tmp-dir/{index}.png" for index in range(4)),
+            ),
+            "user",
+            tenant_id=1,
+        )
+
+    assert exc_info.value.Code == 18313
+    assert "提问最多上传 3 张图片" in exc_info.value.message
+    service.repository.create.assert_not_awaited()
 
 
 async def test_question_update_promotes_only_explicit_asset_fields_and_resolves_copy() -> None:

--- a/src/backend/test/qa_expert/test_data_flow.py
+++ b/src/backend/test/qa_expert/test_data_flow.py
@@ -66,11 +66,11 @@ async def _create_answer(env, question_id: int, content: str) -> int:
     return int(max(rows, key=lambda r: r.id).id)
 
 
-async def _create_answer_anonymous(env, question_id: int, content: str) -> int:
-    resp = await env.client.post(
-        f"{PREFIX}/answers",
-        json={"question_id": question_id, "content": content, "anonymous": True},
-    )
+async def _create_answer_anonymous(env, question_id: int, content: str, *, reveal_on_public: bool | None = None) -> int:
+    payload: dict = {"question_id": question_id, "content": content, "anonymous": True}
+    if reveal_on_public is not None:
+        payload["reveal_on_public"] = reveal_on_public
+    resp = await env.client.post(f"{PREFIX}/answers", json=payload)
     body = _ok(resp)
     assert body.get("status_code") == 200, body
     data = body.get("data") or {}
@@ -1079,6 +1079,107 @@ async def test_df21_publish_todo_and_late_answerer_joins(flow_env, monkeypatch):
     assert env.uid(202) in _receiver_ids(added_msgs[-1]["receiver"])
     still_tasks = await env.reload_all(ApprovalTask, instance_id=instance.id)
     assert {int(row.approver_user_id) for row in still_tasks if row.status == "pending"} == pending_after
+
+
+async def test_df22_publish_approval_masks_anonymous_names_and_department(flow_env):
+    """定向转公开：匿名提问者/专家在审批实例与详情接口不露真名和部门。"""
+    from bisheng.approval.domain.models.approval_instance import ApprovalActionLog, ApprovalInstance, ApprovalTask
+
+    env = flow_env
+    invited = await env.seed_expert(user_id=201, name="专家甲")
+    asker_real_name = env.asker.user_name
+    expert_real_name = "专家甲"
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df22转公开匿名",
+            "description": "定向匿名",
+            "business_domain": "steel",
+            "question_type": "directed",
+            "invited_expert_ids": [invited.id],
+            "asker_anonymous": True,
+            "asker_reveal_on_public": False,
+        },
+    )
+    env.as_user(env.user(201, name=expert_real_name))
+    aid = await _create_answer_anonymous(env, qid, "匿名有效答", reveal_on_public=False)
+    env.as_user(env.asker)
+    _ok(await env.client.post(f"{PREFIX}/questions/{qid}/adopt", json={"answer_id": aid}))
+    created = _ok(await env.client.post(f"{PREFIX}/questions/{qid}/publish-requests", json={"duration_days": 3}))
+    assert created["status_code"] == 200
+
+    instance = await env.reload_row(
+        ApprovalInstance,
+        business_resource_id=str(qid),
+        scenario_code="qa_question_publish",
+    )
+    assert instance is not None
+    assert int(instance.applicant_user_id) == int(env.asker.user_id)
+    assert str(instance.applicant_user_name).startswith("匿名同事")
+    assert instance.applicant_user_name != asker_real_name
+    assert instance.applicant_department_id is None
+
+    logs = await env.reload_all(ApprovalActionLog, instance_id=instance.id)
+    submitted = next((row for row in logs if row.action == "submitted"), None)
+    assert submitted is not None
+    assert str(submitted.operator_user_name).startswith("匿名同事")
+    assert submitted.operator_user_name != asker_real_name
+    assert int(submitted.operator_user_id) == int(env.asker.user_id)
+
+    aliases = await env.reload_all(AnonymousAlias, question_id=qid)
+    assert aliases
+    alias_labels = {str(row.alias_label) for row in aliases}
+
+    tasks = await env.reload_all(ApprovalTask, instance_id=instance.id)
+    expert_task = next((row for row in tasks if int(row.approver_user_id) == env.uid(201)), None)
+    assert expert_task is not None
+
+    env.as_user(env.user(201, name=expert_real_name))
+    listed = _ok(await env.client.get("/api/v1/approval/my-tasks"))
+    assert listed["status_code"] == 200
+    task_rows = (listed.get("data") or {}).get("data") or []
+    hit = next((item for item in task_rows if int(item.get("task_id") or 0) == int(expert_task.id)), None)
+    assert hit is not None
+    assert str(hit.get("applicant_user_name") or "").startswith("匿名同事")
+    assert hit.get("applicant_user_name") != asker_real_name
+    assert hit.get("applicant_department_id") is None
+    assert hit.get("applicant_department_name") is None
+    assert hit.get("applicant_department_display_name") is None
+
+    detail = _ok(await env.client.get(f"/api/v1/approval/my-tasks/{expert_task.id}"))
+    assert detail["status_code"] == 200
+    data = detail.get("data") or {}
+    assert str(data.get("applicant_user_name") or "").startswith("匿名同事")
+    assert data.get("applicant_user_name") != asker_real_name
+    assert data.get("applicant_department_id") is None
+    assert data.get("applicant_department_name") is None
+    assert data.get("applicant_department_display_name") is None
+    task_payload = next(
+        (item for item in (data.get("tasks") or []) if int(item.get("approver_user_id") or 0) == env.uid(201)),
+        None,
+    )
+    assert task_payload is not None
+    assert str(task_payload.get("approver_user_name") or "").startswith("匿名同事")
+    assert task_payload.get("approver_user_name") != expert_real_name
+    assert int(task_payload.get("approver_user_id")) == env.uid(201)
+    submitted_log = next((item for item in (data.get("action_logs") or []) if item.get("action") == "submitted"), None)
+    assert submitted_log is not None
+    assert str(submitted_log.get("operator_user_name") or "").startswith("匿名同事")
+    assert int(submitted_log.get("operator_user_id")) == int(env.asker.user_id)
+
+    again = _ok(await env.client.get(f"/api/v1/approval/my-tasks/{expert_task.id}"))
+    again_data = again.get("data") or {}
+    assert again_data.get("applicant_user_name") == data.get("applicant_user_name")
+    again_task = next(
+        (item for item in (again_data.get("tasks") or []) if int(item.get("approver_user_id") or 0) == env.uid(201)),
+        None,
+    )
+    assert again_task is not None
+    assert again_task.get("approver_user_name") == task_payload.get("approver_user_name")
+    stored = await env.reload_row(ApprovalInstance, id=instance.id)
+    assert stored.applicant_user_name == instance.applicant_user_name
+    assert stored.applicant_user_name in alias_labels or str(stored.applicant_user_name).startswith("匿名同事")
 
 
 async def test_df13_reject_keeps_viewer_decision_on_latest(flow_env):

--- a/src/backend/test/qa_expert/test_data_flow.py
+++ b/src/backend/test/qa_expert/test_data_flow.py
@@ -1502,3 +1502,38 @@ async def test_df25_admin_sees_anonymous_answer_expert_meta(flow_env):
     answer_row = await env.reload_row(Answer, id=aid)
     assert int(answer_row.anonymous) == 1
     assert answer_row.expert_name == expert.expert_name
+
+
+async def test_df_question_too_many_images_rejected_no_dirty_row(flow_env, monkeypatch):
+    """提问超过 3 张图返回 18313, qa_question 无脏行."""
+    env = flow_env
+    stub_storage = SimpleNamespace(
+        tmp_bucket="tmp-dir",
+        bucket="bisheng",
+        minio_config=SimpleNamespace(endpoint="minio:9000", sharepoint="minio:9000"),
+    )
+    monkeypatch.setattr(
+        "bisheng.qa_expert.domain.services.get_minio_storage",
+        AsyncMock(return_value=stub_storage),
+    )
+    title = env.t("df图片超限")
+    before = await env.reload_row(Question, title=title)
+    assert before is None
+    env.as_user(env.asker)
+    payload = {
+        "title": title,
+        "description": "四张图应被拒绝",
+        "business_domain": "营销",
+        "question_type": "public",
+        "image_url": ";".join(f"tmp-dir/{index}.png" for index in range(4)),
+    }
+    resp = await env.client.post(f"{PREFIX}/questions", json=payload)
+    body = _ok(resp)
+    assert body["status_code"] == 18313
+    assert "提问最多上传 3 张图片" in str(body.get("status_message") or "")
+    after = await env.reload_row(Question, title=title)
+    assert after is None
+    again = await env.client.post(f"{PREFIX}/questions", json=payload)
+    again_body = _ok(again)
+    assert again_body["status_code"] == 18313
+    assert await env.reload_row(Question, title=title) is None

--- a/src/backend/test/qa_expert/test_publish_approval_identity.py
+++ b/src/backend/test/qa_expert/test_publish_approval_identity.py
@@ -1,0 +1,37 @@
+# ruff: noqa: RUF002
+"""转公开审批展示身份：匿名标志与实例 question_id 解析。"""
+
+from types import SimpleNamespace
+
+from bisheng.qa_expert.domain.publish_approval_identity import (
+    anonymous_choice_for_user,
+    question_id_from_instance,
+)
+
+
+def test_question_id_prefers_payload_snapshot():
+    instance = SimpleNamespace(payload_snapshot={"question_id": 42}, business_resource_id="99")
+    assert question_id_from_instance(instance) == 42
+
+
+def test_question_id_falls_back_to_business_resource_id():
+    instance = SimpleNamespace(payload_snapshot={}, business_resource_id="18")
+    assert question_id_from_instance(instance) == 18
+
+
+def test_asker_anonymous_choice():
+    question = SimpleNamespace(user_id=7, asker_anonymous=1, asker_reveal_on_public=0)
+    anonymous, reveal = anonymous_choice_for_user(question, [], 7)
+    assert anonymous is True
+    assert int(reveal) == 0
+
+
+def test_answerer_anonymous_choice_overrides_non_asker():
+    question = SimpleNamespace(user_id=7, asker_anonymous=0, asker_reveal_on_public=None)
+    answers = [SimpleNamespace(user_id=9, anonymous=1, reveal_on_public=0)]
+    anonymous, reveal = anonymous_choice_for_user(question, answers, 9)
+    assert anonymous is True
+    assert int(reveal) == 0
+    named, named_reveal = anonymous_choice_for_user(question, answers, 8)
+    assert named is False
+    assert named_reveal is None


### PR DESCRIPTION
## Summary
- 转公开审批：匿名提问者与专家在审批中心展示同题别名，不暴露真名和部门；`user_id` 仍保留真人以便鉴权。
- 提问图片上限与门户对齐为 3 张（原先按单数 `image_url` 限制为 1）；超过 3 张返回业务码 18313，不再冒成 HTTP 500，且不写入 `qa_question`。

## Test plan
- [x] `pytest test/qa_expert/test_publish_approval_identity.py`
- [x] `pytest test/qa_expert/test_asset_persistence.py`（含 3 张通过 / 4 张拒绝）
- [x] `pytest test/qa_expert/test_data_flow.py::test_df_question_too_many_images_rejected_no_dirty_row`
- [ ] 匿名提问转公开：审批待办/日志不显示提问者真名和部门
- [ ] 门户提问上传 2–3 张图可创建成功
- [ ] 第 4 张图被拒绝，提示「提问最多上传 3 张图片」


Made with [Cursor](https://cursor.com)