### PR TITLE
feat(points): 用户积分部门筛选项改为公司→部门两级

### DIFF
--- a/src/backend/bisheng/points/domain/schemas/points_schema.py
+++ b/src/backend/bisheng/points/domain/schemas/points_schema.py
@@ -97,10 +97,15 @@ class PointAdminUserItem(BaseModel):
 
 
 class PointAdminDepartmentOption(BaseModel):
-    """用户积分列表部门筛选项。"""
+    """用户积分列表部门筛选项（仅公司 / 部门两级）。"""
 
     id: int
     name: str
+    org_level: str = Field(description="company 或 dept")
+    parent_id: int | None = Field(
+        default=None,
+        description="部门所属公司 id；公司节点为 null",
+    )
 
 
 class PointAdminUserFilterOptions(BaseModel):

--- a/src/backend/bisheng/points/domain/services/points_query_service.py
+++ b/src/backend/bisheng/points/domain/services/points_query_service.py
@@ -296,19 +296,50 @@ class PointsQueryService:
             logger.warning("points.overview cache write failed key=%s", key, exc_info=True)
 
     async def admin_user_filter_options(self, user: UserPayload) -> PointAdminUserFilterOptions:
-        """用户积分列表筛选项：部门树扁平列表 + PRD 四类角色。"""
+        """用户积分列表筛选项：公司→部门两级 + PRD 四类角色。
+
+        仅返回 org_level 为 company / dept 的活跃节点；科室/班组与未打标不进入下拉。
+        """
         require_platform_admin(user)
         from bisheng.database.models.department import DepartmentDao
         from bisheng.department.domain.services.department_display_service import get_department_display_name
         from bisheng.points.domain.constants.admin_user_type import USER_TYPE_FILTER_OPTIONS
+        from bisheng.points.domain.constants.org_levels import ORG_LEVEL_COMPANY
 
-        departments: list[PointAdminDepartmentOption] = []
-        for row in await DepartmentDao.aget_all_active():
+        rows = await DepartmentDao.aget_all_active()
+        companies: list[PointAdminDepartmentOption] = []
+        depts: list[PointAdminDepartmentOption] = []
+        company_ids: set[int] = set()
+        for row in rows:
+            level = getattr(row, "org_level", None)
+            if level not in (ORG_LEVEL_COMPANY, "dept"):
+                continue
             name = get_department_display_name(row.name, getattr(row, "short_name", None))
-            departments.append(PointAdminDepartmentOption(id=int(row.id), name=name))
-        departments.sort(key=lambda item: item.name)
+            item = PointAdminDepartmentOption(
+                id=int(row.id),
+                name=name,
+                org_level=str(level),
+                parent_id=None
+                if level == ORG_LEVEL_COMPANY
+                else (int(row.parent_id) if row.parent_id is not None else None),
+            )
+            if level == ORG_LEVEL_COMPANY:
+                companies.append(item)
+                company_ids.add(int(row.id))
+            else:
+                depts.append(item)
+
+        # 部门必须挂在已知公司下；孤儿 dept（parent 不是公司）剔除，避免破坏两级展示。
+        depts = [d for d in depts if d.parent_id is not None and d.parent_id in company_ids]
+        companies.sort(key=lambda item: item.name)
+        depts.sort(key=lambda item: (item.parent_id or 0, item.name))
+        # 扁平输出：公司在前，其后各部门（FE 按 parent_id 分组）；保持稳定顺序便于测试。
+        ordered: list[PointAdminDepartmentOption] = []
+        for company in companies:
+            ordered.append(company)
+            ordered.extend(d for d in depts if d.parent_id == company.id)
         return PointAdminUserFilterOptions(
-            departments=departments,
+            departments=ordered,
             user_types=list(USER_TYPE_FILTER_OPTIONS),
         )
 

--- a/src/backend/test/points/test_points_admin_lists.py
+++ b/src/backend/test/points/test_points_admin_lists.py
@@ -80,18 +80,26 @@ async def test_admin_list_users_intersects_dept_and_user_type_filters():
 
 
 @pytest.mark.asyncio
-async def test_admin_user_filter_options_returns_departments_and_roles():
+async def test_admin_user_filter_options_returns_company_dept_hierarchy():
+    """筛选项仅公司→部门两级；科室/未打标剔除。"""
     service = PointsQueryService(session=None, repository=SimpleNamespace(), ledger=None)
-    fake_dept = SimpleNamespace(id=3, name="研发部", short_name=None)
+    company = SimpleNamespace(id=1, name="首钢股份", short_name=None, org_level="company", parent_id=None)
+    dept = SimpleNamespace(id=10, name="技术部", short_name="技术", org_level="dept", parent_id=1)
+    office = SimpleNamespace(id=11, name="研发科", short_name=None, org_level="office", parent_id=10)
+    unlabeled = SimpleNamespace(id=99, name="未打标", short_name=None, org_level=None, parent_id=1)
     with patch(
         "bisheng.database.models.department.DepartmentDao.aget_all_active",
-        AsyncMock(return_value=[fake_dept]),
+        AsyncMock(return_value=[office, dept, unlabeled, company]),
     ):
         out = await service.admin_user_filter_options(
             SimpleNamespace(is_admin=lambda: True, is_global_super=True),
         )
-    assert out.departments[0].id == 3
-    assert out.departments[0].name == "研发部"
+    assert [item.org_level for item in out.departments] == ["company", "dept"]
+    assert out.departments[0].id == 1
+    assert out.departments[0].parent_id is None
+    assert out.departments[1].id == 10
+    assert out.departments[1].parent_id == 1
+    assert out.departments[1].name == "技术"  # short_name 优先展示
     assert "普通用户" in out.user_types
     assert "公共库管理员" in out.user_types
 


### PR DESCRIPTION
## Summary
- `GET /api/v1/points/admin/users/filter-options` 仅返回 `org_level=company/dept`，并带 `parent_id`
- 科室/班组/未打标不进入下拉；列表 `dept_id` 过滤语义不变（精确主部门）
- 配套单测覆盖两级结构

## Test plan
- [ ] `cd src/backend && ./.venv/bin/python -m pytest test/points/test_points_admin_lists.py -q`
- [ ] 与门户 PR 联调：筛选项接口返回公司→部门，选部门后列表按 `dept_id` 过滤

## Merge conflicts（需确认后再解）
相对 `feat/2.5.0-sg`，下列文件双方都改过：
- `points_schema.py`（对方有 `total_issued_mom` 等；本 PR 扩展部门选项字段）
- `points_query_service.py`（对方另有查询改动；本 PR 改 `admin_user_filter_options`）
- `test_points_admin_lists.py`

建议：手工合并两边改动，保留对方 overview/mom 相关 + 本 PR 的公司→部门筛选项。


Made with [Cursor](https://cursor.com)