### PR TITLE
fix(qa-expert): 转公开审批中途新回答专家将截止延后 1 天

### DIFF
--- a/src/backend/bisheng/qa_expert/domain/publish_approval_bridge.py
+++ b/src/backend/bisheng/qa_expert/domain/publish_approval_bridge.py
@@ -282,6 +282,26 @@ async def _sync_after_create(request, question, initiator, approvers: list[Any])
     return instance
 
 
+async def refresh_expire_snapshot(request) -> None:
+    """会签截止延后后，把审批实例快照里的 expire_at 对齐 qa_publish_request。"""
+    try:
+        instance = await _get_instance(request)
+        if instance is None:
+            return
+        expire_iso = to_beijing_iso(getattr(request, "expire_at", None))
+        payload = dict(instance.payload_snapshot or {})
+        detail = dict(instance.detail_snapshot or {})
+        if payload.get("expire_at") == expire_iso and detail.get("expire_at") == expire_iso:
+            return
+        payload["expire_at"] = expire_iso
+        detail["expire_at"] = expire_iso
+        instance.payload_snapshot = payload
+        instance.detail_snapshot = detail
+        await ApprovalInstanceRepository.update_instance(instance)
+    except Exception:
+        logger.exception("qa.publish.bridge.refresh_expire_failed request_id={}", getattr(request, "id", None))
+
+
 async def add_pending_task(request, question, user_id: int) -> ApprovalTask | None:
     """中途新增回答专家：补一条 pending 待办。"""
     try:

--- a/src/backend/bisheng/qa_expert/domain/publish_service.py
+++ b/src/backend/bisheng/qa_expert/domain/publish_service.py
@@ -240,15 +240,29 @@ class PublishService:
             raise QaExpertPublishNotAllowedError()
         if int(request.extension_days or 0) >= MAX_EXTENSION_DAYS:
             raise QaExpertPublishDurationInvalidError()
+        return await self._bump_expire_one_day(request)
+
+    async def _bump_expire_one_day(self, request: PublishRequest) -> PublishRequest:
+        """把 expire_at 往后推 1 天并记 extension_days；调用方已保证未达上限。"""
         new_ext = int(request.extension_days or 0) + 1
-        new_expire = request.expire_at + timedelta(days=1)
+        expire_at = request.expire_at
+        if expire_at is None:
+            return request
         updated = await self.request_repo.update(
             int(request.id),
             extension_days=new_ext,
-            expire_at=new_expire,
+            expire_at=expire_at + timedelta(days=1),
             version=int(request.version or 0) + 1,
         )
         return updated or request
+
+    async def _try_extend_for_late_answerer(self, request: PublishRequest) -> PublishRequest:
+        """中途新会签人：截止 +1 天，累计不超过 3 天；已满则只加人、不改时间。"""
+        if str(request.status) != PUBLISH_PENDING:
+            return request
+        if int(request.extension_days or 0) >= MAX_EXTENSION_DAYS:
+            return request
+        return await self._bump_expire_one_day(request)
 
     async def expire_pending(self, *, now: datetime | None = None, tenant_id: int | None = None) -> int:
         """把到期 pending 标为 expired，并通知。tenant_id 仅记录上下文。"""
@@ -404,9 +418,11 @@ class PublishService:
             if created is not None and str(created.decision) == DECISION_PENDING:
                 await self.approver_repo.delete(int(created.id))
             return
-        from bisheng.qa_expert.domain.publish_approval_bridge import add_pending_task
+        refreshed = await self._try_extend_for_late_answerer(refreshed)
+        from bisheng.qa_expert.domain.publish_approval_bridge import add_pending_task, refresh_expire_snapshot
 
         await add_pending_task(refreshed, question, int(user_id))
+        await refresh_expire_snapshot(refreshed)
         await self._notify(
             "publish_approver_added",
             question,

--- a/src/backend/test/qa_expert/test_data_flow.py
+++ b/src/backend/test/qa_expert/test_data_flow.py
@@ -1011,7 +1011,7 @@ def _receiver_ids(raw) -> set[int]:
 
 
 async def test_df21_publish_todo_and_late_answerer_joins(flow_env, monkeypatch):
-    """转公开先通知相关人，待我处理有 pending task；后回答的受邀专家加入会签。"""
+    """转公开先通知相关人，待我处理有 pending task；后回答的受邀专家加入会签并把截止延后 1 天。"""
     from bisheng.approval.domain.models.approval_instance import ApprovalInstance, ApprovalTask
     from bisheng.qa_expert.domain.publish_service import PublishService
 
@@ -1076,6 +1076,17 @@ async def test_df21_publish_todo_and_late_answerer_joins(flow_env, monkeypatch):
     assert env.uid(202) in pending_after
     still_pending = await env.reload_row(PublishRequest, id=request.id)
     assert still_pending.status == "pending"
+    assert int(still_pending.extension_days or 0) == int(request.extension_days or 0) + 1
+    assert still_pending.expire_at - request.expire_at == timedelta(days=1)
+    instance_after = await env.reload_row(ApprovalInstance, id=instance.id)
+    assert instance_after is not None
+    expected_iso = still_pending.expire_at.strftime("%Y-%m-%dT%H:%M:%S") + "+08:00"
+    assert (instance_after.payload_snapshot or {}).get("expire_at") == expected_iso
+    assert (instance_after.detail_snapshot or {}).get("expire_at") == expected_iso
+    detail = _ok(await env.client.get(f"{PREFIX}/questions/{qid}"))
+    latest = (detail.get("data") or {}).get("latest_publish_request") or {}
+    assert str(latest.get("expire_at") or "") == expected_iso
+    assert int(latest.get("extension_days") or 0) == int(still_pending.extension_days)
     added_msgs = [row for row in await _inbox_rows(env, title) if "approver_added" in str(row.get("action_code") or "")]
     assert added_msgs
     assert env.uid(202) in _receiver_ids(added_msgs[-1]["receiver"])

--- a/src/backend/test/qa_expert/test_publish_request.py
+++ b/src/backend/test/qa_expert/test_publish_request.py
@@ -254,3 +254,13 @@ async def test_extend_one_day_capped_at_three():
     svc.request_repo.get_by_id = AsyncMock(return_value=_request(extension_days=3))
     with pytest.raises(QaExpertPublishDurationInvalidError):
         await svc.extend_one_day(7, _user(user_id=1), now=now)
+
+
+async def test_try_extend_for_late_answerer_skips_at_cap():
+    """第四名中途会签人仍可加人，但截止不再 +1。"""
+    svc = _service()
+    expire = datetime(2026, 8, 18, 12, 0, 0)
+    out = await svc._try_extend_for_late_answerer(_request(extension_days=3, expire_at=expire))
+    assert out.extension_days == 3
+    assert out.expire_at == expire
+    svc.request_repo.update.assert_not_called()


### PR DESCRIPTION
## Summary
- 定向题转公开审批 pending 期间，新增尚未在会签名单中的回答专家时，将 `qa_publish_request.expire_at` 延后 1 天（`extension_days` 累计最多 3 天）。
- 同步回写 `approval_instance` 快照中的 `expire_at`，审批中心截止时间与业务表一致。
- 同一专家再答或已满 3 天：只补会签人，不再加时。

## Test plan
- [ ] 定向题已发起转公开后，另一名受邀专家首次回答：申请 `expire_at` +1 天，`extension_days` +1
- [ ] 审批中心该实例「公开截止时间」与接口 `latest_publish_request.expire_at` 一致
- [ ] 同一专家再次作答不改变截止时间
- [ ] 已延期满 3 天后新专家仍能加入会签，截止时间不再变化
- [ ] `uv run pytest test/qa_expert/test_data_flow.py::test_df21_publish_todo_and_late_answerer_joins test/qa_expert/test_publish_request.py::test_try_extend_for_late_answerer_skips_at_cap`


Made with [Cursor](https://cursor.com)