### PR TITLE
fix(points): 未登录与系统管理员默认看组织树第一家公司的积分榜

### DIFF
--- a/src/backend/bisheng/points/api/dependencies.py
+++ b/src/backend/bisheng/points/api/dependencies.py
@@ -5,6 +5,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from bisheng.common.dependencies.core_deps import get_db_session
 from bisheng.common.dependencies.user_deps import UserPayload
+from bisheng.common.exceptions.auth import JWTDecodeError
 from bisheng.core.context.tenant import DEFAULT_TENANT_ID, get_current_tenant_id
 from bisheng.message.api.dependencies import get_message_service
 from bisheng.points.domain.repositories.points_repository import PointsRepository
@@ -12,6 +13,7 @@ from bisheng.points.domain.services.points_ledger_service import PointsLedgerSer
 from bisheng.points.domain.services.points_notify_service import PointsNotifyService
 from bisheng.points.domain.services.points_query_service import PointsQueryService
 from bisheng.points.domain.services.points_rule_service import PointsRuleService
+from bisheng.user.domain.services.auth import AuthJwt
 
 
 def get_login_user(user: UserPayload = Depends(UserPayload.get_login_user)) -> UserPayload:
@@ -19,9 +21,18 @@ def get_login_user(user: UserPayload = Depends(UserPayload.get_login_user)) -> U
     return user
 
 
-def resolve_tenant_id(user: UserPayload) -> int:
-    """解析当前请求租户；优先中间件注入的 tenant context。"""
-    return int(get_current_tenant_id() or user.tenant_id or DEFAULT_TENANT_ID)
+async def get_optional_login_user(auth_jwt: AuthJwt = Depends()) -> UserPayload | None:
+    """解析登录用户；无 Cookie / Token 无效时返回 None，供首页公开积分榜使用。"""
+    try:
+        return await UserPayload.get_login_user(auth_jwt)
+    except JWTDecodeError:
+        return None
+
+
+def resolve_tenant_id(user: UserPayload | None = None) -> int:
+    """解析当前请求租户；未登录时用中间件租户或默认租户。"""
+    tenant_from_user = getattr(user, "tenant_id", None) if user is not None else None
+    return int(get_current_tenant_id() or tenant_from_user or DEFAULT_TENANT_ID)
 
 
 async def get_points_repository(

--- a/src/backend/bisheng/points/api/endpoints/me.py
+++ b/src/backend/bisheng/points/api/endpoints/me.py
@@ -8,6 +8,7 @@ from bisheng.common.dependencies.user_deps import UserPayload
 from bisheng.common.errcode.base import BaseErrorCode
 from bisheng.common.schemas.api import resp_200
 from bisheng.points.api.dependencies import (
+    get_optional_login_user,
     get_points_query_service,
     get_points_rule_service,
     resolve_tenant_id,
@@ -90,14 +91,15 @@ async def get_public_rules(
 @router.get("/leaderboard")
 async def get_leaderboard(
     period: str = Query("month", pattern="^(month|year|all)$"),
-    login_user: UserPayload = Depends(UserPayload.get_login_user),
+    login_user: UserPayload | None = Depends(get_optional_login_user),
     service: PointsQueryService = Depends(get_points_query_service),
 ):
-    """读取小时快照排行榜。"""
+    """读取小时快照排行榜。
+
+    未登录与平台系统管理员默认看组织架构第一个公司；普通登录用户看所属公司。
+    """
     try:
-        data = await service.leaderboard(
-            resolve_tenant_id(login_user), period, int(login_user.user_id)
-        )
+        data = await service.leaderboard(resolve_tenant_id(login_user), period, login_user)
         return resp_200(data.model_dump())
     except BaseErrorCode as exc:
         return exc.return_resp_instance()

--- a/src/backend/bisheng/points/domain/services/points_query_service.py
+++ b/src/backend/bisheng/points/domain/services/points_query_service.py
@@ -99,6 +99,24 @@ class PointsQueryService:
         dept_by_id = {int(d.id): d for d in all_depts}
         return resolve_company_id(primary, dept_by_id)
 
+    @staticmethod
+    async def _resolve_first_company_id() -> int | None:
+        """组织架构第一个公司根 id；当前租户无公司标签时返回 None。"""
+        from bisheng.database.models.department import DepartmentDao
+        from bisheng.points.domain.services.points_rank_service import resolve_first_company_id
+
+        all_depts = await DepartmentDao.aget_all_active()
+        dept_by_id = {int(d.id): d for d in all_depts}
+        return resolve_first_company_id(dept_by_id)
+
+    async def _resolve_leaderboard_company_id(self, user) -> int | None:
+        """首页榜公司：访客/平台超管取组织树第一家；普通人取所属公司。"""
+        from bisheng.points.domain.services.points_auth import is_platform_super_admin
+
+        if user is None or is_platform_super_admin(user):
+            return await self._resolve_first_company_id()
+        return await self._resolve_user_company_id(int(user.user_id))
+
     async def my_summary(self, tenant_id: int, user_id: int) -> PointSummaryResponse:
         """余额、当月收支与本公司排名（无公司则排名为 —）。"""
         account = await self.repository.find_account(tenant_id, user_id)
@@ -169,8 +187,12 @@ class PointsQueryService:
         )
         return [self._log_response(r) for r in rows], total
 
-    async def leaderboard(self, tenant_id: int, period: str, user_id: int) -> PointLeaderboardResponse:
-        """读取当前用户所属公司的小时快照前十（算法甲含并列）；无公司则空榜（AC-15）。"""
+    async def leaderboard(self, tenant_id: int, period: str, user=None) -> PointLeaderboardResponse:
+        """读取首页积分榜小时快照前十（算法甲含并列）。
+
+        普通人看所属公司；未登录与平台系统管理员看组织架构第一个公司。
+        解析不到公司则空榜（AC-15）。
+        """
         now = datetime.now(SHANGHAI)
         if period == "year":
             period_key = now.strftime("%Y")
@@ -179,7 +201,12 @@ class PointsQueryService:
         else:
             period = "month"
             period_key = now.strftime("%Y-%m")
-        company_id = await self._resolve_user_company_id(user_id)
+        from bisheng.core.context.tenant import DEFAULT_TENANT_ID, get_current_tenant_id, set_current_tenant_id
+
+        # 访客无 JWT 时中间件可能未注入租户；公开榜按默认租户读部门/快照。
+        if get_current_tenant_id() is None:
+            set_current_tenant_id(int(tenant_id or DEFAULT_TENANT_ID))
+        company_id = await self._resolve_leaderboard_company_id(user)
         refreshed = await self.repository.latest_rank_refreshed_at(tenant_id, period, period_key)
         if company_id is None:
             return PointLeaderboardResponse(period=period, refreshed_at=refreshed, items=[])

--- a/src/backend/bisheng/points/domain/services/points_rank_service.py
+++ b/src/backend/bisheng/points/domain/services/points_rank_service.py
@@ -40,6 +40,15 @@ def year_bounds(now: datetime | None = None) -> tuple[datetime, datetime]:
     return start, end
 
 
+def _department_path_ids(path: str | None) -> list[int]:
+    """从 materialized path 抽出部门 id，例如 ``/1/54/`` → ``[1, 54]``。"""
+    parts: list[int] = []
+    for part in str(path or "").strip("/").split("/"):
+        if part.isdigit():
+            parts.append(int(part))
+    return parts
+
+
 def resolve_company_id(
     primary: Department | None,
     departments: dict[int, Department],
@@ -47,15 +56,39 @@ def resolve_company_id(
     """主部门沿 path 向上找最近 org_level=company；找不到返回 None。"""
     if primary is None or not primary.path:
         return None
-    parts: list[int] = []
-    for part in str(primary.path).strip("/").split("/"):
-        if part.isdigit():
-            parts.append(int(part))
-    for dept_id in reversed(parts):
+    for dept_id in reversed(_department_path_ids(primary.path)):
         node = departments.get(dept_id)
         if node is not None and getattr(node, "org_level", None) == ORG_LEVEL_COMPANY:
             return int(node.id)
     return None
+
+
+def resolve_first_company_id(departments: dict[int, Department]) -> int | None:
+    """组织架构树前序中第一个 ``org_level=company`` 节点。
+
+    同级顺序与部门树一致：``sort_order`` 升序，再按 id。无公司标签时返回 None。
+    用途：未登录访客与平台系统管理员看首页积分榜的默认公司。
+    """
+    companies = [
+        node
+        for node in departments.values()
+        if getattr(node, "org_level", None) == ORG_LEVEL_COMPANY and getattr(node, "id", None) is not None
+    ]
+    if not companies:
+        return None
+
+    def _tree_key(node) -> tuple:
+        key: list[tuple[int, int]] = []
+        for dept_id in _department_path_ids(getattr(node, "path", None)):
+            ancestor = departments.get(dept_id)
+            sort_order = int(getattr(ancestor, "sort_order", 0) or 0) if ancestor is not None else 0
+            key.append((sort_order, dept_id))
+        if not key:
+            key.append((int(getattr(node, "sort_order", 0) or 0), int(node.id)))
+        return tuple(key)
+
+    companies.sort(key=_tree_key)
+    return int(companies[0].id)
 
 
 def resolve_dept_bucket_id(

--- a/src/backend/test/points/test_points_leaderboard.py
+++ b/src/backend/test/points/test_points_leaderboard.py
@@ -1,3 +1,4 @@
+# ruff: noqa: RUF002
 """排行榜读路径：按当前用户公司隔离 + 展示字段补齐。"""
 
 from types import SimpleNamespace
@@ -6,6 +7,17 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from bisheng.points.domain.services.points_query_service import PointsQueryService
+from bisheng.user.domain.models.user import UserDao
+
+
+def _user(user_id: int = 10, *, admin: bool = False, global_super: bool = False):
+    """构造排行榜调用方身份。"""
+    return SimpleNamespace(
+        user_id=user_id,
+        tenant_id=1,
+        is_admin=lambda: admin,
+        is_global_super=global_super,
+    )
 
 
 @pytest.mark.asyncio
@@ -29,7 +41,7 @@ async def test_leaderboard_enriches_user_and_dept_names():
             AsyncMock(return_value=({10: "张三"}, {10: "炼铁作业部"})),
         ),
     ):
-        out = await service.leaderboard(1, "month", user_id=10)
+        out = await service.leaderboard(1, "month", user=_user(10))
 
     assert out.period == "month"
     assert len(out.items) == 1
@@ -53,7 +65,7 @@ async def test_leaderboard_empty_when_user_has_no_company():
         "_resolve_user_company_id",
         AsyncMock(return_value=None),
     ):
-        out = await service.leaderboard(1, "month", user_id=10)
+        out = await service.leaderboard(1, "month", user=_user(10))
 
     assert out.items == []
     repo.list_top_ranks.assert_not_awaited()
@@ -69,8 +81,9 @@ async def test_display_maps_uses_org_level_dept_not_leaf():
     squad = SimpleNamespace(id=67, path="/1/54/55/58/67/", name="四级积分部门1", org_level="squad", short_name=None)
 
     with (
-        patch(
-            "bisheng.user.domain.models.user.UserDao.aget_user_by_ids",
+        patch.object(
+            UserDao,
+            "aget_user_by_ids",
             AsyncMock(return_value=[SimpleNamespace(user_id=423, user_name="gzx01204")]),
         ),
         patch(
@@ -95,8 +108,9 @@ async def test_display_maps_omits_dept_when_no_org_level_dept():
     root = SimpleNamespace(id=1, path="/1/", name="默认组织", org_level=None, short_name=None)
 
     with (
-        patch(
-            "bisheng.user.domain.models.user.UserDao.aget_user_by_ids",
+        patch.object(
+            UserDao,
+            "aget_user_by_ids",
             AsyncMock(return_value=[SimpleNamespace(user_id=7, user_name="nobody")]),
         ),
         patch(
@@ -122,8 +136,9 @@ async def test_display_maps_prefers_short_name_for_dept_bucket():
     company = SimpleNamespace(id=54, path="/1/54/", name="公司", org_level="company", short_name=None)
 
     with (
-        patch(
-            "bisheng.user.domain.models.user.UserDao.aget_user_by_ids",
+        patch.object(
+            UserDao,
+            "aget_user_by_ids",
             AsyncMock(return_value=[SimpleNamespace(user_id=423, user_name="gzx")]),
         ),
         patch(
@@ -167,7 +182,83 @@ async def test_leaderboard_keeps_all_ties_at_tenth_score():
             AsyncMock(return_value=({i: str(i) for i in range(1, 13)}, dict.fromkeys(range(1, 13), "部"))),
         ),
     ):
-        out = await service.leaderboard(1, "month", user_id=1)
+        out = await service.leaderboard(1, "month", user=_user(1))
 
     assert len(out.items) == 12
     assert [item.user_id for item in out.items] == list(range(1, 13))
+
+
+@pytest.mark.asyncio
+async def test_leaderboard_guest_uses_first_company():
+    """未登录：默认取组织架构第一个公司的快照。"""
+    repo = SimpleNamespace(
+        list_top_ranks=AsyncMock(
+            return_value=[SimpleNamespace(rank_no=1, user_id=10, balance=100, period_score=40, dept_id=2)]
+        ),
+        latest_rank_refreshed_at=AsyncMock(return_value=None),
+    )
+    service = PointsQueryService(session=None, repository=repo, ledger=None)
+    with (
+        patch.object(PointsQueryService, "_resolve_first_company_id", AsyncMock(return_value=54)),
+        patch.object(
+            PointsQueryService,
+            "_resolve_user_company_id",
+            AsyncMock(return_value=99),
+        ) as resolve_own,
+        patch.object(
+            PointsQueryService,
+            "_leaderboard_display_maps",
+            AsyncMock(return_value=({10: "张三"}, {10: "炼铁作业部"})),
+        ),
+    ):
+        out = await service.leaderboard(1, "month", user=None)
+        resolve_own.assert_not_awaited()
+
+    assert len(out.items) == 1
+    repo.list_top_ranks.assert_awaited_once()
+    assert repo.list_top_ranks.await_args.args[3] == 54
+
+
+@pytest.mark.asyncio
+async def test_leaderboard_platform_admin_uses_first_company_not_own():
+    """平台系统管理员：即使自己有公司，首页榜仍取组织架构第一个公司。"""
+    repo = SimpleNamespace(
+        list_top_ranks=AsyncMock(
+            return_value=[SimpleNamespace(rank_no=1, user_id=10, balance=100, period_score=40, dept_id=2)]
+        ),
+        latest_rank_refreshed_at=AsyncMock(return_value=None),
+    )
+    service = PointsQueryService(session=None, repository=repo, ledger=None)
+    with (
+        patch.object(PointsQueryService, "_resolve_first_company_id", AsyncMock(return_value=54)),
+        patch.object(
+            PointsQueryService,
+            "_resolve_user_company_id",
+            AsyncMock(return_value=88),
+        ) as resolve_own,
+        patch.object(
+            PointsQueryService,
+            "_leaderboard_display_maps",
+            AsyncMock(return_value=({10: "张三"}, {10: "炼铁作业部"})),
+        ),
+    ):
+        out = await service.leaderboard(1, "month", user=_user(1, admin=True))
+        resolve_own.assert_not_awaited()
+
+    assert len(out.items) == 1
+    assert repo.list_top_ranks.await_args.args[3] == 54
+
+
+@pytest.mark.asyncio
+async def test_leaderboard_guest_empty_when_no_company_nodes():
+    """租户没有公司标签时，访客看到空榜且不查 TOP。"""
+    repo = SimpleNamespace(
+        list_top_ranks=AsyncMock(return_value=[]),
+        latest_rank_refreshed_at=AsyncMock(return_value=None),
+    )
+    service = PointsQueryService(session=None, repository=repo, ledger=None)
+    with patch.object(PointsQueryService, "_resolve_first_company_id", AsyncMock(return_value=None)):
+        out = await service.leaderboard(1, "month", user=None)
+
+    assert out.items == []
+    repo.list_top_ranks.assert_not_awaited()

--- a/src/backend/test/points/test_points_leaderboard_api.py
+++ b/src/backend/test/points/test_points_leaderboard_api.py
@@ -1,0 +1,85 @@
+# ruff: noqa: RUF002
+"""首页积分榜 HTTP：未登录可读，且走查询服务（公司解析在 domain 单测覆盖）。"""
+
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from bisheng.points.api.dependencies import get_optional_login_user, get_points_query_service
+from bisheng.points.api.router import router
+from bisheng.points.domain.schemas.points_schema import PointLeaderboardItem, PointLeaderboardResponse
+
+
+def _app(*, user, service):
+    """只挂积分路由，覆盖可选登录与查询服务。"""
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1")
+    app.dependency_overrides[get_optional_login_user] = lambda: user
+    app.dependency_overrides[get_points_query_service] = lambda: service
+    return app
+
+
+def _service(*, company_id: int | None):
+    """记录 leaderboard 入参，返回固定一条榜。"""
+    calls: list[tuple] = []
+    items = []
+    if company_id is not None:
+        items = [
+            PointLeaderboardItem(
+                rank=1,
+                user_id=10,
+                user_name="张三",
+                dept_name="炼铁作业部",
+                balance=100,
+                period_score=40,
+            )
+        ]
+
+    async def leaderboard(tenant_id, period, user):
+        calls.append((tenant_id, period, user))
+        return PointLeaderboardResponse(period=period, refreshed_at=None, items=items)
+
+    return SimpleNamespace(leaderboard=leaderboard, calls=calls)
+
+
+def test_guest_get_leaderboard_ok_without_login():
+    """未登录 GET 积分榜：HTTP 200，且把 user=None 交给查询服务。"""
+    svc = _service(company_id=54)
+    client = TestClient(_app(user=None, service=svc))
+    resp = client.get("/api/v1/points/leaderboard?period=month")
+    body = resp.json()
+    assert resp.status_code == 200, body
+    assert body.get("status_code") == 200
+    data = body.get("data") or {}
+    assert data.get("period") == "month"
+    assert len(data.get("items") or []) == 1
+    assert (data["items"][0] or {}).get("user_name") == "张三"
+    assert svc.calls[0][2] is None
+    again = client.get("/api/v1/points/leaderboard?period=month")
+    assert again.json()["status_code"] == 200
+    assert len((again.json().get("data") or {}).get("items") or []) == 1
+
+
+def test_admin_get_leaderboard_passes_login_user():
+    """平台超管 GET 积分榜：仍 200，身份原样传给查询服务（公司解析在 domain）。"""
+    admin = SimpleNamespace(user_id=1, tenant_id=1, is_admin=lambda: True, is_global_super=True)
+    svc = _service(company_id=54)
+    client = TestClient(_app(user=admin, service=svc))
+    resp = client.get("/api/v1/points/leaderboard")
+    body = resp.json()
+    assert resp.status_code == 200, body
+    assert body.get("status_code") == 200
+    assert svc.calls[0][2] is admin
+
+
+def test_guest_leaderboard_empty_items_when_service_empty():
+    """无公司节点时接口仍 200，items 为空，再读仍空。"""
+    svc = _service(company_id=None)
+    client = TestClient(_app(user=None, service=svc))
+    resp = client.get("/api/v1/points/leaderboard")
+    body = resp.json()
+    assert body.get("status_code") == 200
+    assert (body.get("data") or {}).get("items") == []
+    again = client.get("/api/v1/points/leaderboard")
+    assert (again.json().get("data") or {}).get("items") == []

--- a/src/backend/test/points/test_points_rank_service.py
+++ b/src/backend/test/points/test_points_rank_service.py
@@ -1,3 +1,4 @@
+# ruff: noqa: RUF002
 """积分排行快照：周期键、公司/部门桶解析、稠密名次与按公司刷榜。"""
 
 from datetime import datetime
@@ -13,6 +14,7 @@ from bisheng.points.domain.services.points_rank_service import (
     period_keys,
     resolve_company_id,
     resolve_dept_bucket_id,
+    resolve_first_company_id,
     select_top_n_with_score_ties,
 )
 
@@ -39,6 +41,20 @@ def test_resolve_company_id_none_when_unlabeled():
     primary = SimpleNamespace(id=9, path="/9/")
     assert resolve_company_id(primary, departments) is None
     assert resolve_company_id(None, departments) is None
+
+
+def test_resolve_first_company_id_follows_org_tree_sort_order():
+    """同级按 sort_order：sort 更小的公司是组织架构第一个公司。"""
+    root = SimpleNamespace(id=1, path="/1/", org_level=None, sort_order=0)
+    later = SimpleNamespace(id=10, path="/1/10/", org_level="company", sort_order=2)
+    first = SimpleNamespace(id=20, path="/1/20/", org_level="company", sort_order=0)
+    departments = {1: root, 10: later, 20: first}
+    assert resolve_first_company_id(departments) == 20
+
+
+def test_resolve_first_company_id_none_when_unlabeled():
+    leaf = SimpleNamespace(id=9, path="/9/", org_level=None, sort_order=0)
+    assert resolve_first_company_id({9: leaf}) is None
 
 
 def test_resolve_dept_bucket_walks_path_to_nearest_dept():


### PR DESCRIPTION
## Summary
- `GET /api/v1/points/leaderboard` 允许未登录访问；访客与平台系统管理员默认读取组织架构第一个 `org_level=company` 的小时快照。
- 普通登录用户仍看自己所属公司；无公司节点时保持空榜。`/me/*` 等接口仍需登录。

## Test plan
- [ ] 退出登录打开门户首页：积分榜不再报加载失败，展示第一家公司榜单
- [ ] 用平台系统管理员登录首页：看到同一家公司榜，而不是空榜
- [ ] 普通用户登录：仍看自己所属公司
- [ ] `uv run pytest test/points/test_points_leaderboard.py test/points/test_points_rank_service.py test/points/test_points_leaderboard_api.py`


Made with [Cursor](https://cursor.com)