### PR TITLE
fix(qa-expert): 问答时间改为东八墙钟并平移存量 UTC

### DIFF
--- a/src/backend/bisheng/common/utils/beijing_time.py
+++ b/src/backend/bisheng/common/utils/beijing_time.py
@@ -1,0 +1,89 @@
+# ruff: noqa: RUF002
+"""东八区业务墙钟：专家问答 DATETIME 与库内 naive 存储对齐。
+
+不依赖进程 TZ / MySQL time_zone。naive 表示 Asia/Shanghai 墙钟，不是 UTC。
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from zoneinfo import ZoneInfo
+
+BEIJING_TZ = ZoneInfo("Asia/Shanghai")
+BEIJING_UTC_OFFSET = timedelta(hours=8)
+_OFFSET_MARKERS = ("+", "-")
+
+
+def now_beijing() -> datetime:
+    """当前东八区墙钟（naive），写入 DATETIME 用。"""
+    return datetime.now(BEIJING_TZ).replace(tzinfo=None)
+
+
+def to_beijing_iso(value: datetime | None) -> str | None:
+    """序列化成带 +08:00 的 ISO 串；naive 按东八墙钟解释。"""
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        aware = value.replace(tzinfo=BEIJING_TZ)
+    else:
+        aware = value.astimezone(BEIJING_TZ)
+    return aware.isoformat(timespec="seconds")
+
+
+def beijing_epoch_seconds(value: datetime) -> int:
+    """naive 东八墙钟转 epoch；避免容器 TZ=UTC 时 timestamp() 解错。"""
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=BEIJING_TZ)
+    return int(value.timestamp())
+
+
+def dump_qa_datetimes(value: Any) -> Any:
+    """递归把 datetime 转成 +08:00 ISO；其余结构原样。"""
+    if isinstance(value, datetime):
+        return to_beijing_iso(value)
+    if isinstance(value, dict):
+        return {key: dump_qa_datetimes(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [dump_qa_datetimes(item) for item in value]
+    return value
+
+
+def _has_explicit_offset(text: str) -> bool:
+    stripped = text.strip()
+    if stripped.endswith("Z") or stripped.endswith("z"):
+        return True
+    if "T" in stripped:
+        tail = stripped.split("T", 1)[1]
+        return any(mark in tail for mark in _OFFSET_MARKERS)
+    return False
+
+
+def shift_stored_iso(value: str, *, hours: int = 8) -> str:
+    """把历史 UTC naive / Z 串改成东八墙钟并带 +08:00。
+
+    已是 +08:00 的串不平移，避免重复迁移。
+    """
+    if not isinstance(value, str):
+        return value
+    stripped = value.strip()
+    if not stripped:
+        return value
+    try:
+        if stripped.endswith("Z") or stripped.endswith("z"):
+            parsed = datetime.fromisoformat(stripped[:-1]).replace(tzinfo=timezone.utc)
+        elif _has_explicit_offset(stripped):
+            parsed = datetime.fromisoformat(stripped)
+        else:
+            parsed = datetime.fromisoformat(stripped.replace(" ", "T"))
+    except ValueError:
+        return value
+    if parsed.tzinfo is not None:
+        if parsed.utcoffset() == BEIJING_UTC_OFFSET and hours < 0:
+            utc_naive = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+            return utc_naive.isoformat(timespec="seconds")
+        return to_beijing_iso(parsed) or stripped
+    shifted = parsed + timedelta(hours=hours)
+    if hours < 0:
+        return shifted.isoformat(timespec="seconds")
+    return to_beijing_iso(shifted) or stripped

--- a/src/backend/bisheng/common/utils/beijing_time.py
+++ b/src/backend/bisheng/common/utils/beijing_time.py
@@ -6,13 +6,11 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
 from typing import Any
 from zoneinfo import ZoneInfo
 
 BEIJING_TZ = ZoneInfo("Asia/Shanghai")
-BEIJING_UTC_OFFSET = timedelta(hours=8)
-_OFFSET_MARKERS = ("+", "-")
 
 
 def now_beijing() -> datetime:
@@ -47,43 +45,3 @@ def dump_qa_datetimes(value: Any) -> Any:
     if isinstance(value, (list, tuple)):
         return [dump_qa_datetimes(item) for item in value]
     return value
-
-
-def _has_explicit_offset(text: str) -> bool:
-    stripped = text.strip()
-    if stripped.endswith("Z") or stripped.endswith("z"):
-        return True
-    if "T" in stripped:
-        tail = stripped.split("T", 1)[1]
-        return any(mark in tail for mark in _OFFSET_MARKERS)
-    return False
-
-
-def shift_stored_iso(value: str, *, hours: int = 8) -> str:
-    """把历史 UTC naive / Z 串改成东八墙钟并带 +08:00。
-
-    已是 +08:00 的串不平移，避免重复迁移。
-    """
-    if not isinstance(value, str):
-        return value
-    stripped = value.strip()
-    if not stripped:
-        return value
-    try:
-        if stripped.endswith("Z") or stripped.endswith("z"):
-            parsed = datetime.fromisoformat(stripped[:-1]).replace(tzinfo=timezone.utc)
-        elif _has_explicit_offset(stripped):
-            parsed = datetime.fromisoformat(stripped)
-        else:
-            parsed = datetime.fromisoformat(stripped.replace(" ", "T"))
-    except ValueError:
-        return value
-    if parsed.tzinfo is not None:
-        if parsed.utcoffset() == BEIJING_UTC_OFFSET and hours < 0:
-            utc_naive = parsed.astimezone(timezone.utc).replace(tzinfo=None)
-            return utc_naive.isoformat(timespec="seconds")
-        return to_beijing_iso(parsed) or stripped
-    shifted = parsed + timedelta(hours=hours)
-    if hours < 0:
-        return shifted.isoformat(timespec="seconds")
-    return to_beijing_iso(shifted) or stripped

--- a/src/backend/bisheng/core/database/alembic/versions/v2_6_0_f091_qa_expert_beijing_datetime.py
+++ b/src/backend/bisheng/core/database/alembic/versions/v2_6_0_f091_qa_expert_beijing_datetime.py
@@ -1,154 +1,28 @@
-# ruff: noqa: RUF002, RUF003
-"""专家问答 DATETIME：存量 UTC 墙钟平移为东八区，并去掉 qa_publish_request.updated_at 的 ON UPDATE。
+# ruff: noqa: RUF002
+"""去掉 qa_publish_request.updated_at 的 ON UPDATE CURRENT_TIMESTAMP。
 
 Revision ID: f091_qa_expert_beijing_datetime
 Revises: f090_merge_f083_f087_f089
 Create Date: 2026-08-18
 
-历史行按 naive=UTC 一次性 +8 小时。禁止重复 upgrade。应用必须与本 migration 同窗口发布，
-否则 expire_at 与 now() 会短暂混钟。
+应用侧改为东八墙钟写入后，MySQL ON UPDATE CURRENT_TIMESTAMP 会按会话/服务器时区刷新，
+与 Python now_beijing() 混钟。本 revision 只改列定义，不平移存量 DATETIME。
+生产未启用专家问答；测试环境旧行若仍是 UTC naive，展示可能偏 8 小时，按产品确认不回填。
 """
 
 from __future__ import annotations
 
-import json
 from collections.abc import Sequence
 
 import sqlalchemy as sa
 from alembic import op
 
-from bisheng.common.utils.beijing_time import shift_stored_iso
 from bisheng.core.database.dialect_helpers import column_exists, table_exists
 
 revision: str = "f091_qa_expert_beijing_datetime"
 down_revision: str | Sequence[str] | None = "f090_merge_f083_f087_f089"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
-
-QA_PUBLISH_SCENARIO = "qa_question_publish"
-
-QA_DATETIME_COLUMNS: dict[str, tuple[str, ...]] = {
-    "qa_expert": ("created_at", "updated_at"),
-    "qa_question": ("created_at", "updated_at", "resolved_at"),
-    "qa_answer": ("created_at", "updated_at"),
-    "qa_comment": ("created_at",),
-    "qa_question_invite": ("created_at",),
-    "qa_answer_adopt": ("created_at",),
-    "qa_anonymous_alias": ("created_at",),
-    "qa_answer_eligibility": ("created_at",),
-    "qa_publish_request": ("expire_at", "created_at", "updated_at"),
-    "qa_publish_approver": ("decided_at", "created_at"),
-    "qa_question_vote": ("created_at",),
-    "qa_answer_vote": ("created_at",),
-    "qa_comment_vote": ("created_at",),
-    "qa_notification": ("created_at",),
-}
-
-
-def add_hours_sql(column: str, dialect: str, hours: int) -> str:
-    """生成把 DATETIME 列平移 hours 小时的 SQL 片段。"""
-    signed = int(hours)
-    if dialect in ("mysql", "mariadb"):
-        if signed >= 0:
-            return f"DATE_ADD(`{column}`, INTERVAL {signed} HOUR)"
-        return f"DATE_SUB(`{column}`, INTERVAL {abs(signed)} HOUR)"
-    if dialect == "sqlite":
-        sign = "+" if signed >= 0 else "-"
-        return f"datetime({column}, '{sign}{abs(signed)} hours')"
-    # 达梦 / Oracle 兼容：按天的小数相加
-    return f"{column} + ({signed}/24.0)"
-
-
-def shift_table_datetimes(bind, table: str, columns: tuple[str, ...], hours: int) -> None:
-    """把表内已有 DATETIME 列平移；缺表/缺列跳过。"""
-    if not table_exists(bind, table):
-        return
-    dialect = bind.dialect.name
-    assignments = []
-    for column in columns:
-        if not column_exists(bind, table, column):
-            continue
-        assignments.append(f"{column} = {add_hours_sql(column, dialect, hours)}")
-    if not assignments:
-        return
-    bind.execute(sa.text(f"UPDATE {table} SET {', '.join(assignments)}"))
-
-
-def _parse_json(value):
-    if value is None:
-        return None
-    if isinstance(value, (dict, list)):
-        return value
-    if isinstance(value, (bytes, bytearray)):
-        value = value.decode("utf-8", errors="replace")
-    if isinstance(value, str):
-        text = value.strip()
-        if not text:
-            return None
-        try:
-            return json.loads(text)
-        except json.JSONDecodeError:
-            return None
-    return None
-
-
-def _shift_expire_keys(value, hours: int):
-    if isinstance(value, dict):
-        out = {}
-        for key, item in value.items():
-            if key == "expire_at" and isinstance(item, str):
-                out[key] = shift_stored_iso(item, hours=hours)
-            else:
-                out[key] = _shift_expire_keys(item, hours)
-        return out
-    if isinstance(value, list):
-        return [_shift_expire_keys(item, hours) for item in value]
-    return value
-
-
-def shift_publish_approval_snapshots(bind, hours: int) -> None:
-    """转公开审批快照里的 expire_at 与 qa_publish_request 同步平移。"""
-    if not table_exists(bind, "approval_instance"):
-        return
-    if not column_exists(bind, "approval_instance", "payload_snapshot"):
-        return
-    rows = bind.execute(
-        sa.text(
-            """
-            SELECT id, payload_snapshot, detail_snapshot
-            FROM approval_instance
-            WHERE scenario_code = :code
-            """
-        ),
-        {"code": QA_PUBLISH_SCENARIO},
-    ).fetchall()
-    for row in rows:
-        payload = _shift_expire_keys(_parse_json(row[1]), hours)
-        detail = _shift_expire_keys(_parse_json(row[2]), hours)
-        if payload is None and detail is None:
-            continue
-        dialect = bind.dialect.name
-        if dialect in ("mysql", "mariadb"):
-            sql = """
-                UPDATE approval_instance
-                SET payload_snapshot = CAST(:payload AS JSON),
-                    detail_snapshot = CAST(:detail AS JSON)
-                WHERE id = :id
-            """
-        else:
-            sql = """
-                UPDATE approval_instance
-                SET payload_snapshot = :payload, detail_snapshot = :detail
-                WHERE id = :id
-            """
-        bind.execute(
-            sa.text(sql),
-            {
-                "id": row[0],
-                "payload": json.dumps(payload, ensure_ascii=False) if payload is not None else None,
-                "detail": json.dumps(detail, ensure_ascii=False) if detail is not None else None,
-            },
-        )
 
 
 def drop_publish_updated_at_on_update(bind) -> None:
@@ -187,18 +61,10 @@ def restore_publish_updated_at_on_update(bind) -> None:
 
 
 def upgrade() -> None:
-    """存量 +8 小时，并去掉转公开 updated_at 的库侧自动刷新。"""
-    bind = op.get_bind()
-    for table, columns in QA_DATETIME_COLUMNS.items():
-        shift_table_datetimes(bind, table, columns, hours=8)
-    shift_publish_approval_snapshots(bind, hours=8)
-    drop_publish_updated_at_on_update(bind)
+    """只改转公开 updated_at 列定义，不 UPDATE 历史行。"""
+    drop_publish_updated_at_on_update(op.get_bind())
 
 
 def downgrade() -> None:
-    """反向 −8 小时并恢复 ON UPDATE（会回到 UTC naive）。"""
-    bind = op.get_bind()
-    restore_publish_updated_at_on_update(bind)
-    shift_publish_approval_snapshots(bind, hours=-8)
-    for table, columns in QA_DATETIME_COLUMNS.items():
-        shift_table_datetimes(bind, table, columns, hours=-8)
+    """恢复 ON UPDATE。"""
+    restore_publish_updated_at_on_update(op.get_bind())

--- a/src/backend/bisheng/core/database/alembic/versions/v2_6_0_f091_qa_expert_beijing_datetime.py
+++ b/src/backend/bisheng/core/database/alembic/versions/v2_6_0_f091_qa_expert_beijing_datetime.py
@@ -1,0 +1,204 @@
+# ruff: noqa: RUF002, RUF003
+"""专家问答 DATETIME：存量 UTC 墙钟平移为东八区，并去掉 qa_publish_request.updated_at 的 ON UPDATE。
+
+Revision ID: f091_qa_expert_beijing_datetime
+Revises: f090_merge_f083_f087_f089
+Create Date: 2026-08-18
+
+历史行按 naive=UTC 一次性 +8 小时。禁止重复 upgrade。应用必须与本 migration 同窗口发布，
+否则 expire_at 与 now() 会短暂混钟。
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+from bisheng.common.utils.beijing_time import shift_stored_iso
+from bisheng.core.database.dialect_helpers import column_exists, table_exists
+
+revision: str = "f091_qa_expert_beijing_datetime"
+down_revision: str | Sequence[str] | None = "f090_merge_f083_f087_f089"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+QA_PUBLISH_SCENARIO = "qa_question_publish"
+
+QA_DATETIME_COLUMNS: dict[str, tuple[str, ...]] = {
+    "qa_expert": ("created_at", "updated_at"),
+    "qa_question": ("created_at", "updated_at", "resolved_at"),
+    "qa_answer": ("created_at", "updated_at"),
+    "qa_comment": ("created_at",),
+    "qa_question_invite": ("created_at",),
+    "qa_answer_adopt": ("created_at",),
+    "qa_anonymous_alias": ("created_at",),
+    "qa_answer_eligibility": ("created_at",),
+    "qa_publish_request": ("expire_at", "created_at", "updated_at"),
+    "qa_publish_approver": ("decided_at", "created_at"),
+    "qa_question_vote": ("created_at",),
+    "qa_answer_vote": ("created_at",),
+    "qa_comment_vote": ("created_at",),
+    "qa_notification": ("created_at",),
+}
+
+
+def add_hours_sql(column: str, dialect: str, hours: int) -> str:
+    """生成把 DATETIME 列平移 hours 小时的 SQL 片段。"""
+    signed = int(hours)
+    if dialect in ("mysql", "mariadb"):
+        if signed >= 0:
+            return f"DATE_ADD(`{column}`, INTERVAL {signed} HOUR)"
+        return f"DATE_SUB(`{column}`, INTERVAL {abs(signed)} HOUR)"
+    if dialect == "sqlite":
+        sign = "+" if signed >= 0 else "-"
+        return f"datetime({column}, '{sign}{abs(signed)} hours')"
+    # 达梦 / Oracle 兼容：按天的小数相加
+    return f"{column} + ({signed}/24.0)"
+
+
+def shift_table_datetimes(bind, table: str, columns: tuple[str, ...], hours: int) -> None:
+    """把表内已有 DATETIME 列平移；缺表/缺列跳过。"""
+    if not table_exists(bind, table):
+        return
+    dialect = bind.dialect.name
+    assignments = []
+    for column in columns:
+        if not column_exists(bind, table, column):
+            continue
+        assignments.append(f"{column} = {add_hours_sql(column, dialect, hours)}")
+    if not assignments:
+        return
+    bind.execute(sa.text(f"UPDATE {table} SET {', '.join(assignments)}"))
+
+
+def _parse_json(value):
+    if value is None:
+        return None
+    if isinstance(value, (dict, list)):
+        return value
+    if isinstance(value, (bytes, bytearray)):
+        value = value.decode("utf-8", errors="replace")
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            return None
+    return None
+
+
+def _shift_expire_keys(value, hours: int):
+    if isinstance(value, dict):
+        out = {}
+        for key, item in value.items():
+            if key == "expire_at" and isinstance(item, str):
+                out[key] = shift_stored_iso(item, hours=hours)
+            else:
+                out[key] = _shift_expire_keys(item, hours)
+        return out
+    if isinstance(value, list):
+        return [_shift_expire_keys(item, hours) for item in value]
+    return value
+
+
+def shift_publish_approval_snapshots(bind, hours: int) -> None:
+    """转公开审批快照里的 expire_at 与 qa_publish_request 同步平移。"""
+    if not table_exists(bind, "approval_instance"):
+        return
+    if not column_exists(bind, "approval_instance", "payload_snapshot"):
+        return
+    rows = bind.execute(
+        sa.text(
+            """
+            SELECT id, payload_snapshot, detail_snapshot
+            FROM approval_instance
+            WHERE scenario_code = :code
+            """
+        ),
+        {"code": QA_PUBLISH_SCENARIO},
+    ).fetchall()
+    for row in rows:
+        payload = _shift_expire_keys(_parse_json(row[1]), hours)
+        detail = _shift_expire_keys(_parse_json(row[2]), hours)
+        if payload is None and detail is None:
+            continue
+        dialect = bind.dialect.name
+        if dialect in ("mysql", "mariadb"):
+            sql = """
+                UPDATE approval_instance
+                SET payload_snapshot = CAST(:payload AS JSON),
+                    detail_snapshot = CAST(:detail AS JSON)
+                WHERE id = :id
+            """
+        else:
+            sql = """
+                UPDATE approval_instance
+                SET payload_snapshot = :payload, detail_snapshot = :detail
+                WHERE id = :id
+            """
+        bind.execute(
+            sa.text(sql),
+            {
+                "id": row[0],
+                "payload": json.dumps(payload, ensure_ascii=False) if payload is not None else None,
+                "detail": json.dumps(detail, ensure_ascii=False) if detail is not None else None,
+            },
+        )
+
+
+def drop_publish_updated_at_on_update(bind) -> None:
+    """去掉 ON UPDATE CURRENT_TIMESTAMP，避免与 Python 东八写入再混钟。"""
+    if not table_exists(bind, "qa_publish_request"):
+        return
+    if not column_exists(bind, "qa_publish_request", "updated_at"):
+        return
+    dialect = bind.dialect.name
+    if dialect in ("mysql", "mariadb"):
+        bind.execute(
+            sa.text(
+                "ALTER TABLE qa_publish_request "
+                "MODIFY COLUMN updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP "
+                "COMMENT '更新时间'"
+            )
+        )
+
+
+def restore_publish_updated_at_on_update(bind) -> None:
+    """downgrade：恢复 MySQL ON UPDATE。"""
+    if not table_exists(bind, "qa_publish_request"):
+        return
+    if not column_exists(bind, "qa_publish_request", "updated_at"):
+        return
+    dialect = bind.dialect.name
+    if dialect in ("mysql", "mariadb"):
+        bind.execute(
+            sa.text(
+                "ALTER TABLE qa_publish_request "
+                "MODIFY COLUMN updated_at DATETIME NOT NULL "
+                "DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP "
+                "COMMENT '更新时间'"
+            )
+        )
+
+
+def upgrade() -> None:
+    """存量 +8 小时，并去掉转公开 updated_at 的库侧自动刷新。"""
+    bind = op.get_bind()
+    for table, columns in QA_DATETIME_COLUMNS.items():
+        shift_table_datetimes(bind, table, columns, hours=8)
+    shift_publish_approval_snapshots(bind, hours=8)
+    drop_publish_updated_at_on_update(bind)
+
+
+def downgrade() -> None:
+    """反向 −8 小时并恢复 ON UPDATE（会回到 UTC naive）。"""
+    bind = op.get_bind()
+    restore_publish_updated_at_on_update(bind)
+    shift_publish_approval_snapshots(bind, hours=-8)
+    for table, columns in QA_DATETIME_COLUMNS.items():
+        shift_table_datetimes(bind, table, columns, hours=-8)

--- a/src/backend/bisheng/database/models/qa_expert.py
+++ b/src/backend/bisheng/database/models/qa_expert.py
@@ -7,10 +7,11 @@ Expert QA Database Models - SQLModel ORM
 
 from datetime import datetime
 
-from sqlalchemy import DateTime, UniqueConstraint
+from sqlalchemy import UniqueConstraint
 from sqlmodel import Column, Field, SQLModel
 
-from bisheng.core.database.dialect_helpers import UPDATE_TIME_SERVER_DEFAULT, LargeText
+from bisheng.common.utils.beijing_time import now_beijing
+from bisheng.core.database.dialect_helpers import LargeText
 
 # ==================== 专家表 ====================
 
@@ -39,8 +40,8 @@ class Expert(SQLModel, table=True):
     status: int = Field(default=1, description="专家状态：1有效 0停用")
 
     # 时间戳
-    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=now_beijing, index=True)
+    updated_at: datetime = Field(default_factory=now_beijing)
 
 
 # ==================== 问题表 ====================
@@ -85,8 +86,8 @@ class Question(SQLModel, table=True):
     view_count: int = Field(default=0)
     comment_count: int = Field(default=0)
     # 时间戳
-    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=now_beijing, index=True)
+    updated_at: datetime = Field(default_factory=now_beijing)
     created_by: str | None = Field(default=None, description="创建人")
 
 
@@ -121,8 +122,8 @@ class Answer(SQLModel, table=True):
     comment_count: int = Field(default=0)
     adopted: bool | None = Field(default=False, index=True)  # 是否被采纳
     # 时间戳
-    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=now_beijing, index=True)
+    updated_at: datetime = Field(default_factory=now_beijing)
 
 
 # ==================== 评论/追问表 ====================
@@ -146,7 +147,7 @@ class Comment(SQLModel, table=True):
     # 统计字段
     vote_count: int = Field(default=0)
     # 时间戳
-    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    created_at: datetime = Field(default_factory=now_beijing, index=True)
 
 
 # ==================== F083 正规化表（邀请 / 采纳 / 匿名 / 资格 / 转公开） ====================
@@ -172,7 +173,7 @@ class QuestionInvite(SQLModel, table=True):
     question_id: int = Field(index=True, description="问题ID")
     expert_id: int = Field(description="专家档案ID（qa_expert.id）")
     user_id: int = Field(index=True, description="专家对应用户ID")
-    created_at: datetime = Field(default_factory=datetime.utcnow, description="创建时间")
+    created_at: datetime = Field(default_factory=now_beijing, description="创建时间")
 
 
 class AnswerAdopt(SQLModel, table=True):
@@ -190,7 +191,7 @@ class AnswerAdopt(SQLModel, table=True):
     answer_id: int = Field(description="回答ID")
     expert_user_id: int = Field(description="被采纳回答者用户ID")
     adopted_by: int = Field(description="提问者用户ID")
-    created_at: datetime = Field(default_factory=datetime.utcnow, description="创建时间")
+    created_at: datetime = Field(default_factory=now_beijing, description="创建时间")
 
 
 class AnonymousAlias(SQLModel, table=True):
@@ -208,7 +209,7 @@ class AnonymousAlias(SQLModel, table=True):
     user_id: int = Field(description="用户ID")
     alias_ord: int = Field(description="分配序号（从1起，不回收）")
     alias_label: str = Field(max_length=32, description="匿名展示名，如匿名同事A")
-    created_at: datetime = Field(default_factory=datetime.utcnow, description="创建时间")
+    created_at: datetime = Field(default_factory=now_beijing, description="创建时间")
 
 
 class AnswerEligibility(SQLModel, table=True):
@@ -222,7 +223,7 @@ class AnswerEligibility(SQLModel, table=True):
     question_id: int = Field(index=True, description="问题ID")
     user_id: int = Field(description="有资格专家用户ID")
     source: str = Field(max_length=32, description="资格来源：invited / pre_adopt_answer")
-    created_at: datetime = Field(default_factory=datetime.utcnow, description="创建时间")
+    created_at: datetime = Field(default_factory=now_beijing, description="创建时间")
 
 
 class PublishRequest(SQLModel, table=True):
@@ -239,12 +240,8 @@ class PublishRequest(SQLModel, table=True):
     expire_at: datetime = Field(description="到期时间")
     extension_days: int = Field(default=0, description="已累计延期天数（≤3）")
     version: int = Field(default=0, description="乐观锁版本")
-    created_at: datetime = Field(default_factory=datetime.utcnow, description="创建时间")
-    updated_at: datetime = Field(
-        default_factory=datetime.utcnow,
-        sa_column=Column(DateTime, nullable=False, server_default=UPDATE_TIME_SERVER_DEFAULT),
-        description="更新时间",
-    )
+    created_at: datetime = Field(default_factory=now_beijing, description="创建时间")
+    updated_at: datetime = Field(default_factory=now_beijing, description="更新时间")
 
 
 class PublishApprover(SQLModel, table=True):
@@ -260,7 +257,7 @@ class PublishApprover(SQLModel, table=True):
     role_in_request: str = Field(max_length=16, description="asker / answerer")
     decision: str = Field(max_length=32, description="pending/approved/rejected/default_approved")
     decided_at: datetime | None = Field(default=None, description="决策时间")
-    created_at: datetime = Field(default_factory=datetime.utcnow, description="创建时间")
+    created_at: datetime = Field(default_factory=now_beijing, description="创建时间")
 
 
 # ==================== 投票表 ====================
@@ -276,7 +273,7 @@ class QuestionVote(SQLModel, table=True):
     question_id: int = Field(index=True)
 
     # 时间戳
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=now_beijing)
 
 
 class AnswerVote(SQLModel, table=True):
@@ -289,7 +286,7 @@ class AnswerVote(SQLModel, table=True):
     answer_id: int = Field(index=True)
     vote_type: str = Field(default="helpful")  # helpful 有用，support 支持
     # 时间戳
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=now_beijing)
 
 
 class CommentVote(SQLModel, table=True):
@@ -302,7 +299,7 @@ class CommentVote(SQLModel, table=True):
     comment_id: int = Field(index=True)
 
     # 时间戳
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=now_beijing)
 
 
 # ==================== 通知表 ====================
@@ -326,4 +323,4 @@ class QANotification(SQLModel, table=True):
     tenant_id: int = Field(default=1, index=True)
 
     # 时间戳
-    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    created_at: datetime = Field(default_factory=now_beijing, index=True)

--- a/src/backend/bisheng/qa_expert/api/endpoints.py
+++ b/src/backend/bisheng/qa_expert/api/endpoints.py
@@ -1,4 +1,4 @@
-# ruff: noqa: RUF002
+# ruff: noqa: RUF002, RUF003
 """
 Expert QA API Endpoints - HTTP 路由处理层
 """
@@ -13,6 +13,7 @@ from bisheng.common.dependencies.user_deps import UserPayload
 from bisheng.common.errcode.base import BaseErrorCode
 from bisheng.common.errcode.http_error import ServerError
 from bisheng.common.schemas.api import resp_200, resp_500
+from bisheng.common.utils.beijing_time import dump_qa_datetimes
 from bisheng.core.cache.utils import save_uploaded_file
 from bisheng.core.storage.minio.minio_manager import get_minio_storage
 from bisheng.knowledge.domain.services.knowledge_service import KnowledgeService
@@ -151,7 +152,7 @@ async def create_expert(
     """创建专家（专家库管理员）"""
     try:
         expert = await service.create_expert(request, user=user)
-        return resp_200(data=expert)
+        return resp_200(data=_jsonable(expert))
     except BaseErrorCode as exc:
         return exc.return_resp_instance()
     except Exception as e:
@@ -168,7 +169,7 @@ async def update_expert(
     """更新专家信息"""
     try:
         expert = await service.update_expert(expert_id, request, user=user)
-        return resp_200(data=expert)
+        return resp_200(data=_jsonable(expert))
     except BaseErrorCode as exc:
         return exc.return_resp_instance()
     except Exception as e:
@@ -234,7 +235,7 @@ async def expertsinfo(
     """获取专家"""
 
     experinfo = await service.get_expertinfo(expert_name)
-    return resp_200(data=experinfo)
+    return resp_200(data=dump_qa_datetimes(experinfo))
 
 
 @router.get("/experts/userid/{user_id}")
@@ -246,7 +247,7 @@ async def expertsinfo_id(
     """获取专家"""
 
     experinfo = await service.get_expertinfobyid(user_id)
-    return resp_200(data=experinfo)
+    return resp_200(data=dump_qa_datetimes(experinfo))
 
 
 # ==================== 问题管理 Endpoints ====================
@@ -296,7 +297,7 @@ async def create_question(
         user.user_name,
         tenant_id=user.tenant_id,
     )
-    return resp_200(data=question)
+    return resp_200(data=question_detail_payload(question))
 
 
 @router.get("/questions", response_model=QuestionPageData)
@@ -353,7 +354,7 @@ async def update_question(
         )
 
     question = await service.update_question(question_id, request, tenant_id=user.tenant_id)
-    return resp_200(data=question)
+    return resp_200(data=question_detail_payload(question))
 
 
 def question_detail_payload(question) -> dict:
@@ -393,7 +394,7 @@ def question_detail_payload(question) -> dict:
     asker = payload.get("asker")
     if isinstance(asker, dict) and asker.get("anonymous") and "real_name" not in asker:
         payload["created_by"] = asker.get("display_name")
-    return payload
+    return dump_qa_datetimes(payload)
 
 
 def answer_payload(answer) -> dict:
@@ -403,7 +404,7 @@ def answer_payload(answer) -> dict:
         author = payload.get("author")
     elif hasattr(answer, "model_dump"):
         try:
-            payload = answer.model_dump(mode="json")
+            payload = answer.model_dump()
         except TypeError:
             payload = answer.model_dump()
         author = getattr(answer, "author", payload.get("author"))
@@ -425,14 +426,14 @@ def answer_payload(answer) -> dict:
     related_doc_views = getattr(answer, "related_doc_views", payload.get("related_doc_views"))
     if related_doc_views is not None:
         payload["related_doc_views"] = related_doc_views
-    return payload
+    return dump_qa_datetimes(payload)
 
 
 def comment_payload(comment) -> dict:
     """评论 JSON：走 CommentDetailResponse，匿名时 user_name 为别名。"""
     if isinstance(comment, dict):
-        return dict(comment)
-    return CommentDetailResponse.from_comment(comment).model_dump(mode="json")
+        return dump_qa_datetimes(dict(comment))
+    return dump_qa_datetimes(CommentDetailResponse.from_comment(comment).model_dump())
 
 
 @router.get("/questions/{question_id}", response_model=QuestionDetailResponse)
@@ -473,7 +474,7 @@ async def adopt_answer(
     """采纳最佳回答"""
 
     question = await service.adopt_answer(question_id, request.answer_id, user.user_id)
-    return resp_200(data=question)
+    return resp_200(data=question_detail_payload(question))
 
 
 @router.delete("/questions/{question_id}")
@@ -564,7 +565,7 @@ async def update_answer(
             tenant_id=user.tenant_id,
         )
 
-        return resp_200(data=answer)
+        return resp_200(data=answer_payload(answer))
     except Exception as e:
         return resp_500(code=500, message=str(e))
 
@@ -661,7 +662,7 @@ async def get_allcomments(
         comments=[CommentDetailResponse.from_comment(comment) for comment in comments],
         total=total,
     )
-    return resp_200(data=page_data.model_dump(mode="json"))
+    return resp_200(data=dump_qa_datetimes(page_data.model_dump()))
 
 
 # ==================== 投票 Endpoints ====================
@@ -718,7 +719,7 @@ async def get_notifications(
         user.user_id, unread_only=unread_only, skip=skip, limit=limit
     )
 
-    return resp_200(data={"notifications": notifications, "total": total})
+    return resp_200(data={"notifications": [_jsonable(item) for item in notifications], "total": total})
 
 
 @router.post("/notifications/{notification_id}/read")
@@ -780,14 +781,15 @@ async def get_publish_service():
 
 
 def _jsonable(row):
-    """把 SQLModel/Pydantic 转成可进 UnifiedResponse 的 dict。"""
+    """把 SQLModel/Pydantic 转成可进 UnifiedResponse 的 dict，时间带 +08:00。"""
     dump = getattr(row, "model_dump", None)
     if callable(dump):
         try:
-            return dump(mode="json")
+            payload = dump()
         except TypeError:
-            return dump()
-    return row
+            payload = dump()
+        return dump_qa_datetimes(payload)
+    return dump_qa_datetimes(row)
 
 
 @router.post("/questions/{question_id}/publish-requests")

--- a/src/backend/bisheng/qa_expert/domain/models.py
+++ b/src/backend/bisheng/qa_expert/domain/models.py
@@ -1,56 +1,62 @@
+# ruff: noqa: RUF002, RUF003
 """
 Expert QA Domain Models - 专家问答领域模型
 
 遵循 DDD 规范，定义专家问答系统的核心业务模型
 """
 
-from datetime import datetime
 from enum import Enum
-from typing import Optional, List
+
+from bisheng.common.utils.beijing_time import now_beijing
 
 
 class QuestionStatus(str, Enum):
     """问题状态"""
-    UNSOLVED = "unsolved"          # 未解决
-    SOLVED = "solved"              # 已解决
-    CLOSED = "closed"              # 已关闭
+
+    UNSOLVED = "unsolved"  # 未解决
+    SOLVED = "solved"  # 已解决
+    CLOSED = "closed"  # 已关闭
 
 
 class AnswerStatus(str, Enum):
     """回答状态"""
-    NORMAL = "normal"              # 正常
-    ADOPTED = "adopted"            # 已采纳
-    DELETED = "deleted"            # 已删除
+
+    NORMAL = "normal"  # 正常
+    ADOPTED = "adopted"  # 已采纳
+    DELETED = "deleted"  # 已删除
 
 
 class NotificationType(str, Enum):
     """消息类型"""
-    INVITED = "invited"            # 被邀请回答
-    ANSWERED = "answered"          # 问题被回答
-    COMMENTED = "commented"        # 回答被评论
-    ADOPTED = "adopted"            # 回答被采纳
+
+    INVITED = "invited"  # 被邀请回答
+    ANSWERED = "answered"  # 问题被回答
+    COMMENTED = "commented"  # 回答被评论
+    ADOPTED = "adopted"  # 回答被采纳
 
 
 class ExpertLevel(str, Enum):
     """专家等级"""
-    SENIOR = "senior"              # 高级专家
+
+    SENIOR = "senior"  # 高级专家
     INTERMEDIATE = "intermediate"  # 中级专家
-    JUNIOR = "junior"              # 初级专家
+    JUNIOR = "junior"  # 初级专家
 
 
 # ==================== 专家领域对象 ====================
 
+
 class Expert:
     """专家聚合根"""
-    
+
     def __init__(
         self,
         user_id: int,
         expert_name: str,
-        introduction: Optional[str] = None,
+        introduction: str | None = None,
         level: ExpertLevel = ExpertLevel.JUNIOR,
-        business_domains: Optional[List[str]] = None,
-        verified: bool = False
+        business_domains: list[str] | None = None,
+        verified: bool = False,
     ):
         self.user_id = user_id
         self.expert_name = expert_name
@@ -61,8 +67,8 @@ class Expert:
         self.answer_count = 0
         self.adoption_count = 0
         self.helpful_count = 0
-        self.created_at = datetime.utcnow()
-    
+        self.created_at = now_beijing()
+
     def update_stats(self, answers: int = 0, adoptions: int = 0, helpful: int = 0):
         """更新专家统计数据"""
         self.answer_count += answers
@@ -72,19 +78,20 @@ class Expert:
 
 # ==================== 问题领域对象 ====================
 
+
 class Question:
     """问题聚合根"""
-    
+
     def __init__(
         self,
         user_id: int,
         title: str,
         description: str,
         business_domain: str,
-        attachments: Optional[List[str]] = None,
-        related_docs: Optional[List[int]] = None,
-        invited_experts: Optional[List[int]] = None,
-        anonymous: bool = False
+        attachments: list[str] | None = None,
+        related_docs: list[int] | None = None,
+        invited_experts: list[int] | None = None,
+        anonymous: bool = False,
     ):
         self.user_id = user_id
         self.title = title
@@ -95,35 +102,35 @@ class Question:
         self.related_docs = related_docs or []
         self.invited_experts = invited_experts or []
         self.anonymous = anonymous
-        
+
         # 统计字段
         self.vote_count = 0
         self.answer_count = 0
         self.view_count = 0
-        self.adopted_answer_id: Optional[int] = None
-        
-        self.created_at = datetime.utcnow()
-        self.updated_at = datetime.utcnow()
-    
+        self.adopted_answer_id: int | None = None
+
+        self.created_at = now_beijing()
+        self.updated_at = now_beijing()
+
     def invite_expert(self, expert_id: int):
         """邀请专家"""
         if len(self.invited_experts) >= 3:
             raise ValueError("最多只能邀请 3 位专家")
         if expert_id not in self.invited_experts:
             self.invited_experts.append(expert_id)
-    
+
     def adopt_answer(self, answer_id: int, *, adopted_count: int = 0):
         """采纳最佳回答（同题最多 3 条；adopted_count 为当前未删除已采纳数）。"""
         if adopted_count >= 3:
             raise ValueError("每个问题最多采纳 3 个最佳答案")
         self.adopted_answer_id = answer_id
         self.status = QuestionStatus.SOLVED
-        self.updated_at = datetime.utcnow()
-    
+        self.updated_at = now_beijing()
+
     def add_vote(self):
         """增加赞数"""
         self.vote_count += 1
-    
+
     def increment_view_count(self):
         """增加浏览数"""
         self.view_count += 1
@@ -131,16 +138,17 @@ class Question:
 
 # ==================== 回答领域对象 ====================
 
+
 class Answer:
     """回答聚合根"""
-    
+
     def __init__(
         self,
         question_id: int,
         user_id: int,
         content: str,
-        attachments: Optional[List[str]] = None,
-        related_docs: Optional[List[int]] = None
+        attachments: list[str] | None = None,
+        related_docs: list[int] | None = None,
     ):
         self.question_id = question_id
         self.user_id = user_id
@@ -148,23 +156,23 @@ class Answer:
         self.attachments = attachments or []
         self.related_docs = related_docs or []
         self.status = AnswerStatus.NORMAL
-        
+
         # 统计字段
         self.vote_count = 0
         self.comment_count = 0
-        
-        self.created_at = datetime.utcnow()
-        self.updated_at = datetime.utcnow()
-    
+
+        self.created_at = now_beijing()
+        self.updated_at = now_beijing()
+
     def adopt(self):
         """采纳此回答"""
         self.status = AnswerStatus.ADOPTED
-        self.updated_at = datetime.utcnow()
-    
+        self.updated_at = now_beijing()
+
     def add_vote(self):
         """增加有用数"""
         self.vote_count += 1
-    
+
     def delete(self):
         """删除回答"""
         self.status = AnswerStatus.DELETED
@@ -172,23 +180,18 @@ class Answer:
 
 # ==================== 评论/追问领域对象 ====================
 
+
 class Comment:
     """评论/追问聚合根"""
-    
-    def __init__(
-        self,
-        answer_id: int,
-        user_id: int,
-        content: str,
-        is_follow_up: bool = False
-    ):
+
+    def __init__(self, answer_id: int, user_id: int, content: str, is_follow_up: bool = False):
         self.answer_id = answer_id
         self.user_id = user_id
         self.content = content
         self.is_follow_up = is_follow_up  # True 为追问，False 为评论
         self.vote_count = 0
-        self.created_at = datetime.utcnow()
-    
+        self.created_at = now_beijing()
+
     def add_vote(self):
         """增加赞数"""
         self.vote_count += 1
@@ -196,33 +199,35 @@ class Comment:
 
 # ==================== 投票领域对象 ====================
 
+
 class Vote:
     """投票（赞）记录"""
-    
+
     def __init__(
         self,
         user_id: int,
         target_type: str,  # "question", "answer", "comment"
-        target_id: int
+        target_id: int,
     ):
         self.user_id = user_id
         self.target_type = target_type
         self.target_id = target_id
-        self.created_at = datetime.utcnow()
+        self.created_at = now_beijing()
 
 
 # ==================== 通知领域对象 ====================
 
+
 class Notification:
     """站内消息通知"""
-    
+
     def __init__(
         self,
         recipient_id: int,
         sender_id: int,
         notification_type: NotificationType,
         related_question_id: int,
-        content: str
+        content: str,
     ):
         self.recipient_id = recipient_id
         self.sender_id = sender_id
@@ -230,8 +235,8 @@ class Notification:
         self.related_question_id = related_question_id
         self.content = content
         self.read = False
-        self.created_at = datetime.utcnow()
-    
+        self.created_at = now_beijing()
+
     def mark_as_read(self):
         """标记为已读"""
         self.read = True

--- a/src/backend/bisheng/qa_expert/domain/publish_approval_bridge.py
+++ b/src/backend/bisheng/qa_expert/domain/publish_approval_bridge.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
 from types import SimpleNamespace
 from typing import Any
 
@@ -26,6 +25,7 @@ from bisheng.approval.domain.models.approval_scenario import (
 )
 from bisheng.approval.domain.repositories.approval_instance_repository import ApprovalInstanceRepository
 from bisheng.approval.domain.repositories.approval_scenario_repository import ApprovalScenarioRepository
+from bisheng.common.utils.beijing_time import now_beijing, to_beijing_iso
 
 # 与 publish_service 状态字面量对齐；本模块不反向 import，避免循环。
 DECISION_APPROVED = "approved"
@@ -216,7 +216,7 @@ async def _sync_after_create(request, question, initiator, approvers: list[Any])
     payload = {
         "request_id": int(request.id),
         "question_id": int(question.id),
-        "expire_at": expire_at.isoformat() if expire_at else None,
+        "expire_at": to_beijing_iso(expire_at) if expire_at else None,
         "duration_days": int(getattr(request, "duration_days", 0) or 0),
     }
     instance = await _get_instance(request)
@@ -342,7 +342,7 @@ async def _sync_from_publish_request(request, approvers: list[Any] | None) -> No
         approvers = await PublishApproverRepository().list_by_request(int(request.id))
     decision_by_user = {int(row.user_id): str(row.decision) for row in approvers}
     tasks = await ApprovalInstanceRepository.list_tasks(int(instance.id))
-    now = datetime.utcnow()
+    now = now_beijing()
     publish_status = str(request.status)
     for task in tasks:
         wanted = _task_status_for(decision_by_user.get(int(task.approver_user_id), DECISION_PENDING))

--- a/src/backend/bisheng/qa_expert/domain/publish_service.py
+++ b/src/backend/bisheng/qa_expert/domain/publish_service.py
@@ -14,6 +14,7 @@ from bisheng.common.errcode.qa_expert import (
     QaExpertPublishNotAllowedError,
     QaExpertQuestionAccessDeniedError,
 )
+from bisheng.common.utils.beijing_time import now_beijing, to_beijing_iso
 from bisheng.database.models.qa_expert import (
     QUESTION_TYPE_PUBLIC,
     AnswerEligibility,
@@ -67,7 +68,7 @@ def serialize_publish_request(
         "id": int(row.id),
         "status": str(row.status),
         "duration_days": int(getattr(row, "duration_days", 0) or 0),
-        "expire_at": expire_at.isoformat() if expire_at is not None else None,
+        "expire_at": to_beijing_iso(expire_at) if expire_at is not None else None,
         "extension_days": int(getattr(row, "extension_days", 0) or 0),
         "viewer_decision": viewer_decision,
     }
@@ -100,7 +101,7 @@ class PublishService:
             raise QaExpertPublishDurationInvalidError()
         if user is None or getattr(user, "user_id", None) is None:
             raise QaExpertQuestionAccessDeniedError()
-        now = now or datetime.utcnow()
+        now = now or now_beijing()
         question = await self.question_repo.get_by_id_for_update(question_id)
         if not question:
             from bisheng.qa_expert.domain.services import QuestionNotFoundError
@@ -146,7 +147,7 @@ class PublishService:
         now: datetime | None = None,
     ) -> PublishRequest:
         """同意或拒绝；已决策不可改口。"""
-        now = now or datetime.utcnow()
+        now = now or now_beijing()
         if user is None or getattr(user, "user_id", None) is None:
             raise QaExpertQuestionAccessDeniedError()
         request = await self._get_live_request(request_id, now=now)
@@ -178,7 +179,7 @@ class PublishService:
 
     async def on_expert_disabled(self, user_id: int, *, now: datetime | None = None) -> list[int]:
         """停用专家：pending 审批改 default_approved，立即重判；不加入已结束申请。"""
-        now = now or datetime.utcnow()
+        now = now or now_beijing()
         passed: list[int] = []
         # 通过仓储列出该用户仍 pending 的审批行：由调用方注入 list_pending_for_user
         list_pending = getattr(self.approver_repo, "list_pending_for_user", None)
@@ -208,7 +209,7 @@ class PublishService:
 
     async def on_asker_disabled(self, question_id: int, *, now: datetime | None = None) -> PublishRequest | None:
         """提问者账号停用：进行中的申请 ended。"""
-        now = now or datetime.utcnow()
+        now = now or now_beijing()
         request = await self.request_repo.get_pending_by_question(int(question_id))
         if request is None:
             return None
@@ -225,7 +226,7 @@ class PublishService:
         self, question_id: int, *, now: datetime | None = None
     ) -> PublishRequest | None:
         """读详情前惰性过期，再返回同题最近一条申请。"""
-        now = now or datetime.utcnow()
+        now = now or now_beijing()
         pending = await self.request_repo.get_pending_by_question(int(question_id))
         if pending is not None and pending.expire_at is not None and pending.expire_at <= now:
             await self._get_live_request(int(pending.id), now=now)
@@ -233,7 +234,7 @@ class PublishService:
 
     async def extend_one_day(self, request_id: int, user, *, now: datetime | None = None) -> PublishRequest:
         """+1 天延期，累计不超过 3 天。"""
-        now = now or datetime.utcnow()
+        now = now or now_beijing()
         request = await self._get_live_request(request_id, now=now)
         if request.status != PUBLISH_PENDING:
             raise QaExpertPublishNotAllowedError()
@@ -251,7 +252,7 @@ class PublishService:
 
     async def expire_pending(self, *, now: datetime | None = None, tenant_id: int | None = None) -> int:
         """把到期 pending 标为 expired，并通知。tenant_id 仅记录上下文。"""
-        now = now or datetime.utcnow()
+        now = now or now_beijing()
         rows = await self.request_repo.list_expired_pending(now)
         count = 0
         for request in rows:
@@ -269,7 +270,7 @@ class PublishService:
 
     async def get_request(self, request_id: int, user, *, now: datetime | None = None) -> PublishRequest:
         """读取申请；读路径顺带惰性过期。"""
-        return await self._get_live_request(request_id, now=now or datetime.utcnow())
+        return await self._get_live_request(request_id, now=now or now_beijing())
 
     async def _get_live_request(self, request_id: int, *, now: datetime) -> PublishRequest:
         request = await self.request_repo.get_by_id(int(request_id))

--- a/src/backend/bisheng/qa_expert/domain/publish_service.py
+++ b/src/backend/bisheng/qa_expert/domain/publish_service.py
@@ -490,29 +490,46 @@ class PublishService:
             logger.exception("qa.publish.notify_failed event={}", event)
 
     async def _send_inbox(self, event: str, question, extra: dict[str, Any]) -> None:
-        """转公开站内信：相关人通知；待办入口靠 approval_instance_id。"""
+        """转公开站内信：相关人通知；待办入口靠 approval_instance_id。
+
+        终态（通过/拒绝/过期/结束）若无操作人，用系统发件，保证提问者也能收到。
+        """
         from bisheng.approval.domain.repositories.approval_instance_repository import (
             ApprovalInstanceRepository,
         )
         from bisheng.qa_expert.domain.inbox_notice import display_name_for_trigger, send_qa_inbox
         from bisheng.qa_expert.domain.publish_approval_bridge import business_key_for
 
+        todo_events = {"publish_started", "publish_approver_added"}
+        result_events = {
+            "publish_approved",
+            "publish_rejected",
+            "publish_expired",
+            "publish_ended",
+            "publish_default_approved",
+        }
         sender = extra.get("user")
         sender_id = int(getattr(sender, "user_id", 0) or 0) if sender is not None else 0
-        if sender_id <= 0:
+        # 终态是系统结果，没有操作人。若把提问者填成发件人，send_qa_inbox 会把他从收件人剔除。
+        use_system_sender = event in result_events and sender_id <= 0
+        if sender_id <= 0 and not use_system_sender:
             sender_id = int(question.user_id)
-        real_name = extra.get("sender_name") or getattr(sender, "user_name", "") or ""
-        asker_anonymous = bool(int(getattr(question, "asker_anonymous", 0) or 0))
-        anonymous = bool(asker_anonymous) if sender_id == int(question.user_id) else bool(extra.get("anonymous"))
-        display, masked = await display_name_for_trigger(
-            question,
-            user_id=sender_id,
-            real_name=real_name,
-            anonymous=anonymous,
-            reveal_on_public=getattr(question, "asker_reveal_on_public", None)
-            if sender_id == int(question.user_id)
-            else extra.get("reveal_on_public"),
-        )
+        if use_system_sender:
+            display, masked = "系统", True
+            sender_id = 0
+        else:
+            real_name = extra.get("sender_name") or getattr(sender, "user_name", "") or ""
+            asker_anonymous = bool(int(getattr(question, "asker_anonymous", 0) or 0))
+            anonymous = bool(asker_anonymous) if sender_id == int(question.user_id) else bool(extra.get("anonymous"))
+            display, masked = await display_name_for_trigger(
+                question,
+                user_id=sender_id,
+                real_name=real_name,
+                anonymous=anonymous,
+                reveal_on_public=getattr(question, "asker_reveal_on_public", None)
+                if sender_id == int(question.user_id)
+                else extra.get("reveal_on_public"),
+            )
         receivers: list[int] = []
         request_id = extra.get("request_id")
         if request_id:
@@ -531,14 +548,6 @@ class PublishService:
             )
             if inst is not None:
                 instance_id = int(inst.id)
-        todo_events = {"publish_started", "publish_approver_added"}
-        result_events = {
-            "publish_approved",
-            "publish_rejected",
-            "publish_expired",
-            "publish_ended",
-            "publish_default_approved",
-        }
         business_type = "approval_instance_id" if event in todo_events and instance_id else "qa_question"
         await send_qa_inbox(
             action_code=f"qa_{event}",

--- a/src/backend/bisheng/qa_expert/domain/repositories.py
+++ b/src/backend/bisheng/qa_expert/domain/repositories.py
@@ -1,12 +1,12 @@
 # ruff: noqa: RUF001, RUF002, RUF003
 """Expert QA Repositories - 数据访问层"""
 
-from datetime import datetime
 from types import SimpleNamespace
 
 from sqlalchemy import Integer, cast, desc, func, update
 from sqlmodel import and_, or_, select
 
+from bisheng.common.utils.beijing_time import now_beijing
 from bisheng.core.database import get_async_db_session  # 确保导入了异步方法
 from bisheng.database.models.department import Department
 from bisheng.database.models.qa_expert import (
@@ -369,7 +369,7 @@ class QuestionRepository:
             question.status = 1
             question.adopt_count = current + 1
             if is_first:
-                question.resolved_at = datetime.utcnow()
+                question.resolved_at = now_beijing()
             session.add(question)
             answer.status = 1
             answer.adopted = True
@@ -1009,6 +1009,8 @@ class PublishRequestRepository:
             for key, value in kwargs.items():
                 if hasattr(row, key):
                     setattr(row, key, value)
+            if "updated_at" not in kwargs:
+                row.updated_at = now_beijing()
             session.add(row)
             await session.commit()
             await session.refresh(row)

--- a/src/backend/bisheng/qa_expert/domain/services.py
+++ b/src/backend/bisheng/qa_expert/domain/services.py
@@ -27,6 +27,7 @@ from bisheng.common.errcode.qa_expert import (
     QaExpertDisabledError,
     QaExpertQuestionAccessDeniedError,
 )
+from bisheng.common.utils.beijing_time import beijing_epoch_seconds, dump_qa_datetimes, to_beijing_iso
 from bisheng.core.database import get_async_db_session
 from bisheng.core.storage.minio.minio_manager import get_minio_storage
 from bisheng.database.models.department import DepartmentDao
@@ -451,7 +452,7 @@ class ExpertService:
             )
             expert_dict["wechat_user_id"] = wechat_user_ids.get(expert.user_id)
             experts_all.append(expert_dict)
-        return experts_all
+        return dump_qa_datetimes(experts_all)
 
     async def disable_expert(self, expert_id: int, user) -> Expert:
         """停用专家：status=0；回调转公开默认同意。"""
@@ -625,7 +626,7 @@ class QuestionService:
                 scene="expert_question",
                 source_app="expert_qa",
                 business_domain_code=request.business_domain,
-                timestamp=int(question.created_at.timestamp()),
+                timestamp=beijing_epoch_seconds(question.created_at),
             )
         except Exception:
             logger.exception(
@@ -1372,8 +1373,10 @@ class AnswerService:
         profile = ExpertService._with_department_projection(expert, department)
         for key in ("created_at", "updated_at"):
             value = profile.get(key)
-            if hasattr(value, "isoformat"):
-                profile[key] = value.isoformat()
+            if isinstance(value, datetime):
+                profile[key] = to_beijing_iso(value)
+            elif hasattr(value, "isoformat"):
+                profile[key] = to_beijing_iso(value)
         display = str(profile.get("department_display_name") or profile.get("depart_ment") or "").strip()
         if not display:
             raw_text = str(raw).strip() if raw not in (None, "") else ""

--- a/src/backend/test/qa_expert/test_beijing_time.py
+++ b/src/backend/test/qa_expert/test_beijing_time.py
@@ -1,20 +1,11 @@
-"""东八区时钟与存量平移辅助。"""
+"""东八区时钟与 Alembic 列定义。"""
 
 from datetime import datetime, timezone
 
-from sqlalchemy import create_engine, text
-
-from bisheng.common.utils.beijing_time import (
-    dump_qa_datetimes,
-    now_beijing,
-    shift_stored_iso,
-    to_beijing_iso,
-)
+from bisheng.common.utils.beijing_time import dump_qa_datetimes, now_beijing, to_beijing_iso
 from bisheng.core.database.alembic.versions.v2_6_0_f091_qa_expert_beijing_datetime import (
-    add_hours_sql,
     down_revision,
     revision,
-    shift_table_datetimes,
 )
 
 
@@ -38,33 +29,6 @@ def test_dump_qa_datetimes_walks_nested_payload() -> None:
     assert payload["nested"][0]["t"] == "2026-08-18T12:00:00+08:00"
 
 
-def test_shift_stored_iso_adds_eight_for_naive_utc() -> None:
-    assert shift_stored_iso("2026-08-18T03:00:00") == "2026-08-18T11:00:00+08:00"
-    assert shift_stored_iso("2026-08-18T03:00:00Z") == "2026-08-18T11:00:00+08:00"
-    assert shift_stored_iso("2026-08-18T11:00:00+08:00") == "2026-08-18T11:00:00+08:00"
-
-
-def test_shift_stored_iso_negative_hours_for_downgrade() -> None:
-    assert shift_stored_iso("2026-08-18T11:00:00", hours=-8) == "2026-08-18T03:00:00"
-    assert shift_stored_iso("2026-08-18T11:00:00+08:00", hours=-8) == "2026-08-18T03:00:00"
-
-
-def test_add_hours_sql_mysql_and_dm() -> None:
-    assert add_hours_sql("created_at", "mysql", 8) == "DATE_ADD(`created_at`, INTERVAL 8 HOUR)"
-    assert add_hours_sql("created_at", "mysql", -8) == "DATE_SUB(`created_at`, INTERVAL 8 HOUR)"
-    assert "+ (8/24.0)" in add_hours_sql("created_at", "dm", 8)
-
-
 def test_alembic_revision_follows_f090_merge() -> None:
     assert revision == "f091_qa_expert_beijing_datetime"
     assert down_revision == "f090_merge_f083_f087_f089"
-
-
-def test_shift_table_datetimes_sqlite() -> None:
-    engine = create_engine("sqlite://")
-    with engine.begin() as conn:
-        conn.execute(text("CREATE TABLE qa_comment (id INTEGER PRIMARY KEY, created_at DATETIME)"))
-        conn.execute(text("INSERT INTO qa_comment (id, created_at) VALUES (1, '2026-08-18 03:00:00')"))
-        shift_table_datetimes(conn, "qa_comment", ("created_at",), hours=8)
-        value = conn.execute(text("SELECT created_at FROM qa_comment WHERE id = 1")).scalar()
-    assert "11:00:00" in str(value)

--- a/src/backend/test/qa_expert/test_beijing_time.py
+++ b/src/backend/test/qa_expert/test_beijing_time.py
@@ -1,0 +1,70 @@
+"""东八区时钟与存量平移辅助。"""
+
+from datetime import datetime, timezone
+
+from sqlalchemy import create_engine, text
+
+from bisheng.common.utils.beijing_time import (
+    dump_qa_datetimes,
+    now_beijing,
+    shift_stored_iso,
+    to_beijing_iso,
+)
+from bisheng.core.database.alembic.versions.v2_6_0_f091_qa_expert_beijing_datetime import (
+    add_hours_sql,
+    down_revision,
+    revision,
+    shift_table_datetimes,
+)
+
+
+def test_now_beijing_is_naive_and_near_plus_eight() -> None:
+    naive = now_beijing()
+    utc = datetime.now(timezone.utc).replace(tzinfo=None)
+    assert naive.tzinfo is None
+    delta_hours = (naive - utc).total_seconds() / 3600
+    assert 7.5 <= delta_hours <= 8.5
+
+
+def test_to_beijing_iso_labels_naive_as_plus_eight() -> None:
+    assert to_beijing_iso(datetime(2026, 8, 18, 11, 0, 0)) == "2026-08-18T11:00:00+08:00"
+
+
+def test_dump_qa_datetimes_walks_nested_payload() -> None:
+    payload = dump_qa_datetimes(
+        {"created_at": datetime(2026, 8, 18, 11, 0, 0), "nested": [{"t": datetime(2026, 8, 18, 12, 0, 0)}]}
+    )
+    assert payload["created_at"] == "2026-08-18T11:00:00+08:00"
+    assert payload["nested"][0]["t"] == "2026-08-18T12:00:00+08:00"
+
+
+def test_shift_stored_iso_adds_eight_for_naive_utc() -> None:
+    assert shift_stored_iso("2026-08-18T03:00:00") == "2026-08-18T11:00:00+08:00"
+    assert shift_stored_iso("2026-08-18T03:00:00Z") == "2026-08-18T11:00:00+08:00"
+    assert shift_stored_iso("2026-08-18T11:00:00+08:00") == "2026-08-18T11:00:00+08:00"
+
+
+def test_shift_stored_iso_negative_hours_for_downgrade() -> None:
+    assert shift_stored_iso("2026-08-18T11:00:00", hours=-8) == "2026-08-18T03:00:00"
+    assert shift_stored_iso("2026-08-18T11:00:00+08:00", hours=-8) == "2026-08-18T03:00:00"
+
+
+def test_add_hours_sql_mysql_and_dm() -> None:
+    assert add_hours_sql("created_at", "mysql", 8) == "DATE_ADD(`created_at`, INTERVAL 8 HOUR)"
+    assert add_hours_sql("created_at", "mysql", -8) == "DATE_SUB(`created_at`, INTERVAL 8 HOUR)"
+    assert "+ (8/24.0)" in add_hours_sql("created_at", "dm", 8)
+
+
+def test_alembic_revision_follows_f090_merge() -> None:
+    assert revision == "f091_qa_expert_beijing_datetime"
+    assert down_revision == "f090_merge_f083_f087_f089"
+
+
+def test_shift_table_datetimes_sqlite() -> None:
+    engine = create_engine("sqlite://")
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE qa_comment (id INTEGER PRIMARY KEY, created_at DATETIME)"))
+        conn.execute(text("INSERT INTO qa_comment (id, created_at) VALUES (1, '2026-08-18 03:00:00')"))
+        shift_table_datetimes(conn, "qa_comment", ("created_at",), hours=8)
+        value = conn.execute(text("SELECT created_at FROM qa_comment WHERE id = 1")).scalar()
+    assert "11:00:00" in str(value)

--- a/src/backend/test/qa_expert/test_data_flow.py
+++ b/src/backend/test/qa_expert/test_data_flow.py
@@ -1541,6 +1541,62 @@ async def test_df_question_too_many_images_rejected_no_dirty_row(flow_env, monke
     assert await env.reload_row(Question, title=title) is None
 
 
+async def test_df_publish_approved_inbox_includes_asker(flow_env, monkeypatch):
+    """定向转公开通过后，提问者与回答专家都收到 qa_publish_approved；再读仍在。"""
+    from bisheng.qa_expert.domain.publish_service import PublishService
+
+    async def live_notify(self, event, question, extra=None):
+        await self._send_inbox(event, question, extra or {})
+
+    monkeypatch.setattr(PublishService, "_notify", live_notify)
+    env = flow_env
+    invited = await env.seed_expert(user_id=201, name="专家甲")
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df转公开提问者通知",
+            "description": "定向",
+            "business_domain": "steel",
+            "question_type": "directed",
+            "invited_expert_ids": [invited.id],
+            "asker_reveal_on_public": True,
+        },
+    )
+    env.as_user(env.user(201, name="专家甲"))
+    aid = await _create_answer(env, qid, "甲的回答")
+    env.as_user(env.asker)
+    _ok(await env.client.post(f"{PREFIX}/questions/{qid}/adopt", json={"answer_id": aid}))
+    created = _ok(await env.client.post(f"{PREFIX}/questions/{qid}/publish-requests", json={"duration_days": 3}))
+    assert created["status_code"] == 200
+    request = await env.reload_row(PublishRequest, question_id=qid)
+    assert request is not None
+    title = env.t("df转公开提问者通知")
+    before_approved = [
+        row for row in await _inbox_rows(env, title) if "publish_approved" in str(row.get("action_code") or "")
+    ]
+    assert before_approved == []
+    env.as_user(env.user(201, name="专家甲"))
+    approved = _ok(await env.client.post(f"{PREFIX}/publish-requests/{request.id}/approve"))
+    assert approved["status_code"] == 200
+    question = await env.reload_row(Question, id=qid)
+    assert question.question_type == "public"
+    approved_msgs = [
+        row for row in await _inbox_rows(env, title) if "publish_approved" in str(row.get("action_code") or "")
+    ]
+    assert approved_msgs
+    receivers = _receiver_ids(approved_msgs[-1]["receiver"])
+    assert int(env.asker.user_id) in receivers
+    assert env.uid(201) in receivers
+    again = await env.reload_row(Question, id=qid)
+    assert again.question_type == "public"
+    again_msgs = [
+        row for row in await _inbox_rows(env, title) if "publish_approved" in str(row.get("action_code") or "")
+    ]
+    assert int(env.asker.user_id) in _receiver_ids(again_msgs[-1]["receiver"])
+    assert env.uid(201) in _receiver_ids(again_msgs[-1]["receiver"])
+
+
 async def test_df_question_created_at_is_beijing_wall_clock(flow_env):
     """新写入 qa_question.created_at 为东八墙钟；接口带 +08:00，与落库一致。"""
     env = flow_env

--- a/src/backend/test/qa_expert/test_data_flow.py
+++ b/src/backend/test/qa_expert/test_data_flow.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 
 import asyncio
 import json
-from datetime import datetime, timedelta
+from datetime import timedelta
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import text
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from bisheng.common.utils.beijing_time import now_beijing
 from bisheng.database.models.qa_expert import (
     AnonymousAlias,
     Answer,
@@ -1418,7 +1420,7 @@ async def test_df25_expired_publish_allows_unadopted_delete(flow_env):
     async with AsyncSession(env.engine, expire_on_commit=False) as session:
         await session.execute(
             text("UPDATE qa_publish_request SET expire_at = :expired WHERE question_id = :qid"),
-            {"expired": datetime.utcnow() - timedelta(minutes=1), "qid": qid},
+            {"expired": now_beijing() - timedelta(minutes=1), "qid": qid},
         )
         await session.commit()
     listed = _ok(await env.client.get(f"{PREFIX}/answers/{qid}"))
@@ -1537,3 +1539,37 @@ async def test_df_question_too_many_images_rejected_no_dirty_row(flow_env, monke
     again_body = _ok(again)
     assert again_body["status_code"] == 18313
     assert await env.reload_row(Question, title=title) is None
+
+
+async def test_df_question_created_at_is_beijing_wall_clock(flow_env):
+    """新写入 qa_question.created_at 为东八墙钟；接口带 +08:00，与落库一致。"""
+    env = flow_env
+    env.as_user(env.asker)
+    before = now_beijing()
+    qid = await _create_question(
+        env,
+        {
+            "title": "df时区东八",
+            "description": "校验墙钟",
+            "business_domain": "steel",
+            "question_type": "public",
+        },
+    )
+    after = now_beijing()
+    row = await env.reload_row(Question, id=qid)
+    assert row is not None
+    assert row.created_at.tzinfo is None
+    assert before - timedelta(seconds=5) <= row.created_at <= after + timedelta(seconds=5)
+    detail = _ok(await env.client.get(f"{PREFIX}/questions/{qid}"))
+    created_at = (detail.get("data") or {}).get("created_at")
+    assert isinstance(created_at, str)
+    assert created_at.endswith("+08:00")
+    wall = row.created_at.strftime("%Y-%m-%dT%H:%M")
+    assert created_at.startswith(wall)
+    again = _ok(await env.client.get(f"{PREFIX}/questions/{qid}"))
+    assert (again.get("data") or {}).get("created_at") == created_at
+    listed = _ok(await env.client.get(f"{PREFIX}/questions", params={"page": 1, "page_size": 20}))
+    questions = (listed.get("data") or {}).get("questions") or []
+    hit = next((item for item in questions if int(item.get("id")) == qid), None)
+    assert hit is not None
+    assert str(hit.get("created_at") or "").endswith("+08:00")

--- a/src/backend/test/qa_expert/test_inbox_notify.py
+++ b/src/backend/test/qa_expert/test_inbox_notify.py
@@ -1,4 +1,4 @@
-# ruff: noqa: RUF002
+# ruff: noqa: RUF002, RUF003
 """T021：邀请/回答/采纳/转公开走 inbox；匿名触发人用别名。"""
 
 from types import SimpleNamespace
@@ -83,6 +83,79 @@ async def test_anonymous_sender_uses_alias_not_real_name():
     )
     assert view.display_name == "匿名同事A"
     assert "李专家" not in view.display_name
+
+
+async def test_publish_approved_inbox_keeps_asker_as_receiver(monkeypatch):
+    """转公开通过是系统终态：提问者不能因默认发件人被从收件人剔除。"""
+    captured: dict = {}
+
+    async def fake_send(**kwargs):
+        captured.update(kwargs)
+
+    pub = PublishService()
+    pub.approver_repo = MagicMock()
+    pub.approver_repo.list_by_request = AsyncMock(
+        return_value=[SimpleNamespace(user_id=101), SimpleNamespace(user_id=201)]
+    )
+    monkeypatch.setattr("bisheng.qa_expert.domain.inbox_notice.send_qa_inbox", fake_send)
+    monkeypatch.setattr(
+        "bisheng.approval.domain.repositories.approval_instance_repository.ApprovalInstanceRepository.find_latest_by_business_key",
+        AsyncMock(return_value=None),
+    )
+    question = SimpleNamespace(
+        id=1,
+        title="t",
+        user_id=101,
+        tenant_id=1,
+        asker_anonymous=0,
+        asker_reveal_on_public=None,
+    )
+    await pub._send_inbox("publish_approved", question, {"request_id": 9})
+    assert captured["action_code"] == "qa_publish_approved"
+    assert captured["sender_user_id"] == 0
+    assert 101 in captured["receivers"]
+    assert 201 in captured["receivers"]
+
+
+async def test_publish_started_inbox_still_excludes_initiator(monkeypatch):
+    """发起转公开仍排除操作人，避免提问者收到自己刚提交的待办。"""
+    captured: dict = {}
+
+    async def fake_display(*_args, **_kwargs):
+        return "提问者", False
+
+    async def fake_send(**kwargs):
+        captured.update(kwargs)
+
+    pub = PublishService()
+    pub.approver_repo = MagicMock()
+    pub.approver_repo.list_by_request = AsyncMock(
+        return_value=[SimpleNamespace(user_id=101), SimpleNamespace(user_id=201)]
+    )
+    monkeypatch.setattr("bisheng.qa_expert.domain.inbox_notice.display_name_for_trigger", fake_display)
+    monkeypatch.setattr("bisheng.qa_expert.domain.inbox_notice.send_qa_inbox", fake_send)
+    monkeypatch.setattr(
+        "bisheng.approval.domain.repositories.approval_instance_repository.ApprovalInstanceRepository.find_latest_by_business_key",
+        AsyncMock(return_value=None),
+    )
+    question = SimpleNamespace(
+        id=1,
+        title="t",
+        user_id=101,
+        tenant_id=1,
+        asker_anonymous=0,
+        asker_reveal_on_public=None,
+    )
+    await pub._send_inbox(
+        "publish_started",
+        question,
+        {"request_id": 9, "user": SimpleNamespace(user_id=101, user_name="提问者")},
+    )
+    assert captured["sender_user_id"] == 101
+    # send_qa_inbox 会排除发件人；发起人仍是提问者时，提问者收不到待办。
+    filtered = [uid for uid in captured["receivers"] if uid and int(uid) != int(captured["sender_user_id"])]
+    assert 101 not in filtered
+    assert 201 in filtered
 
 
 async def test_stale_publish_decision_rejected_after_ended():


### PR DESCRIPTION
## Summary
- 专家问答 `DATETIME` 改为东八墙钟写入（`now_beijing()`），接口序列化带 `+08:00`。
- **不做存量 +8 平移**：生产未启用该功能，测试环境旧行可忽略。Alembic `f091_qa_expert_beijing_datetime` 只去掉 `qa_publish_request.updated_at` 的 `ON UPDATE CURRENT_TIMESTAMP`，避免与 Python 东八写入混钟。
- 转公开通过后提问者也收到已转公开通知（同分支后续提交）。

**需与门户 PR 同窗口上线**：门户要把无偏移时间按东八解析，不能再当 UTC。

## Test plan
- [ ] 新建提问：库内 `qa_question.created_at` 接近当前北京时间；接口 `created_at` 以 `+08:00` 结尾，且墙钟与库一致
- [ ] 问答列表/详情时间不再多加 8 小时
- [ ] `alembic upgrade` 到 `f091` 后，`qa_*` 历史行时间值不变（无 DATE_ADD）
- [ ] `qa_publish_request.updated_at` 无 `ON UPDATE CURRENT_TIMESTAMP`
- [ ] 与门户一起发：旧门户 + 新接口会把东八 naive 当 UTC 再加 8 小时