### PR TITLE
fix(knowledge): 图片 PDF 下载水印改用描边增强可见性

### DIFF
--- a/src/backend/bisheng/knowledge/pdf/watermark.py
+++ b/src/backend/bisheng/knowledge/pdf/watermark.py
@@ -96,10 +96,7 @@ def _calculate_watermark_layout(
     block_height = line_height * len(spec.lines)
     try:
         measurement_font = fitz.Font(fontfile=font.font_file, fontname=font.font_name)
-        text_width = max(
-            measurement_font.text_length(line, fontsize=font_size)
-            for line in spec.lines
-        )
+        text_width = max(measurement_font.text_length(line, fontsize=font_size) for line in spec.lines)
     except Exception as exc:
         raise PdfWatermarkError("CJK watermark font cannot measure text") from exc
 
@@ -148,6 +145,64 @@ def _tile_positions(page_rect: fitz.Rect, layout: _WatermarkLayout) -> list[fitz
     return positions
 
 
+# 图片页（照片/扫件）上单层浅灰半透明字对比度不足，需白底+深色双描提高可见性。
+_IMAGE_PAGE_COVERAGE_RATIO = 0.45
+_IMAGE_PAGE_HALO_COLOR = (1.0, 1.0, 1.0)
+_IMAGE_PAGE_HALO_OPACITY = 0.55
+_IMAGE_PAGE_FOREGROUND_COLOR = (0.15, 0.15, 0.15)
+_IMAGE_PAGE_FOREGROUND_OPACITY = 0.5
+
+
+def _page_image_coverage_ratio(page: fitz.Page) -> float:
+    """估算页面被位图覆盖的面积占比（用于识别图片主导页）。"""
+    page_area = abs(float(page.rect.width) * float(page.rect.height))
+    if page_area <= 0:
+        return 0.0
+    covered = 0.0
+    for image in page.get_images(full=True):
+        xref = int(image[0])
+        try:
+            rects = page.get_image_rects(xref)
+        except Exception:
+            rects = []
+        for rect in rects:
+            covered += abs(float(rect.width) * float(rect.height))
+    return min(covered / page_area, 1.0)
+
+
+def _page_is_image_dominated(page: fitz.Page) -> bool:
+    """
+    判断是否为图片主导页（如 Pillow 转 PDF 的整页图）。
+
+    文档页保持原有单层浅灰水印；图片页改用描边增强，避免「能下但看不见水印」。
+    """
+    return _page_image_coverage_ratio(page) >= _IMAGE_PAGE_COVERAGE_RATIO
+
+
+def _insert_watermark_line(
+    page: fitz.Page,
+    *,
+    point: fitz.Point,
+    line: str,
+    font: _FontSelection,
+    font_size: float,
+    color: tuple[float, float, float],
+    opacity: float,
+    rotation_matrix: fitz.Matrix,
+) -> None:
+    kwargs = {
+        "fontsize": font_size,
+        "fontname": font.font_name,
+        "color": color,
+        "fill_opacity": opacity,
+        "morph": (point, rotation_matrix),
+        "overlay": True,
+    }
+    if font.font_file:
+        kwargs["fontfile"] = font.font_file
+    page.insert_text(point, line, **kwargs)
+
+
 def _apply_page_watermark(
     page: fitz.Page,
     spec: PdfWatermarkSpec,
@@ -155,20 +210,43 @@ def _apply_page_watermark(
 ) -> None:
     layout = _calculate_watermark_layout(page.rect, spec, font)
     rotation_matrix = fitz.Matrix(spec.rotation)
+    image_dominated = _page_is_image_dominated(page)
     for anchor in _tile_positions(page.rect, layout):
         for line_index, line in enumerate(spec.lines):
             point = fitz.Point(anchor.x, anchor.y + line_index * layout.line_height)
-            kwargs = {
-                "fontsize": layout.font_size,
-                "fontname": font.font_name,
-                "color": spec.color,
-                "fill_opacity": spec.opacity,
-                "morph": (point, rotation_matrix),
-                "overlay": True,
-            }
-            if font.font_file:
-                kwargs["fontfile"] = font.font_file
-            page.insert_text(point, line, **kwargs)
+            if image_dominated:
+                # 先铺浅色底，再叠深色字，保证深色/纹理照片上仍可读。
+                _insert_watermark_line(
+                    page,
+                    point=point,
+                    line=line,
+                    font=font,
+                    font_size=layout.font_size,
+                    color=_IMAGE_PAGE_HALO_COLOR,
+                    opacity=_IMAGE_PAGE_HALO_OPACITY,
+                    rotation_matrix=rotation_matrix,
+                )
+                _insert_watermark_line(
+                    page,
+                    point=point,
+                    line=line,
+                    font=font,
+                    font_size=layout.font_size,
+                    color=_IMAGE_PAGE_FOREGROUND_COLOR,
+                    opacity=_IMAGE_PAGE_FOREGROUND_OPACITY,
+                    rotation_matrix=rotation_matrix,
+                )
+                continue
+            _insert_watermark_line(
+                page,
+                point=point,
+                line=line,
+                font=font,
+                font_size=layout.font_size,
+                color=spec.color,
+                opacity=spec.opacity,
+                rotation_matrix=rotation_matrix,
+            )
 
 
 def apply_pdf_watermark(

--- a/src/backend/test/knowledge/pdf/test_pdf_watermark.py
+++ b/src/backend/test/knowledge/pdf/test_pdf_watermark.py
@@ -108,6 +108,51 @@ def test_watermark_uses_chinese_text_opacity_and_arbitrary_angle(tmp_path: Path)
         assert all(trace["opacity"] == pytest.approx(0.31) for trace in watermark_traces)
 
 
+def _create_image_source(path: Path, *, color: tuple[int, int, int] = (40, 80, 40)) -> None:
+    """用 Pillow 整页图生成源 PDF，模拟门户图片下载转 PDF 产物。"""
+    from PIL import Image
+
+    image_path = path.with_suffix(".png")
+    Image.new("RGB", (1000, 750), color=color).save(image_path)
+    with Image.open(image_path) as image:
+        image.save(path, "PDF", resolution=150.0)
+
+
+def test_watermark_is_visually_contrastive_on_image_pdf(tmp_path: Path) -> None:
+    """图片主导页须使用描边增强，渲染后相对原图应有足够色差（避免「能下无水印」）。"""
+    source = tmp_path / "image-source.pdf"
+    output = tmp_path / "image-watermarked.pdf"
+    _create_image_source(source, color=(40, 80, 40))
+
+    with fitz.open(source) as original:
+        before = original.load_page(0).get_pixmap()
+    apply_pdf_watermark(source, output, _spec())
+
+    with fitz.open(output) as watermarked:
+        page = watermarked.load_page(0)
+        after = page.get_pixmap()
+        text = page.get_text()
+        assert "设备管理部-张三-SG001-2026/07/21" in text
+        assert "首钢股份内部资料，严禁外传，违者必究" in text  # noqa: RUF001
+        # 图片页双描：白底 + 深色字，同一文案至少出现两层
+        assert text.count("设备管理部-张三-SG001-2026/07/21") >= 4
+
+    assert before.width == after.width and before.height == after.height
+    max_delta = 0
+    changed = 0
+    for y in range(after.height):
+        for x in range(after.width):
+            before_pixel = before.pixel(x, y)
+            after_pixel = after.pixel(x, y)
+            delta = max(abs(after_pixel[i] - before_pixel[i]) for i in range(3))
+            if delta:
+                changed += 1
+            if delta > max_delta:
+                max_delta = delta
+    assert changed > 0
+    assert max_delta >= 40
+
+
 def test_watermark_spec_uses_two_lines_and_pdf_visual_baseline() -> None:
     spec = _spec()
 


### PR DESCRIPTION
## Summary
- 根因：图片转 PDF 后整页位图上，原浅灰 + 0.31 透明度水印几乎不可见（色差约 20/255），表现为「能下、无水印」
- 对图片主导页改为白底 + 深色字双描；普通文档页保持原水印样式
- 补充图片 PDF 渲染对比度断言

## Test plan
- [ ] `cd src/backend && ./.venv/bin/python -m pytest test/knowledge/pdf/test_pdf_watermark.py -q`
- [ ] 专家问答关联文档打开图片详情 → 下载 PDF，肉眼可见水印
- [ ] 普通 PDF/Office 下载水印观感与改前一致


Made with [Cursor](https://cursor.com)