### PR TITLE
fix(qa-expert): 收藏关联文档改写为源文件，避免详情预览报错

### DIFF
--- a/src/backend/bisheng/qa_expert/domain/related_docs_access.py
+++ b/src/backend/bisheng/qa_expert/domain/related_docs_access.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from loguru import logger
+
 RELATED_DOC_ACCESS_TIMEOUT_SEC = 3.0
 
 
@@ -15,6 +17,28 @@ def related_doc_display_title(row: Any | None) -> str | None:
     name = str(getattr(row, "file_name", None) or "").strip()
     alias = str(getattr(row, "alias_name", None) or "").strip()
     return name or alias or None
+
+
+def favorite_source_ref(row: Any | None) -> tuple[int, int] | None:
+    """收藏引用解析为源空间/源文件；非引用或元数据残缺返回 None。"""
+    if row is None:
+        return None
+    if str(getattr(row, "file_source", "") or "") != "favorite_reference":
+        return None
+    meta = getattr(row, "user_metadata", None) or {}
+    if not isinstance(meta, dict):
+        return None
+    ref = meta.get("favorite_reference") or {}
+    if not isinstance(ref, dict):
+        return None
+    try:
+        src_space = int(ref.get("source_space_id") or 0)
+        src_file = int(ref.get("source_file_id") or 0)
+    except (TypeError, ValueError):
+        return None
+    if src_space <= 0 or src_file <= 0:
+        return None
+    return src_space, src_file
 
 
 async def _load_related_doc_file(space_id: int, file_id: int) -> Any | None:
@@ -37,6 +61,62 @@ async def _load_related_doc_file(space_id: int, file_id: int) -> Any | None:
     if knowledge_id and knowledge_id != int(space_id):
         return None
     return row
+
+
+async def resolve_related_doc_target(space_id: int, file_id: int) -> tuple[int, int] | None:
+    """解析应对齐预览的 space/file。
+
+    普通缺失文件返回原 pair，交给 checker 标 not_found/forbidden。
+    收藏引用且源存在则返回源 pair；收藏指针在但源已删返回 None。
+    """
+    row = await _load_related_doc_file(int(space_id), int(file_id))
+    if row is None:
+        return int(space_id), int(file_id)
+    source = favorite_source_ref(row)
+    if source is None:
+        return int(space_id), int(file_id)
+    src_row = await _load_related_doc_file(source[0], source[1])
+    if src_row is None:
+        return None
+    return source
+
+
+async def canonicalize_related_docs(raw: str | None) -> str | None:
+    """把 related_docs 串里的收藏引用改写成源 space-file，避免详情链到空指针。"""
+    from bisheng.qa_expert.domain.question_query import parse_related_doc_ref, parse_related_doc_tokens
+
+    tokens = parse_related_doc_tokens(raw)
+    if not tokens:
+        return None
+    out: list[str] = []
+    seen: set[str] = set()
+    for token in tokens:
+        parsed = parse_related_doc_ref(token)
+        if parsed is None:
+            if token not in seen:
+                seen.add(token)
+                out.append(token)
+            continue
+        resolved = await resolve_related_doc_target(*parsed)
+        pair = resolved if resolved is not None else parsed
+        canonical = f"{pair[0]}-{pair[1]}"
+        if canonical in seen:
+            continue
+        seen.add(canonical)
+        out.append(canonical)
+    return ";".join(out) if out else None
+
+
+async def safe_canonicalize_related_docs(raw: str | None) -> str | None:
+    """canonicalize 的容错包装：解析失败保留原串，不阻断提问/回答。"""
+    if not raw:
+        return raw
+    try:
+        canonical = await canonicalize_related_docs(raw)
+    except Exception:
+        logger.exception("canonicalize related_docs failed")
+        return raw
+    return canonical if canonical is not None else raw
 
 
 async def _file_belongs_to_space(space_id: int, file_id: int) -> bool:

--- a/src/backend/bisheng/qa_expert/domain/services.py
+++ b/src/backend/bisheng/qa_expert/domain/services.py
@@ -534,6 +534,12 @@ class QuestionService:
         response_data.update(resolved)
         return Question(**response_data)
 
+    async def _canonicalize_related_docs(self, raw: str | None) -> str | None:
+        """收藏引用改写成源文件 token；解析失败时保留原串，不阻断提问。"""
+        from bisheng.qa_expert.domain.related_docs_access import safe_canonicalize_related_docs
+
+        return await safe_canonicalize_related_docs(raw)
+
     async def create_question(
         self,
         user_id: int,
@@ -554,6 +560,7 @@ class QuestionService:
             getattr(request, "related_doc_ids", None),
             request.related_docs,
         )
+        related_docs = await self._canonicalize_related_docs(related_docs)
         asker_anonymous = 1 if bool(getattr(request, "asker_anonymous", False)) else 0
         reveal = getattr(request, "asker_reveal_on_public", None)
         # 未匿名时转公开姓名选项无意义，不落库，避免旧客户端误带 true/false。
@@ -824,6 +831,29 @@ class QuestionService:
                 )
                 continue
             space_id, file_id = parsed
+            # 注入 checker 的单测不打库；线上把「我的收藏」指针解析成可预览的源文件。
+            if not callable(injected):
+                try:
+                    from bisheng.qa_expert.domain.related_docs_access import (
+                        resolve_related_doc_target,
+                    )
+
+                    resolved = await resolve_related_doc_target(space_id, file_id)
+                except Exception:
+                    resolved = (space_id, file_id)
+                if resolved is None:
+                    views.append(
+                        {
+                            "id": f"{space_id}-{file_id}",
+                            "space_id": space_id,
+                            "file_id": file_id,
+                            "title": None,
+                            "accessible": False,
+                            "unavailable_reason": "not_found",
+                        }
+                    )
+                    continue
+                space_id, file_id = resolved
             doc_id = f"{space_id}-{file_id}"
             accessible = False
             reason = "forbidden"
@@ -1253,6 +1283,8 @@ class QuestionService:
         update_data = request.model_dump(exclude_unset=True)
         if update_data.get("status") == 2:
             update_data.pop("status", None)
+        if "related_docs" in update_data:
+            update_data["related_docs"] = await self._canonicalize_related_docs(update_data.get("related_docs"))
         asset_fields = {"image_url", "file_url", "attachments"}
         requested_assets = {name: update_data[name] for name in asset_fields if name in update_data}
         promotion = None
@@ -1575,13 +1607,18 @@ class AnswerService:
             )
             asset_values.update(promotion.values)
 
+        from bisheng.qa_expert.domain.related_docs_access import safe_canonicalize_related_docs
+
+        related_docs = request.related_docs
+        if isinstance(related_docs, str):
+            related_docs = await safe_canonicalize_related_docs(related_docs)
         answer = Answer(
             question_id=request.question_id,
             expert_id=expert.id,
             user_id=user_id,
             content=request.content,
             attachments=asset_values["attachments"],
-            related_docs=request.related_docs,
+            related_docs=related_docs,
             images_url=asset_values["images_url"],
             expert_name=expert.expert_name,
             tenant_id=tenant_id or getattr(question, "tenant_id", 1) or 1,
@@ -1690,7 +1727,11 @@ class AnswerService:
         if attachments is not None:
             update_data["attachments"] = attachments
         if related_docs is not None:
-            update_data["related_docs"] = related_docs
+            from bisheng.qa_expert.domain.related_docs_access import safe_canonicalize_related_docs
+
+            update_data["related_docs"] = (
+                await safe_canonicalize_related_docs(related_docs) if isinstance(related_docs, str) else related_docs
+            )
         if images_url is not None:
             update_data["images_url"] = images_url
         requested_assets = {}

--- a/src/backend/test/qa_expert/test_data_flow.py
+++ b/src/backend/test/qa_expert/test_data_flow.py
@@ -265,6 +265,133 @@ async def test_df04b_related_docs_follow_space_read_not_asker(flow_env, monkeypa
     assert all(item.get("accessible") is False for item in asker_views_again)
 
 
+async def test_df04c_favorite_reference_rewrites_to_source_file(flow_env, monkeypatch):
+    """从「我的收藏」选文档后，qa_question.related_docs 与详情链接必须指向源文件。"""
+    from bisheng.knowledge.domain.models.knowledge_file import (
+        FileType,
+        KnowledgeFile,
+        KnowledgeFileStatus,
+    )
+    from bisheng.qa_expert.domain import related_docs_access as related_docs_access_mod
+
+    env = flow_env
+    src_space_id = 88_100_000 + (env.asker.user_id % 9000)
+    fav_space_id = src_space_id + 1
+    src_file_id = 0
+    fav_file_id = 0
+    async with AsyncSession(env.engine, expire_on_commit=False) as session:
+        src_file = KnowledgeFile(
+            tenant_id=1,
+            knowledge_id=src_space_id,
+            user_id=env.asker.user_id,
+            file_name=f"{env.prefix}src-规程.pdf",
+            file_type=FileType.FILE.value,
+            file_source="upload",
+            status=KnowledgeFileStatus.SUCCESS.value,
+            object_name=f"{env.prefix}src-object",
+        )
+        session.add(src_file)
+        await session.flush()
+        fav_file = KnowledgeFile(
+            tenant_id=1,
+            knowledge_id=fav_space_id,
+            user_id=env.asker.user_id,
+            file_name=f"{env.prefix}fav-规程.pdf",
+            file_type=FileType.FILE.value,
+            file_source="favorite_reference",
+            status=KnowledgeFileStatus.SUCCESS.value,
+            user_metadata={
+                "favorite_reference": {
+                    "source_space_id": src_space_id,
+                    "source_file_id": int(src_file.id),
+                }
+            },
+        )
+        session.add(fav_file)
+        await session.commit()
+        await session.refresh(src_file)
+        await session.refresh(fav_file)
+        src_file_id = int(src_file.id)
+        fav_file_id = int(fav_file.id)
+    fav_token = f"{fav_space_id}-{fav_file_id}"
+    src_token = f"{src_space_id}-{src_file_id}"
+
+    async def fake_check(*, user_id, relation, object_type, object_id, login_user=None):
+        assert relation == "can_read"
+        assert object_type == "knowledge_space"
+        return int(object_id) == int(src_space_id) and int(user_id) == int(env.asker.user_id)
+
+    monkeypatch.setattr(
+        "bisheng.permission.domain.services.permission_service.PermissionService.check",
+        fake_check,
+    )
+
+    async def live_check(user, space_id, file_id, *, space_cache=None):
+        if not await related_docs_access_mod._file_belongs_to_space(int(space_id), int(file_id)):
+            return None
+        cache_key = int(space_id)
+        if space_cache is not None and cache_key in space_cache:
+            return space_cache[cache_key]
+        allowed = await related_docs_access_mod._space_can_read(user, cache_key)
+        if space_cache is not None:
+            space_cache[cache_key] = allowed
+        return allowed
+
+    monkeypatch.setattr(
+        "bisheng.qa_expert.domain.related_docs_access.check_related_doc_access",
+        live_check,
+    )
+
+    try:
+        env.as_user(env.asker)
+        qid = await _create_question(
+            env,
+            {
+                "title": "df04c收藏关联",
+                "description": "收藏文档正文",
+                "business_domain": "steel",
+                "question_type": "public",
+                "related_doc_ids": [fav_token],
+            },
+        )
+        stored = await env.reload_row(Question, id=qid)
+        assert stored.related_docs == src_token
+        assert fav_token not in (stored.related_docs or "")
+
+        asker_detail = _ok(await env.client.get(f"{PREFIX}/questions/{qid}"))
+        assert asker_detail["status_code"] == 200
+        asker_views = (asker_detail.get("data") or {}).get("related_doc_views") or []
+        assert len(asker_views) == 1
+        assert asker_views[0].get("accessible") is True
+        assert asker_views[0].get("space_id") == src_space_id
+        assert asker_views[0].get("file_id") == src_file_id
+        assert asker_views[0].get("id") == src_token
+        assert "收藏文档正文" in str(asker_detail.get("data") or {})
+
+        env.as_user(env.stranger)
+        stranger_detail = _ok(await env.client.get(f"{PREFIX}/questions/{qid}"))
+        stranger_views = (stranger_detail.get("data") or {}).get("related_doc_views") or []
+        assert len(stranger_views) == 1
+        assert stranger_views[0].get("accessible") is False
+        assert stranger_views[0].get("unavailable_reason") == "forbidden"
+
+        again = await env.reload_row(Question, id=qid)
+        assert again.related_docs == src_token
+
+        env.as_user(env.asker)
+        asker_again = _ok(await env.client.get(f"{PREFIX}/questions/{qid}"))
+        asker_views_again = (asker_again.get("data") or {}).get("related_doc_views") or []
+        assert asker_views_again[0].get("accessible") is True
+        assert asker_views_again[0].get("space_id") == src_space_id
+    finally:
+        async with AsyncSession(env.engine, expire_on_commit=False) as session:
+            await session.execute(
+                text("DELETE FROM knowledgefile WHERE file_name LIKE :p"),
+                {"p": f"{env.prefix}%"},
+            )
+            await session.commit()
+
+
 async def test_df05_first_answer_locks_content(flow_env):
     env = flow_env
     expert = await env.seed_expert(user_id=201, name="专家甲")

--- a/src/backend/test/qa_expert/test_related_docs.py
+++ b/src/backend/test/qa_expert/test_related_docs.py
@@ -186,3 +186,30 @@ async def test_hydrate_fills_title_from_knowledge_file(monkeypatch):
     views = await svc.hydrate_related_docs("8-15")
     assert views[0]["id"] == "8-15"
     assert views[0]["title"] == "炼钢规程.pdf"
+
+
+async def test_hydrate_rewrites_favorite_reference_to_source(monkeypatch):
+    """「我的收藏」指针在详情里改写成源空间/源文件，前端才能打开可预览文档。"""
+    from bisheng.qa_expert.domain import related_docs_access
+
+    monkeypatch.setattr(related_docs_access, "resolve_related_doc_target", AsyncMock(return_value=(90, 12)))
+    monkeypatch.setattr(related_docs_access, "check_related_doc_access", AsyncMock(return_value=True))
+    monkeypatch.setattr(related_docs_access, "load_related_doc_title", AsyncMock(return_value="规程.pdf"))
+    svc = _service()
+    views = await svc.hydrate_related_docs("5-77", user=SimpleNamespace(user_id=1))
+    assert views[0]["id"] == "90-12"
+    assert views[0]["space_id"] == 90
+    assert views[0]["file_id"] == 12
+    assert views[0]["accessible"] is True
+    assert views[0]["title"] == "规程.pdf"
+
+
+async def test_hydrate_dangling_favorite_is_not_found(monkeypatch):
+    """收藏指针还在、源文件已删：详情标 not_found，不能链到空预览。"""
+    from bisheng.qa_expert.domain import related_docs_access
+
+    monkeypatch.setattr(related_docs_access, "resolve_related_doc_target", AsyncMock(return_value=None))
+    svc = _service()
+    views = await svc.hydrate_related_docs("5-77", user=SimpleNamespace(user_id=1))
+    assert views[0]["accessible"] is False
+    assert views[0]["unavailable_reason"] == "not_found"

--- a/src/backend/test/qa_expert/test_related_docs_access.py
+++ b/src/backend/test/qa_expert/test_related_docs_access.py
@@ -141,3 +141,61 @@ async def test_non_personal_space_admin_still_uses_space_read(monkeypatch):
     admin = SimpleNamespace(user_id=1, is_admin=lambda: True)
     assert await related_docs_access.check_related_doc_access(admin, 8, 15) is True
     space_read.assert_awaited_once()
+
+
+async def test_resolve_favorite_reference_to_source(monkeypatch):
+    fav = SimpleNamespace(
+        id=77,
+        knowledge_id=5,
+        file_source="favorite_reference",
+        user_metadata={"favorite_reference": {"source_space_id": 90, "source_file_id": 12}},
+    )
+    src = SimpleNamespace(id=12, knowledge_id=90, file_source="upload", user_metadata={})
+
+    async def load(space_id, file_id):
+        if (space_id, file_id) == (5, 77):
+            return fav
+        if (space_id, file_id) == (90, 12):
+            return src
+        return None
+
+    monkeypatch.setattr(related_docs_access, "_load_related_doc_file", load)
+    assert await related_docs_access.resolve_related_doc_target(5, 77) == (90, 12)
+
+
+async def test_resolve_plain_file_unchanged(monkeypatch):
+    row = SimpleNamespace(id=15, knowledge_id=8, file_source="upload", user_metadata={})
+    monkeypatch.setattr(related_docs_access, "_load_related_doc_file", AsyncMock(return_value=row))
+    assert await related_docs_access.resolve_related_doc_target(8, 15) == (8, 15)
+
+
+async def test_resolve_missing_file_keeps_original_pair(monkeypatch):
+    monkeypatch.setattr(related_docs_access, "_load_related_doc_file", AsyncMock(return_value=None))
+    assert await related_docs_access.resolve_related_doc_target(8, 404) == (8, 404)
+
+
+async def test_resolve_dangling_favorite_is_none(monkeypatch):
+    fav = SimpleNamespace(
+        id=77,
+        knowledge_id=5,
+        file_source="favorite_reference",
+        user_metadata={"favorite_reference": {"source_space_id": 90, "source_file_id": 12}},
+    )
+
+    async def load(space_id, file_id):
+        if (space_id, file_id) == (5, 77):
+            return fav
+        return None
+
+    monkeypatch.setattr(related_docs_access, "_load_related_doc_file", load)
+    assert await related_docs_access.resolve_related_doc_target(5, 77) is None
+
+
+async def test_canonicalize_rewrites_favorite_token(monkeypatch):
+    async def resolve(space_id, file_id):
+        if (space_id, file_id) == (5, 77):
+            return (90, 12)
+        return space_id, file_id
+
+    monkeypatch.setattr(related_docs_access, "resolve_related_doc_target", resolve)
+    assert await related_docs_access.canonicalize_related_docs("5-77") == "90-12"


### PR DESCRIPTION
## Summary
- 从「我的收藏」关联文档时，落库与详情 hydrate 把收藏指针改写成源知识空间/源文件，避免打开空预览页报错。
- 源文件已删时标 `not_found`；可读性仍按源空间 `can_read`。
- 补充单测与 171 流转用例（提交收藏 token → `qa_question.related_docs` 为源 token → 提问者可点、路人 forbidden）。

## Test plan
- [ ] 提问时从「我的收藏」选文档并提交，提问者在问题详情打开关联文档可预览源文件
- [ ] 已提交且仍存收藏 token 的旧问题，详情链接同样打开源文件
- [ ] 源文件删除后，详情关联文档为不可点（not_found），正文仍可见
- [ ] 对源空间无 `can_read` 的路人看到 forbidden，不能打开
- [ ] `pytest test/qa_expert/test_related_docs.py test/qa_expert/test_related_docs_access.py test/qa_expert/test_data_flow.py::test_df04c_favorite_reference_rewrites_to_source_file`


Made with [Cursor](https://cursor.com)