### PR TITLE
fix(permission): admins pass the visibility gate on resource context/…

### DIFF
--- a/src/backend/bisheng/permission/application/resource_api.py
+++ b/src/backend/bisheng/permission/application/resource_api.py
@@ -457,7 +457,27 @@ class F048ResourcePermissionApi:
             include_roster=include_roster,
         )
 
+    @staticmethod
+    def _privileged(actor: PermissionActor, target) -> bool:
+        """A super admin (any tenant) or a tenant admin of the target's tenant.
+
+        This mirrors the identity shortcut the action decision path already
+        applies in ``check_action``. It is intentionally NOT applied by
+        ``check_visible``, which only consults FGA ``visible`` tuples — so an
+        admin who can plainly manage a resource (``check_action`` waves them
+        through for ``manage_permission``) was still denied at the visibility
+        gate of the permission-management endpoints.
+        """
+        if actor.super_admin:
+            return True
+        return (
+            target.tenant_id == actor.current_tenant_id
+            and target.tenant_id in actor.tenant_admin_tenant_ids
+        )
+
     async def _require_visible(self, actor, target) -> None:
+        if self._privileged(actor, target):
+            return
         if not await self._runtime.check_action(
             actor,
             target,

--- a/src/backend/test/permission/test_f048_resource_api.py
+++ b/src/backend/test/permission/test_f048_resource_api.py
@@ -174,6 +174,96 @@ async def test_super_admin_subject_validation_uses_target_tenant() -> None:
     assert runtime.page_calls == []
 
 
+class _ContextRuntime(_Runtime):
+    """A runtime whose FGA visible check always denies.
+
+    check_visible never waves admins through, so an admin's context request must
+    not depend on it — the API's own identity shortcut is what must let them in.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.visible_checks = 0
+
+    async def check_action(self, actor, target, action):
+        if action == "visible":
+            self.visible_checks += 1
+            return False
+        return True
+
+    async def current_mode(self, target):
+        del target
+        return SimpleNamespace(mode="CUSTOM", projection_state="READY")
+
+
+@pytest.mark.asyncio
+async def test_super_admin_reads_context_without_a_visible_tuple() -> None:
+    runtime = _ContextRuntime()
+    api = F048ResourcePermissionApi(
+        resources=_Resources(),
+        runtime=runtime,
+        subjects=_Subjects(),
+    )
+    actor = PermissionActor(user_id=7, current_tenant_id=5, super_admin=True)
+
+    result = await api.get_context(
+        resource_type="workflow",
+        resource_id="wf-1",
+        actor=actor,
+    )
+
+    # The visibility gate must be skipped for the super admin, never consulted.
+    assert runtime.visible_checks == 0
+    assert result["mode"] == "CUSTOM"
+    assert result["can_manage_permission"] is True
+
+
+@pytest.mark.asyncio
+async def test_tenant_admin_reads_context_for_own_tenant_without_visible_tuple() -> None:
+    runtime = _ContextRuntime()
+    api = F048ResourcePermissionApi(
+        resources=_Resources(),
+        runtime=runtime,
+        subjects=_Subjects(),
+    )
+    # _Resources resolves the target into tenant 9.
+    actor = PermissionActor(
+        user_id=7,
+        current_tenant_id=9,
+        tenant_admin_tenant_ids=frozenset({9}),
+    )
+
+    result = await api.get_context(
+        resource_type="workflow",
+        resource_id="wf-1",
+        actor=actor,
+    )
+
+    assert runtime.visible_checks == 0
+    assert result["can_manage_permission"] is True
+
+
+@pytest.mark.asyncio
+async def test_ordinary_user_context_still_requires_a_visible_tuple() -> None:
+    from bisheng.common.errcode.permission import PermissionDeniedError
+
+    runtime = _ContextRuntime()
+    api = F048ResourcePermissionApi(
+        resources=_Resources(),
+        runtime=runtime,
+        subjects=_Subjects(),
+    )
+    actor = PermissionActor(user_id=7, current_tenant_id=9)
+
+    with pytest.raises(PermissionDeniedError):
+        await api.get_context(
+            resource_type="workflow",
+            resource_id="wf-1",
+            actor=actor,
+        )
+    assert runtime.visible_checks == 1
+
+
 @pytest.mark.asyncio
 async def test_roster_uses_bounded_sql_page_instead_of_full_explanation() -> None:
     runtime = _Runtime()


### PR DESCRIPTION
…my-permissions

get_context and get_my_permissions gated entry on check_visible, which only consults FGA 'visible' tuples and — unlike check_action — never applies the super-admin / tenant-admin identity shortcut. A super admin (or a tenant admin of the resource's tenant) was therefore denied ('Permission denied') on a resource they can plainly manage, since _can_manage (check_action) would grant them manage_permission.

Wave privileged actors past _require_visible, mirroring the action decision path. Ordinary users still require a real 'visible' relation. check_visible is left unchanged so listing/enumeration stays bounded and is not admin-expanded.

## What

简要描述做了什么改动。

## Why

为什么需要这个改动？

## How

实现方式、设计决策（如有）。

## Test

- [ ] 本地测试通过
- [ ] 114 测试服务器验证通过

## Related

- Issue/ticket:
