### PR TITLE
fix(points): 违规删除扣分后补发积分变动站内信 (IK9KP5)

### DIFF
--- a/src/backend/bisheng/points/domain/services/points_pending_deduct_service.py
+++ b/src/backend/bisheng/points/domain/services/points_pending_deduct_service.py
@@ -12,10 +12,14 @@ from datetime import datetime, timedelta
 
 from bisheng.common.errcode.points import PointsInvalidAdjustError, PointsRuleNotFoundError
 from bisheng.core.database import get_async_db_session
+from bisheng.points.domain.constants.notify_templates import format_deduct_notify_reason
 from bisheng.points.domain.models import PointPendingDeduct
 from bisheng.points.domain.repositories.points_repository import PointsRepository
 from bisheng.points.domain.services.points_ledger_service import PointsLedgerService
-from bisheng.points.domain.services.points_notify_service import PointsNotifyService
+from bisheng.points.domain.services.points_notify_service import (
+    PointsNotifyService,
+    build_points_notify_service,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +47,46 @@ class PointsPendingDeductService:
     def __init__(self, notify: PointsNotifyService | None = None):
         self.notify = notify or PointsNotifyService()
 
+    def _has_usable_notify(self) -> bool:
+        """已注入 MessageService 或单测 mock 时可直接发；裸服务必须走工厂。"""
+        if self.notify is None:
+            return False
+        if not isinstance(self.notify, PointsNotifyService):
+            return True
+        return self.notify.message_service is not None
+
+    async def _notify_admin_deduct(
+        self,
+        *,
+        user_id: int,
+        delta: int,
+        rule_name: str | None,
+        remark: str | None,
+        log_key: str,
+    ) -> None:
+        """账本提交后发扣分站内信；失败只记日志，不回滚积分。"""
+        reason = format_deduct_notify_reason(rule_name=rule_name, remark=remark)
+        try:
+            if self._has_usable_notify():
+                await self.notify.notify(
+                    user_id=user_id,
+                    template_code="deduct_admin",
+                    delta=delta,
+                    reason=reason,
+                )
+                return
+            async with get_async_db_session() as session:
+                notify = await build_points_notify_service(session)
+                await notify.notify(
+                    user_id=user_id,
+                    template_code="deduct_admin",
+                    delta=delta,
+                    reason=reason,
+                )
+                await session.commit()
+        except Exception:
+            logger.exception("points.pending_deduct.notify_failed user_id=%s key=%s", user_id, log_key)
+
     async def deduct_or_enqueue(
         self,
         *,
@@ -67,6 +111,7 @@ class PointsPendingDeductService:
                 score = abs(int((rule.score_expr or {}).get("score", 0)))
                 if score == 0:
                     raise PointsInvalidAdjustError(msg="扣减规则分值为 0")
+                rule_name = rule.name
                 result = await ledger.deduct(
                     tenant_id=tenant_id,
                     user_id=user_id,
@@ -95,15 +140,13 @@ class PointsPendingDeductService:
                     last_error="ledger_returned_no_log",
                 )
                 return DeductAttemptResult(applied=False, pending=True, reason="ledger_empty")
-            try:
-                await self.notify.notify(
-                    user_id=user_id,
-                    template_code="deduct_admin",
-                    delta=score,
-                    reason=format_deduct_notify_reason(rule_name=rule.name, remark=remark),
-                )
-            except Exception:
-                logger.exception("points.pending_deduct.notify_failed user_id=%s key=%s", user_id, key)
+            await self._notify_admin_deduct(
+                user_id=user_id,
+                delta=score,
+                rule_name=rule_name,
+                remark=remark,
+                log_key=key,
+            )
             return DeductAttemptResult(applied=True, pending=False)
         except Exception as exc:
             logger.exception(
@@ -220,18 +263,13 @@ class PointsPendingDeductService:
             row.next_retry_at = None
             await repo.save_pending_deduct(row)
             if not result.replayed and result.log_id is not None:
-                try:
-                    await self.notify.notify(
-                        user_id=int(row.user_id),
-                        template_code="deduct_admin",
-                        delta=score,
-                        reason=format_deduct_notify_reason(rule_name=rule.name, remark=row.remark),
-                    )
-                except Exception:
-                    logger.exception(
-                        "points.pending_deduct.drain_notify_failed id=%s",
-                        row.id,
-                    )
+                await self._notify_admin_deduct(
+                    user_id=int(row.user_id),
+                    delta=score,
+                    rule_name=rule.name,
+                    remark=row.remark,
+                    log_key=row.idempotency_key,
+                )
             return "done"
         except Exception as exc:
             row.retry_count = int(row.retry_count or 0) + 1

--- a/src/backend/test/points/test_points_pending_deduct.py
+++ b/src/backend/test/points/test_points_pending_deduct.py
@@ -1,6 +1,10 @@
-"""补扣队列：稳定幂等键与失败入队语义。"""
+# ruff: noqa: RUF002
+"""补扣队列：稳定幂等键、失败入队与扣分站内信。"""
 
 from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -9,6 +13,41 @@ from bisheng.points.domain.services.points_pending_deduct_service import (
     PointsPendingDeductService,
     stable_deduct_idempotency_key,
 )
+
+
+def _patch_successful_ledger(monkeypatch, *, score: int = 100, log_id: int = 42, replayed: bool = False):
+    """伪造账本会话：规则启用且扣分成功。"""
+    session = AsyncMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+    session.commit = AsyncMock()
+    rule = SimpleNamespace(
+        rule_code="R1",
+        rule_type="deduct",
+        status="enabled",
+        name="色情低俗/暴力违法",
+        score_expr={"score": score},
+    )
+    repo = SimpleNamespace(get_rule=AsyncMock(return_value=rule))
+    ledger_result = SimpleNamespace(replayed=replayed, log_id=log_id)
+
+    class _Ledger:
+        async def deduct(self, **_kwargs):
+            return ledger_result
+
+    monkeypatch.setattr(
+        "bisheng.points.domain.services.points_pending_deduct_service.PointsRepository",
+        lambda _session: repo,
+    )
+    monkeypatch.setattr(
+        "bisheng.points.domain.services.points_pending_deduct_service.PointsLedgerService",
+        lambda _repo: _Ledger(),
+    )
+    monkeypatch.setattr(
+        "bisheng.points.domain.services.points_pending_deduct_service.get_async_db_session",
+        lambda: session,
+    )
+    return session
 
 
 def test_stable_deduct_idempotency_key_normalizes_rule():
@@ -58,3 +97,79 @@ async def test_deduct_or_enqueue_enqueues_when_ledger_raises(monkeypatch):
     assert result.applied is False
     assert result.pending is True
     assert calls and calls[0]["idempotency_key"] == "deduct:R1:qa_comment:77"
+
+
+@pytest.mark.asyncio
+async def test_deduct_or_enqueue_notifies_injected_service(monkeypatch):
+    """立即扣分成功后必须发 deduct_admin 站内信；备注优先作为原因。"""
+    _patch_successful_ledger(monkeypatch)
+    notify = AsyncMock()
+    service = PointsPendingDeductService(notify=notify)
+    result = await service.deduct_or_enqueue(
+        tenant_id=1,
+        user_id=66,
+        rule_code="r1",
+        biz_type="qa_answer",
+        biz_id="11",
+        operator_id=9,
+        remark="违规删除未采纳回答",
+    )
+    assert result.applied is True
+    assert result.pending is False
+    notify.notify.assert_awaited_once_with(
+        user_id=66,
+        template_code="deduct_admin",
+        delta=100,
+        reason="违规删除未采纳回答",
+    )
+
+
+@pytest.mark.asyncio
+async def test_deduct_or_enqueue_builds_message_service_when_bare(monkeypatch):
+    """裸 PointsNotifyService 必须走工厂注入 MessageService，不能静默跳过。"""
+    ledger_session = _patch_successful_ledger(monkeypatch)
+    notify = AsyncMock()
+    built = AsyncMock(return_value=notify)
+    monkeypatch.setattr(
+        "bisheng.points.domain.services.points_pending_deduct_service.build_points_notify_service",
+        built,
+    )
+    service = PointsPendingDeductService()
+    assert service.notify.message_service is None
+
+    result = await service.deduct_or_enqueue(
+        tenant_id=1,
+        user_id=66,
+        rule_code="R1",
+        biz_type="qa_answer",
+        biz_id="11",
+        operator_id=9,
+        remark="",
+    )
+    assert result.applied is True
+    built.assert_awaited_once()
+    notify.notify.assert_awaited_once_with(
+        user_id=66,
+        template_code="deduct_admin",
+        delta=100,
+        reason="色情低俗/暴力违法",
+    )
+    assert ledger_session.commit.await_count >= 2
+
+
+@pytest.mark.asyncio
+async def test_deduct_or_enqueue_skips_notify_on_replay(monkeypatch):
+    """幂等重放已入账时不再发站内信。"""
+    _patch_successful_ledger(monkeypatch, replayed=True)
+    notify = AsyncMock()
+    service = PointsPendingDeductService(notify=notify)
+    result = await service.deduct_or_enqueue(
+        tenant_id=1,
+        user_id=66,
+        rule_code="R1",
+        biz_type="qa_answer",
+        biz_id="11",
+        operator_id=9,
+    )
+    assert result.replayed is True
+    notify.notify.assert_not_awaited()

--- a/src/backend/test/qa_expert/test_moderate_delete_points_notify_flow.py
+++ b/src/backend/test/qa_expert/test_moderate_delete_points_notify_flow.py
@@ -1,0 +1,195 @@
+# ruff: noqa: RUF002
+"""IK9KP5：超管删未采纳回答并扣分后，账本与积分变动站内信必须同时落库。"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+from sqlalchemy import text
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from bisheng.database.models.qa_expert import Answer, Question
+from bisheng.points.domain.services.points_pending_deduct_service import (
+    stable_deduct_idempotency_key,
+)
+
+PREFIX = "/api/v1/qa_experts"
+
+
+def _ok(resp) -> dict:
+    body = resp.json()
+    assert resp.status_code == 200, body
+    return body
+
+
+async def _create_question(env, payload: dict) -> int:
+    payload = {**payload, "title": env.t(payload["title"])}
+    resp = await env.client.post(f"{PREFIX}/questions", json=payload)
+    body = _ok(resp)
+    assert body.get("status_code") == 200, body
+    data = body.get("data") or {}
+    if data.get("id"):
+        return int(data["id"])
+    row = await env.reload_row(Question, title=payload["title"])
+    assert row is not None
+    return int(row.id)
+
+
+async def _create_answer(env, question_id: int, content: str) -> int:
+    resp = await env.client.post(
+        f"{PREFIX}/answers",
+        json={"question_id": question_id, "content": content, "reveal_on_public": True},
+    )
+    body = _ok(resp)
+    assert body.get("status_code") == 200, body
+    data = body.get("data") or {}
+    if data.get("id"):
+        return int(data["id"])
+    rows = await env.reload_all(Answer, question_id=question_id)
+    assert rows
+    return int(max(rows, key=lambda r: r.id).id)
+
+
+async def _select_maps(engine, sql: str, params: dict) -> list[dict]:
+    """按参数执行 SELECT，返回 mapping 列表。"""
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        rows = (await session.execute(text(sql), params)).mappings().all()
+        return [dict(row) for row in rows]
+
+
+async def _cleanup_points_rows(engine, *, user_id: int, remark: str) -> None:
+    """清掉本用例写入的积分流水、账户、补扣队列和站内信。"""
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        await session.execute(text("DELETE FROM user_point_log WHERE user_id = :u"), {"u": user_id})
+        await session.execute(text("DELETE FROM user_point_account WHERE user_id = :u"), {"u": user_id})
+        await session.execute(text("DELETE FROM point_pending_deduct WHERE user_id = :u"), {"u": user_id})
+        await session.execute(
+            text(
+                "DELETE FROM inbox_message_read WHERE message_id IN "
+                "(SELECT id FROM (SELECT id FROM inbox_message WHERE CAST(content AS CHAR) LIKE :p) t)"
+            ),
+            {"p": f"%{remark}%"},
+        )
+        await session.execute(
+            text("DELETE FROM inbox_message WHERE CAST(content AS CHAR) LIKE :p"),
+            {"p": f"%{remark}%"},
+        )
+        await session.commit()
+
+
+async def test_moderate_delete_unadopted_answer_writes_log_and_inbox(flow_env, monkeypatch):
+    """超管删未采纳回答并选 R1：user_point_log 扣分，inbox_message 发 points_changed；再删不得脏写。"""
+    env = flow_env
+
+    @asynccontextmanager
+    async def patched_session():
+        session = AsyncSession(bind=env.engine, expire_on_commit=False)
+        try:
+            yield session
+        finally:
+            await session.close()
+
+    monkeypatch.setattr(
+        "bisheng.points.domain.services.points_pending_deduct_service.get_async_db_session",
+        patched_session,
+    )
+    await env.seed_expert(user_id=201, name="被扣分专家")
+    expert_uid = env.uid(201)
+    remark = env.t("违规删除未采纳回答")
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df删答扣分通知",
+            "description": "未采纳回答",
+            "business_domain": "steel",
+            "question_type": "public",
+        },
+    )
+    env.as_user(env.user(201, name="被扣分专家"))
+    aid = await _create_answer(env, qid, "待删除未采纳回答")
+    key = stable_deduct_idempotency_key("R1", "qa_answer", str(aid))
+
+    rules = await _select_maps(
+        env.engine,
+        "SELECT rule_code, status, rule_type FROM point_rule WHERE tenant_id = 1 AND rule_code = 'R1'",
+        {},
+    )
+    assert rules, "171 验收库缺少 R1 扣减规则"
+    assert rules[0]["status"] == "enabled"
+    assert rules[0]["rule_type"] == "deduct"
+
+    try:
+        env.as_user(env.user(501, name="super-admin", super_admin=True))
+        body = _ok(
+            await env.client.post(
+                f"{PREFIX}/admin/moderate-delete",
+                json={
+                    "target_type": "answer",
+                    "target_id": aid,
+                    "rule_code": "R1",
+                    "remark": remark,
+                },
+            )
+        )
+        assert body.get("status_code") == 200, body
+        data = body.get("data") or {}
+        assert data.get("deleted") is True
+        assert data.get("deducted") is True
+        assert data.get("target_user_id") == expert_uid
+
+        logs = await _select_maps(
+            env.engine,
+            "SELECT id, user_id, delta, direction, rule_code, idempotency_key, remark "
+            "FROM user_point_log WHERE idempotency_key = :k",
+            {"k": key},
+        )
+        assert len(logs) == 1
+        assert int(logs[0]["user_id"]) == expert_uid
+        assert int(logs[0]["delta"]) < 0
+        assert logs[0]["direction"] == "deduct"
+        assert logs[0]["rule_code"] == "R1"
+
+        inbox = await _select_maps(
+            env.engine,
+            "SELECT id, action_code, receiver, content FROM inbox_message "
+            "WHERE action_code = 'points_changed' AND CAST(content AS CHAR) LIKE :p "
+            "ORDER BY id",
+            {"p": f"%{remark}%"},
+        )
+        assert len(inbox) == 1
+        assert str(expert_uid) in str(inbox[0]["receiver"])
+        content = str(inbox[0]["content"])
+        assert "points_changed" in content
+        assert "管理员为您扣减" in content or "deduct_admin" in content
+
+        answer = await env.reload_row(Answer, id=aid)
+        assert answer is not None
+        assert int(answer.status) == 3
+
+        again = _ok(
+            await env.client.post(
+                f"{PREFIX}/admin/moderate-delete",
+                json={
+                    "target_type": "answer",
+                    "target_id": aid,
+                    "rule_code": "R1",
+                    "remark": remark,
+                },
+            )
+        )
+        assert again.get("status_code") != 200
+        logs_after = await _select_maps(
+            env.engine,
+            "SELECT id FROM user_point_log WHERE idempotency_key = :k",
+            {"k": key},
+        )
+        inbox_after = await _select_maps(
+            env.engine,
+            "SELECT id FROM inbox_message WHERE action_code = 'points_changed' AND CAST(content AS CHAR) LIKE :p",
+            {"p": f"%{remark}%"},
+        )
+        assert len(logs_after) == 1
+        assert len(inbox_after) == 1
+    finally:
+        await _cleanup_points_rows(env.engine, user_id=expert_uid, remark=remark)


### PR DESCRIPTION
## Summary
- 修复 [IK9KP5](https://e.gitee.com/Data-Elem_1/issues/list?issue=IK9KP5)：管理员删除专家未采纳回答并扣分后，积分已扣但未发送「积分变动提醒」。
- 根因是补扣路径使用未注入 `MessageService` 的裸 `PointsNotifyService`，且未导入扣分文案函数，通知被跳过或吞掉。
- 账本提交后按月奖/自动发分同一套工厂发 `deduct_admin` 站内信；通知失败不回滚积分。

## Test plan
- [x] `pytest test/points/test_points_pending_deduct.py`
- [x] `pytest test/qa_expert/test_moderate_delete_points_notify_flow.py`（171：`user_point_log` + `inbox_message`，再删不得脏写）
- [ ] 页面：超管删未采纳回答并选 R1 → 专家积分减少 → 该专家消息中心出现「积分变动提醒」

## Gitee
- Issues: IK9KP5
- State: → 修复中（PR 已开）


Made with [Cursor](https://cursor.com)