### PR TITLE
fix(qa-expert): 定向非匿名转公开审批展示申请人部门

### DIFF
--- a/src/backend/bisheng/qa_expert/domain/publish_approval_bridge.py
+++ b/src/backend/bisheng/qa_expert/domain/publish_approval_bridge.py
@@ -196,16 +196,28 @@ async def sync_after_create(request, question, initiator, approvers: list[Any]) 
         return None
 
 
-async def _initiator_display(question, initiator) -> str:
-    """发起人写入审批实例的展示名：匿名则为同题别名。"""
+async def _initiator_identity(question, initiator):
+    """发起人展示身份：匿名用同题别名。"""
     from bisheng.qa_expert.domain.publish_approval_identity import display_name_for_publish_user
 
-    identity = await display_name_for_publish_user(
+    return await display_name_for_publish_user(
         question,
         user_id=int(initiator.user_id),
         real_name=str(getattr(initiator, "user_name", "") or ""),
     )
-    return identity.display_name
+
+
+async def applicant_department_id_for_initiator(*, anonymous: bool, user_id: int) -> int | None:
+    """非匿名发起人写入主部门；匿名为空，避免审批列表拼出身份。"""
+    if anonymous or int(user_id) <= 0:
+        return None
+    from bisheng.database.models.department import UserDepartmentDao
+
+    row = await UserDepartmentDao.aget_user_primary_department(int(user_id))
+    raw = getattr(row, "department_id", None) if row is not None else None
+    if raw in (None, 0, "0"):
+        return None
+    return int(raw)
 
 
 async def _sync_after_create(request, question, initiator, approvers: list[Any]) -> ApprovalInstance | None:
@@ -221,7 +233,12 @@ async def _sync_after_create(request, question, initiator, approvers: list[Any])
     }
     instance = await _get_instance(request)
     if instance is None:
-        applicant_display_name = await _initiator_display(question, initiator)
+        identity = await _initiator_identity(question, initiator)
+        applicant_display_name = identity.display_name
+        applicant_department_id = await applicant_department_id_for_initiator(
+            anonymous=identity.anonymous,
+            user_id=int(initiator.user_id),
+        )
         instance = await ApprovalInstanceRepository.create_instance(
             ApprovalInstance(
                 tenant_id=tenant_id,
@@ -234,6 +251,7 @@ async def _sync_after_create(request, question, initiator, approvers: list[Any])
                 business_name=str(question.title or ""),
                 applicant_user_id=int(initiator.user_id),
                 applicant_user_name=applicant_display_name,
+                applicant_department_id=applicant_department_id,
                 flow_version_id=contract.flow_version_id,
                 route_rule_id=contract.route_rule_id,
                 status=ApprovalInstanceStatus.PENDING,

--- a/src/backend/test/qa_expert/test_data_flow.py
+++ b/src/backend/test/qa_expert/test_data_flow.py
@@ -1094,7 +1094,7 @@ async def test_df21_publish_todo_and_late_answerer_joins(flow_env, monkeypatch):
     assert {int(row.approver_user_id) for row in still_tasks if row.status == "pending"} == pending_after
 
 
-async def test_df22_publish_approval_masks_anonymous_names_and_department(flow_env):
+async def test_df22_publish_approval_masks_anonymous_names_and_department(flow_env, monkeypatch):
     """定向转公开：匿名提问者/专家在审批实例与详情接口不露真名和部门。"""
     from bisheng.approval.domain.models.approval_instance import ApprovalActionLog, ApprovalInstance, ApprovalTask
 
@@ -1119,6 +1119,10 @@ async def test_df22_publish_approval_masks_anonymous_names_and_department(flow_e
     aid = await _create_answer_anonymous(env, qid, "匿名有效答", reveal_on_public=False)
     env.as_user(env.asker)
     _ok(await env.client.post(f"{PREFIX}/questions/{qid}/adopt", json={"answer_id": aid}))
+    monkeypatch.setattr(
+        "bisheng.database.models.department.UserDepartmentDao.aget_user_primary_department",
+        AsyncMock(return_value=SimpleNamespace(department_id=101)),
+    )
     created = _ok(await env.client.post(f"{PREFIX}/questions/{qid}/publish-requests", json={"duration_days": 3}))
     assert created["status_code"] == 200
 
@@ -1193,6 +1197,79 @@ async def test_df22_publish_approval_masks_anonymous_names_and_department(flow_e
     stored = await env.reload_row(ApprovalInstance, id=instance.id)
     assert stored.applicant_user_name == instance.applicant_user_name
     assert stored.applicant_user_name in alias_labels or str(stored.applicant_user_name).startswith("匿名同事")
+
+
+async def test_df24_named_directed_publish_shows_applicant_department(flow_env, monkeypatch):
+    """定向非匿名提问转公开：审批实例与待办接口展示申请人主部门。"""
+    from bisheng.approval.domain.models.approval_instance import ApprovalInstance, ApprovalTask
+
+    env = flow_env
+    invited = await env.seed_expert(user_id=201, name="专家甲")
+    dept_id = 101
+    dept_name = "炼铁厂"
+    monkeypatch.setattr(
+        "bisheng.database.models.department.UserDepartmentDao.aget_user_primary_department",
+        AsyncMock(return_value=SimpleNamespace(department_id=dept_id)),
+    )
+    monkeypatch.setattr(
+        "bisheng.approval.domain.services.approval_center_service.DepartmentDao.aget_by_ids",
+        AsyncMock(return_value=[SimpleNamespace(id=dept_id, name=dept_name, short_name="炼铁")]),
+    )
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df24转公开实名部门",
+            "description": "定向非匿名",
+            "business_domain": "steel",
+            "question_type": "directed",
+            "invited_expert_ids": [invited.id],
+            "asker_anonymous": False,
+        },
+    )
+    env.as_user(env.user(201, name="专家甲"))
+    aid = await _create_answer(env, qid, "甲实名答")
+    env.as_user(env.asker)
+    _ok(await env.client.post(f"{PREFIX}/questions/{qid}/adopt", json={"answer_id": aid}))
+    created = _ok(await env.client.post(f"{PREFIX}/questions/{qid}/publish-requests", json={"duration_days": 3}))
+    assert created["status_code"] == 200
+
+    instance = await env.reload_row(
+        ApprovalInstance,
+        business_resource_id=str(qid),
+        scenario_code="qa_question_publish",
+    )
+    assert instance is not None
+    assert int(instance.applicant_user_id) == int(env.asker.user_id)
+    assert instance.applicant_user_name == env.asker.user_name
+    assert int(instance.applicant_department_id) == dept_id
+
+    tasks = await env.reload_all(ApprovalTask, instance_id=instance.id)
+    expert_task = next((row for row in tasks if int(row.approver_user_id) == env.uid(201)), None)
+    assert expert_task is not None
+    env.as_user(env.user(201, name="专家甲"))
+    listed = _ok(await env.client.get("/api/v1/approval/my-tasks"))
+    hit = next(
+        (
+            item
+            for item in ((listed.get("data") or {}).get("data") or [])
+            if int(item.get("task_id") or 0) == int(expert_task.id)
+        ),
+        None,
+    )
+    assert hit is not None
+    assert int(hit.get("applicant_department_id") or 0) == dept_id
+    shown = str(hit.get("applicant_department_display_name") or hit.get("applicant_department_name") or "")
+    assert dept_name
+    assert shown
+    assert dept_name in shown or shown in dept_name
+    detail = _ok(await env.client.get(f"/api/v1/approval/my-tasks/{expert_task.id}"))
+    data = detail.get("data") or {}
+    assert int(data.get("applicant_department_id") or 0) == dept_id
+    again = _ok(await env.client.get(f"/api/v1/approval/my-tasks/{expert_task.id}"))
+    assert int((again.get("data") or {}).get("applicant_department_id") or 0) == dept_id
+    stored = await env.reload_row(ApprovalInstance, id=instance.id)
+    assert int(stored.applicant_department_id) == dept_id
 
 
 async def test_df13_reject_keeps_viewer_decision_on_latest(flow_env):

--- a/src/backend/test/qa_expert/test_publish_approval_identity.py
+++ b/src/backend/test/qa_expert/test_publish_approval_identity.py
@@ -2,7 +2,9 @@
 """转公开审批展示身份：匿名标志与实例 question_id 解析。"""
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
+from bisheng.qa_expert.domain.publish_approval_bridge import applicant_department_id_for_initiator
 from bisheng.qa_expert.domain.publish_approval_identity import (
     anonymous_choice_for_user,
     question_id_from_instance,
@@ -35,3 +37,23 @@ def test_answerer_anonymous_choice_overrides_non_asker():
     named, named_reveal = anonymous_choice_for_user(question, answers, 8)
     assert named is False
     assert named_reveal is None
+
+
+async def test_applicant_department_id_skips_anonymous(monkeypatch) -> None:
+    """匿名发起人不查、不写部门。"""
+    lookup = AsyncMock(return_value=SimpleNamespace(department_id=101))
+    monkeypatch.setattr(
+        "bisheng.database.models.department.UserDepartmentDao.aget_user_primary_department",
+        lookup,
+    )
+    assert await applicant_department_id_for_initiator(anonymous=True, user_id=7) is None
+    lookup.assert_not_awaited()
+
+
+async def test_applicant_department_id_uses_primary_department(monkeypatch) -> None:
+    """实名发起人写入主部门 ID。"""
+    monkeypatch.setattr(
+        "bisheng.database.models.department.UserDepartmentDao.aget_user_primary_department",
+        AsyncMock(return_value=SimpleNamespace(department_id=101)),
+    )
+    assert await applicant_department_id_for_initiator(anonymous=False, user_id=7) == 101


### PR DESCRIPTION
## Summary
- 定向题由实名发起人转公开时，把申请人主部门写入 `approval_instance.applicant_department_id`，审批中心「部门」不再是空。
- 匿名提问仍不落部门，读接口继续清空，避免用姓名+部门反推身份。

## Test plan
- [ ] 定向非匿名提问 → 转公开：待办/详情显示申请人部门
- [ ] 定向匿名提问 → 转公开：部门仍为空，展示名为「匿名同事*」
- [ ] `uv run pytest test/qa_expert/test_data_flow.py::test_df24_named_directed_publish_shows_applicant_department test/qa_expert/test_data_flow.py::test_df22_publish_approval_masks_anonymous_names_and_department test/qa_expert/test_publish_approval_identity.py`


Made with [Cursor](https://cursor.com)