### PR TITLE
fix(permission): short-circuit super admin in single-resource action …

### DIFF
--- a/src/backend/bisheng/permission/application/business_authorization.py
+++ b/src/backend/bisheng/permission/application/business_authorization.py
@@ -34,6 +34,15 @@ async def check_business_action(
     """Check one business-verified resource through the sole F048 facade."""
 
     actor = await resolve_permission_actor(login_user)
+    if actor.super_admin:
+        # The decision layer allows a super admin unconditionally, but only after
+        # the target is resolved. Resolution runs business data-validity guards
+        # (e.g. owner/tenant/status checks in the F048 resource adapter) that do
+        # not exempt super admins, so a legitimate-but-imperfect record would
+        # raise before the decision is ever reached. The batch path already
+        # short-circuits super admins for the same reason; mirror it here so the
+        # single-resource path (detail, delete, etc.) stays consistent.
+        return True
     registry = await get_f048_resource_registry()
     target = await registry.resolve(
         resource_type=resource_type,

--- a/src/backend/test/permission/test_f048_list_action_cost.py
+++ b/src/backend/test/permission/test_f048_list_action_cost.py
@@ -34,6 +34,10 @@ class _AllowAllRuntime:
         del actor, action
         return [True] * len(targets)
 
+    async def check_action(self, actor, target, action):
+        del actor, target, action
+        return True
+
 
 @pytest.fixture
 def counted(monkeypatch):
@@ -120,6 +124,47 @@ async def test_an_ordinary_user_still_goes_through_resolution(monkeypatch, count
     )
 
     assert counted.resolutions == 3
+
+
+async def test_super_admin_single_check_resolves_nothing(monkeypatch, counted) -> None:
+    """Single-resource checks (detail, delete, ...) must short-circuit too.
+
+    Resolution runs business data-validity guards that do not exempt super
+    admins, so resolving a legitimate-but-imperfect record (e.g. a system-owned
+    custom dashboard with a null owner) would raise before the decision layer
+    ever allowed the super admin. Mirror the batch path and resolve nothing.
+    """
+
+    _actor_resolver(
+        monkeypatch,
+        PermissionActor(user_id=1, current_tenant_id=1, super_admin=True),
+    )
+
+    allowed = await business_authorization.check_business_action(
+        object(),
+        resource_type="dashboard",
+        resource_id="156",
+        action="visible",
+    )
+
+    assert allowed is True
+    assert counted.resolutions == 0
+
+
+async def test_ordinary_user_single_check_still_resolves(monkeypatch, counted) -> None:
+    """The shortcut keys off the identity, never off the call shape."""
+
+    _actor_resolver(monkeypatch, PermissionActor(user_id=7, current_tenant_id=1))
+
+    allowed = await business_authorization.check_business_action(
+        object(),
+        resource_type="dashboard",
+        resource_id="156",
+        action="visible",
+    )
+
+    assert allowed is True
+    assert counted.resolutions == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
…check

The dashboard detail path (and other single-resource checks) resolved the F048 target before reaching the decision layer. Resolution runs business data-validity guards that do not exempt super admins, so a legitimate but imperfect record (e.g. a custom dashboard with a null owner) raised PermissionInvalidResourceError before the super admin was ever allowed. The batch path already short-circuits super admins; mirror it here so the single-resource path stays consistent.

## What

简要描述做了什么改动。

## Why

为什么需要这个改动？

## How

实现方式、设计决策（如有）。

## Test

- [ ] 本地测试通过
- [ ] 114 测试服务器验证通过

## Related

- Issue/ticket:
