### PR TITLE
feat(points): 规则 display_name 与默认 name 分离

### DIFF
--- a/src/backend/bisheng/core/database/alembic/versions/v2_6_0_f092_merge_points_display_name_heads.py
+++ b/src/backend/bisheng/core/database/alembic/versions/v2_6_0_f092_merge_points_display_name_heads.py
@@ -1,0 +1,27 @@
+# ruff: noqa: RUF002
+"""合并积分展示名与专家问答迁移 head，并为 point_rule 增加 display_name。
+
+Revision ID: f092_merge_points_display_name_heads
+Revises: f090_points_rule_display_names, f091_qa_expert_beijing_datetime
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+revision: str = "f092_merge_points_display_name_heads"
+down_revision: str | Sequence[str] | None = (
+    "f090_points_rule_display_names",
+    "f091_qa_expert_beijing_datetime",
+)
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """空合并 revision，仅收口双 head。"""
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/src/backend/bisheng/core/database/alembic/versions/v2_6_0_f093_point_rule_display_name.py
+++ b/src/backend/bisheng/core/database/alembic/versions/v2_6_0_f093_point_rule_display_name.py
@@ -1,0 +1,63 @@
+# ruff: noqa: RUF002
+"""point_rule 增加 display_name：默认名 name 只读，展示名可运营修改。
+
+Revision ID: f093_point_rule_display_name
+Revises: f092_merge_points_display_name_heads
+
+存量：display_name 先复制当前 name；再将 name 写回种子默认名（按 rule_code）。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+from bisheng.core.database.dialect_helpers import column_exists, table_exists
+from bisheng.points.domain.constants.seed_rules import SEED_RULES
+
+revision: str = "f093_point_rule_display_name"
+down_revision: str | Sequence[str] | None = "f092_merge_points_display_name_heads"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if not table_exists(bind, "point_rule"):
+        return
+    if not column_exists(bind, "point_rule", "display_name"):
+        op.add_column(
+            "point_rule",
+            sa.Column(
+                "display_name",
+                sa.String(40),
+                nullable=True,
+                comment="积分项展示名称（运营可改，列表与流水展示）",
+            ),
+        )
+        bind.execute(sa.text("UPDATE point_rule SET display_name = name WHERE display_name IS NULL"))
+        for rule in SEED_RULES:
+            bind.execute(
+                sa.text("UPDATE point_rule SET name = :default_name WHERE rule_code = :code"),
+                {"default_name": rule["name"], "code": rule["rule_code"]},
+            )
+        op.alter_column("point_rule", "display_name", existing_type=sa.String(40), nullable=False)
+    if column_exists(bind, "point_rule", "name"):
+        try:
+            op.alter_column(
+                "point_rule",
+                "name",
+                existing_type=sa.String(40),
+                nullable=False,
+                comment="积分项默认名称（系统内置，运营不可改）",
+            )
+        except Exception:
+            pass
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if table_exists(bind, "point_rule") and column_exists(bind, "point_rule", "display_name"):
+        op.drop_column("point_rule", "display_name")

--- a/src/backend/bisheng/points/domain/constants/rule_display_name.py
+++ b/src/backend/bisheng/points/domain/constants/rule_display_name.py
@@ -1,0 +1,20 @@
+"""积分规则展示名解析（默认名 vs 运营可改展示名）。"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class PointRuleNameSource(Protocol):
+    rule_code: str
+    name: str
+    display_name: str | None
+
+
+def resolve_point_rule_display_name(rule: PointRuleNameSource) -> str:
+    """返回用户可见规则名：优先 ``display_name``，否则回退 ``name`` / ``rule_code``。"""
+    for candidate in (getattr(rule, "display_name", None), rule.name, rule.rule_code):
+        text = str(candidate or "").strip()
+        if text:
+            return text
+    return str(rule.rule_code or "").strip()

--- a/src/backend/bisheng/points/domain/constants/seed_rules.py
+++ b/src/backend/bisheng/points/domain/constants/seed_rules.py
@@ -205,9 +205,21 @@ SEED_RULES = [
 ]
 
 # 系统默认启用的编码（便于迁移/脚本对齐）。
-DEFAULT_ENABLED_RULE_CODES = frozenset(
-    {"G1", "G2", "G3", "G4", "R1", "R2", "R3", "M1", "M4", "M6"}
-)
+DEFAULT_ENABLED_RULE_CODES = frozenset({"G1", "G2", "G3", "G4", "R1", "R2", "R3", "M1", "M4", "M6"})
+
+# 种子入库时展示名与默认名一致；运营后续只改 display_name。
+for _seed in SEED_RULES:
+    _seed["display_name"] = _seed["name"]
+
+
+def seed_default_name(rule_code: str) -> str | None:
+    """按规则编码取种子默认名；未知编码返回 None。"""
+    code = (rule_code or "").strip().upper()
+    for row in SEED_RULES:
+        if row["rule_code"] == code:
+            return str(row["name"])
+    return None
+
 
 # Single rich-text guide for the public rules modal (Portal admin edits `guide` only).
 SEED_COPIES = [

--- a/src/backend/bisheng/points/domain/models/points.py
+++ b/src/backend/bisheng/points/domain/models/points.py
@@ -22,36 +22,24 @@ class UserPointAccount(SQLModelSerializable, table=True):
     )
     tenant_id: int = Field(
         default=1,
-        sa_column=Column(
-            Integer, nullable=False, server_default=text("1"), comment="租户ID"
-        ),
+        sa_column=Column(Integer, nullable=False, server_default=text("1"), comment="租户ID"),
     )
-    user_id: int = Field(
-        sa_column=Column(Integer, nullable=False, comment="用户ID")
-    )
+    user_id: int = Field(sa_column=Column(Integer, nullable=False, comment="用户ID"))
     balance: int = Field(
         default=0,
-        sa_column=Column(
-            Integer, nullable=False, server_default=text("0"), comment="当前积分余额（可为负）"
-        ),
+        sa_column=Column(Integer, nullable=False, server_default=text("0"), comment="当前积分余额（可为负）"),
     )
     lifetime_earned: int = Field(
         default=0,
-        sa_column=Column(
-            Integer, nullable=False, server_default=text("0"), comment="累计获得积分"
-        ),
+        sa_column=Column(Integer, nullable=False, server_default=text("0"), comment="累计获得积分"),
     )
     lifetime_deducted: int = Field(
         default=0,
-        sa_column=Column(
-            Integer, nullable=False, server_default=text("0"), comment="累计扣减积分（绝对值合计）"
-        ),
+        sa_column=Column(Integer, nullable=False, server_default=text("0"), comment="累计扣减积分（绝对值合计）"),
     )
     version: int = Field(
         default=0,
-        sa_column=Column(
-            Integer, nullable=False, server_default=text("0"), comment="乐观锁版本号"
-        ),
+        sa_column=Column(Integer, nullable=False, server_default=text("0"), comment="乐观锁版本号"),
     )
     create_time: datetime | None = Field(
         default=None,
@@ -95,31 +83,17 @@ class UserPointLog(SQLModelSerializable, table=True):
     )
     tenant_id: int = Field(
         default=1,
-        sa_column=Column(
-            Integer, nullable=False, server_default=text("1"), comment="租户ID"
-        ),
+        sa_column=Column(Integer, nullable=False, server_default=text("1"), comment="租户ID"),
     )
-    user_id: int = Field(
-        sa_column=Column(Integer, nullable=False, comment="用户ID")
-    )
-    delta: int = Field(
-        sa_column=Column(Integer, nullable=False, comment="本次变动分值（正为获得，负为扣减）")
-    )
-    balance_after: int = Field(
-        sa_column=Column(Integer, nullable=False, comment="变动后余额")
-    )
-    direction: str = Field(
-        sa_column=Column(
-            String(16), nullable=False, comment="变动方向：earn/deduct 等"
-        )
-    )
+    user_id: int = Field(sa_column=Column(Integer, nullable=False, comment="用户ID"))
+    delta: int = Field(sa_column=Column(Integer, nullable=False, comment="本次变动分值（正为获得，负为扣减）"))
+    balance_after: int = Field(sa_column=Column(Integer, nullable=False, comment="变动后余额"))
+    direction: str = Field(sa_column=Column(String(16), nullable=False, comment="变动方向：earn/deduct 等"))
     rule_code: str | None = Field(
         default=None,
         sa_column=Column(String(32), comment="规则编码，如 G1/R1/M1"),
     )
-    title: str = Field(
-        sa_column=Column(String(64), nullable=False, comment="流水标题（展示用）")
-    )
+    title: str = Field(sa_column=Column(String(64), nullable=False, comment="流水标题（展示用）"))
     source: str = Field(
         sa_column=Column(
             String(32),
@@ -135,9 +109,7 @@ class UserPointLog(SQLModelSerializable, table=True):
         default=None,
         sa_column=Column(String(64), comment="业务主键（字符串）"),
     )
-    idempotency_key: str = Field(
-        sa_column=Column(String(128), nullable=False, comment="幂等键，租户内唯一")
-    )
+    idempotency_key: str = Field(sa_column=Column(String(128), nullable=False, comment="幂等键，租户内唯一"))
     operator_id: int | None = Field(
         default=None,
         sa_column=Column(Integer, comment="操作人用户ID（人工调分/扣分时）"),
@@ -192,13 +164,9 @@ class PointRule(SQLModelSerializable, table=True):
     )
     tenant_id: int = Field(
         default=1,
-        sa_column=Column(
-            Integer, nullable=False, server_default=text("1"), comment="租户ID"
-        ),
+        sa_column=Column(Integer, nullable=False, server_default=text("1"), comment="租户ID"),
     )
-    rule_code: str = Field(
-        sa_column=Column(String(16), nullable=False, comment="规则编码，如 G1/R1/M1")
-    )
+    rule_code: str = Field(sa_column=Column(String(16), nullable=False, comment="规则编码，如 G1/R1/M1"))
     rule_type: str = Field(
         sa_column=Column(
             String(32),
@@ -206,8 +174,9 @@ class PointRule(SQLModelSerializable, table=True):
             comment="规则类型：earn/deduct/admin_reward",
         )
     )
-    name: str = Field(
-        sa_column=Column(String(40), nullable=False, comment="规则名称")
+    name: str = Field(sa_column=Column(String(40), nullable=False, comment="积分项默认名称（系统内置，运营不可改）"))
+    display_name: str = Field(
+        sa_column=Column(String(40), nullable=False, comment="积分项展示名称（运营可改，列表与流水展示）")
     )
     score_expr: dict = Field(
         default_factory=dict,
@@ -236,9 +205,7 @@ class PointRule(SQLModelSerializable, table=True):
     )
     sort_order: int = Field(
         default=0,
-        sa_column=Column(
-            Integer, nullable=False, server_default=text("0"), comment="排序权重，越小越靠前"
-        ),
+        sa_column=Column(Integer, nullable=False, server_default=text("0"), comment="排序权重，越小越靠前"),
     )
     create_time: datetime | None = Field(
         default=None,
@@ -271,21 +238,13 @@ class PointCopy(SQLModelSerializable, table=True):
     )
     tenant_id: int = Field(
         default=1,
-        sa_column=Column(
-            Integer, nullable=False, server_default=text("1"), comment="租户ID"
-        ),
+        sa_column=Column(Integer, nullable=False, server_default=text("1"), comment="租户ID"),
     )
-    copy_key: str = Field(
-        sa_column=Column(String(64), nullable=False, comment="文案键，如 guide")
-    )
-    content: str = Field(
-        sa_column=Column(LargeText, nullable=False, comment="文案内容（富文本/纯文本）")
-    )
+    copy_key: str = Field(sa_column=Column(String(64), nullable=False, comment="文案键，如 guide"))
+    content: str = Field(sa_column=Column(LargeText, nullable=False, comment="文案内容（富文本/纯文本）"))
     sort_order: int = Field(
         default=0,
-        sa_column=Column(
-            Integer, nullable=False, server_default=text("0"), comment="排序权重"
-        ),
+        sa_column=Column(Integer, nullable=False, server_default=text("0"), comment="排序权重"),
     )
     create_time: datetime | None = Field(
         default=None,
@@ -318,20 +277,10 @@ class PointRankSnapshot(SQLModelSerializable, table=True):
     )
     tenant_id: int = Field(
         default=1,
-        sa_column=Column(
-            Integer, nullable=False, server_default=text("1"), comment="租户ID"
-        ),
+        sa_column=Column(Integer, nullable=False, server_default=text("1"), comment="租户ID"),
     )
-    period: str = Field(
-        sa_column=Column(
-            String(16), nullable=False, comment="周期类型：month/year/all"
-        )
-    )
-    scope: str = Field(
-        sa_column=Column(
-            String(16), nullable=False, comment="榜单范围：global（公司）/dept（部门桶）"
-        )
-    )
+    period: str = Field(sa_column=Column(String(16), nullable=False, comment="周期类型：month/year/all"))
+    scope: str = Field(sa_column=Column(String(16), nullable=False, comment="榜单范围：global（公司）/dept（部门桶）"))
     scope_id: int | None = Field(
         default=None,
         sa_column=Column(Integer, comment="范围ID：公司部门ID或部门桶ID"),
@@ -343,18 +292,10 @@ class PointRankSnapshot(SQLModelSerializable, table=True):
             comment="周期键：YYYY-MM / YYYY / all",
         )
     )
-    user_id: int = Field(
-        sa_column=Column(Integer, nullable=False, comment="用户ID")
-    )
-    rank_no: int = Field(
-        sa_column=Column(Integer, nullable=False, comment="名次（同分稠密并列）")
-    )
-    period_score: int = Field(
-        sa_column=Column(Integer, nullable=False, comment="周期内积分净变动（all 为终身获得）")
-    )
-    balance: int = Field(
-        sa_column=Column(Integer, nullable=False, comment="快照时账户余额")
-    )
+    user_id: int = Field(sa_column=Column(Integer, nullable=False, comment="用户ID"))
+    rank_no: int = Field(sa_column=Column(Integer, nullable=False, comment="名次（同分稠密并列）"))
+    period_score: int = Field(sa_column=Column(Integer, nullable=False, comment="周期内积分净变动（all 为终身获得）"))
+    balance: int = Field(sa_column=Column(Integer, nullable=False, comment="快照时账户余额"))
     dept_id: int | None = Field(
         default=None,
         sa_column=Column(Integer, comment="用户所属部门桶ID（展示用）"),
@@ -419,19 +360,11 @@ class PointFavoriteTierAward(SQLModelSerializable, table=True):
     )
     tenant_id: int = Field(
         default=1,
-        sa_column=Column(
-            Integer, nullable=False, server_default=text("1"), comment="租户ID"
-        ),
+        sa_column=Column(Integer, nullable=False, server_default=text("1"), comment="租户ID"),
     )
-    file_id: int = Field(
-        sa_column=Column(Integer, nullable=False, comment="知识文件ID")
-    )
-    highest_tier: int = Field(
-        sa_column=Column(Integer, nullable=False, comment="已发放的最高阶梯档位")
-    )
-    points_granted_total: int = Field(
-        sa_column=Column(Integer, nullable=False, comment="该文件累计已发 G3 积分")
-    )
+    file_id: int = Field(sa_column=Column(Integer, nullable=False, comment="知识文件ID"))
+    highest_tier: int = Field(sa_column=Column(Integer, nullable=False, comment="已发放的最高阶梯档位"))
+    points_granted_total: int = Field(sa_column=Column(Integer, nullable=False, comment="该文件累计已发 G3 积分"))
     create_time: datetime | None = Field(
         default=None,
         sa_column=Column(
@@ -463,27 +396,13 @@ class PointPendingDeduct(SQLModelSerializable, table=True):
     )
     tenant_id: int = Field(
         default=1,
-        sa_column=Column(
-            Integer, nullable=False, server_default=text("1"), comment="租户ID"
-        ),
+        sa_column=Column(Integer, nullable=False, server_default=text("1"), comment="租户ID"),
     )
-    user_id: int = Field(
-        sa_column=Column(Integer, nullable=False, comment="待扣分用户ID")
-    )
-    rule_code: str = Field(
-        sa_column=Column(String(32), nullable=False, comment="扣减规则编码，如 R1")
-    )
-    biz_type: str = Field(
-        sa_column=Column(
-            String(32), nullable=False, comment="业务类型，如 qa_question/qa_answer"
-        )
-    )
-    biz_id: str = Field(
-        sa_column=Column(String(64), nullable=False, comment="业务主键")
-    )
-    idempotency_key: str = Field(
-        sa_column=Column(String(128), nullable=False, comment="幂等键，与正式扣分一致")
-    )
+    user_id: int = Field(sa_column=Column(Integer, nullable=False, comment="待扣分用户ID"))
+    rule_code: str = Field(sa_column=Column(String(32), nullable=False, comment="扣减规则编码，如 R1"))
+    biz_type: str = Field(sa_column=Column(String(32), nullable=False, comment="业务类型，如 qa_question/qa_answer"))
+    biz_id: str = Field(sa_column=Column(String(64), nullable=False, comment="业务主键"))
+    idempotency_key: str = Field(sa_column=Column(String(128), nullable=False, comment="幂等键，与正式扣分一致"))
     operator_id: int | None = Field(
         default=None,
         sa_column=Column(Integer, comment="发起违规删除的操作人ID"),
@@ -504,9 +423,7 @@ class PointPendingDeduct(SQLModelSerializable, table=True):
     )
     retry_count: int = Field(
         default=0,
-        sa_column=Column(
-            Integer, nullable=False, server_default=text("0"), comment="已重试次数"
-        ),
+        sa_column=Column(Integer, nullable=False, server_default=text("0"), comment="已重试次数"),
     )
     next_retry_at: datetime | None = Field(
         default=None,
@@ -550,13 +467,9 @@ class PointSyncOutbox(SQLModelSerializable, table=True):
     )
     tenant_id: int = Field(
         default=1,
-        sa_column=Column(
-            Integer, nullable=False, server_default=text("1"), comment="租户ID"
-        ),
+        sa_column=Column(Integer, nullable=False, server_default=text("1"), comment="租户ID"),
     )
-    log_id: int = Field(
-        sa_column=Column(BigInteger, nullable=False, comment="关联 user_point_log.id")
-    )
+    log_id: int = Field(sa_column=Column(BigInteger, nullable=False, comment="关联 user_point_log.id"))
     payload: dict = Field(
         default_factory=dict,
         sa_column=Column(JsonType, nullable=False, comment="同步载荷 JSON"),
@@ -572,9 +485,7 @@ class PointSyncOutbox(SQLModelSerializable, table=True):
     )
     retry_count: int = Field(
         default=0,
-        sa_column=Column(
-            Integer, nullable=False, server_default=text("0"), comment="已重试次数"
-        ),
+        sa_column=Column(Integer, nullable=False, server_default=text("0"), comment="已重试次数"),
     )
     next_retry_at: datetime | None = Field(
         default=None,

--- a/src/backend/bisheng/points/domain/schemas/points_schema.py
+++ b/src/backend/bisheng/points/domain/schemas/points_schema.py
@@ -29,6 +29,7 @@ class PointRuleRequest(BaseModel):
     rule_code: str | None = None
     rule_type: str | None = None
     name: str | None = None
+    display_name: str | None = None
     score_expr: dict | None = None
     daily_cap: int | None = None
     beneficiary: str | None = None
@@ -156,6 +157,7 @@ class PointRuleResponse(BaseModel):
     rule_code: str
     rule_type: str
     name: str
+    display_name: str
     score_expr: dict
     daily_cap: int | None
     beneficiary: str | None

--- a/src/backend/bisheng/points/domain/services/points_award_facade.py
+++ b/src/backend/bisheng/points/domain/services/points_award_facade.py
@@ -193,7 +193,7 @@ class PointsAwardFacade:
             tenant_id=event.tenant_id,
             user_id=payee,
             delta=score,
-            title=rule.name or rule_code,
+            title=resolve_point_rule_display_name(rule),
             rule_code=rule_code,
             idempotency_key=key,
             daily_cap=rule.daily_cap,
@@ -208,7 +208,7 @@ class PointsAwardFacade:
             result=result,
             user_id=payee,
             rule_code=rule_code,
-            rule_name=rule.name or rule_code,
+            rule_name=resolve_point_rule_display_name(rule),
         )
 
     async def _award_document_shared(self, event: DocumentSharedEvent) -> AwardOutcome:
@@ -233,7 +233,7 @@ class PointsAwardFacade:
             tenant_id=event.tenant_id,
             user_id=payee,
             delta=score,
-            title=rule.name or "G7",
+            title=resolve_point_rule_display_name(rule),
             rule_code="G7",
             idempotency_key=key,
             daily_cap=rule.daily_cap,
@@ -247,7 +247,7 @@ class PointsAwardFacade:
             result=result,
             user_id=payee,
             rule_code="G7",
-            rule_name=rule.name or "G7",
+            rule_name=resolve_point_rule_display_name(rule),
         )
 
     async def _award_favorite_tier(self, event: FavoriteChangedEvent) -> AwardOutcome:
@@ -271,7 +271,7 @@ class PointsAwardFacade:
             tenant_id=event.tenant_id,
             user_id=payee,
             delta=delta,
-            title=rule.name or "G3",
+            title=resolve_point_rule_display_name(rule),
             rule_code="G3",
             idempotency_key=key,
             daily_cap=rule.daily_cap,
@@ -292,7 +292,7 @@ class PointsAwardFacade:
             result=result,
             user_id=payee,
             rule_code="G3",
-            rule_name=rule.name or "G3",
+            rule_name=resolve_point_rule_display_name(rule),
             notify_extra={"favorite_count": int(event.unique_favoriter_count)},
         )
 
@@ -312,7 +312,7 @@ class PointsAwardFacade:
             tenant_id=event.tenant_id,
             user_id=payee,
             delta=score,
-            title=rule.name or "G4",
+            title=resolve_point_rule_display_name(rule),
             rule_code="G4",
             idempotency_key=key,
             daily_cap=rule.daily_cap,
@@ -328,7 +328,7 @@ class PointsAwardFacade:
             result=result,
             user_id=payee,
             rule_code="G4",
-            rule_name=rule.name or "G4",
+            rule_name=resolve_point_rule_display_name(rule),
         )
 
     async def _should_skip_payee(self, payee: int, manager_ids: frozenset[int]) -> str | None:

--- a/src/backend/bisheng/points/domain/services/points_monthly_reward_service.py
+++ b/src/backend/bisheng/points/domain/services/points_monthly_reward_service.py
@@ -213,7 +213,7 @@ class PointsMonthlyRewardService:
                 tenant_id=tenant_id,
                 user_id=user_id,
                 rule_code=rule_code,
-                rule_name=rule.name or rule_code,
+                rule_name=resolve_point_rule_display_name(rule),
                 score=score,
                 period_key=month_key,
             )

--- a/src/backend/bisheng/points/domain/services/points_pending_deduct_service.py
+++ b/src/backend/bisheng/points/domain/services/points_pending_deduct_service.py
@@ -111,13 +111,13 @@ class PointsPendingDeductService:
                 score = abs(int((rule.score_expr or {}).get("score", 0)))
                 if score == 0:
                     raise PointsInvalidAdjustError(msg="扣减规则分值为 0")
-                rule_name = rule.name
+                rule_name = resolve_point_rule_display_name(rule)
                 result = await ledger.deduct(
                     tenant_id=tenant_id,
                     user_id=user_id,
                     delta=-score,
                     rule_code=rule.rule_code,
-                    title=rule.name or rule.rule_code,
+                    title=rule_name,
                     idempotency_key=key,
                     operator_id=operator_id,
                     remark=remark,
@@ -251,7 +251,7 @@ class PointsPendingDeductService:
                 user_id=int(row.user_id),
                 delta=-score,
                 rule_code=rule.rule_code,
-                title=rule.name or rule.rule_code,
+                title=resolve_point_rule_display_name(rule),
                 idempotency_key=row.idempotency_key,
                 operator_id=int(row.operator_id or 0),
                 remark=row.remark,
@@ -266,7 +266,7 @@ class PointsPendingDeductService:
                 await self._notify_admin_deduct(
                     user_id=int(row.user_id),
                     delta=score,
-                    rule_name=rule.name,
+                    rule_name=resolve_point_rule_display_name(rule),
                     remark=row.remark,
                     log_key=row.idempotency_key,
                 )

--- a/src/backend/bisheng/points/domain/services/points_query_service.py
+++ b/src/backend/bisheng/points/domain/services/points_query_service.py
@@ -610,7 +610,7 @@ class PointsQueryService:
             user_id=body.user_id,
             delta=-score,
             rule_code=rule.rule_code,
-            title=rule.name,
+            title=resolve_point_rule_display_name(rule),
             idempotency_key=(f"deduct:{rule.rule_code}:{user.user_id}:{body.user_id}:{uuid.uuid4().hex}"),
             operator_id=int(user.user_id),
             remark=body.remark,
@@ -626,6 +626,9 @@ class PointsQueryService:
             user_id=body.user_id,
             template_code="deduct_admin",
             delta=abs(int(log.delta)),
-            reason=format_deduct_notify_reason(rule_name=rule.name, remark=body.remark),
+            reason=format_deduct_notify_reason(
+                rule_name=resolve_point_rule_display_name(rule),
+                remark=body.remark,
+            ),
         )
         return self._log_response(log)

--- a/src/backend/bisheng/points/domain/services/points_rule_service.py
+++ b/src/backend/bisheng/points/domain/services/points_rule_service.py
@@ -8,6 +8,8 @@ from bisheng.common.dependencies.user_deps import UserPayload
 from bisheng.common.errcode.points import PointsRuleConflictError, PointsRuleNotFoundError
 from bisheng.points.domain.constants.beneficiary import allowed_beneficiaries
 from bisheng.points.domain.constants.optional_fixed_score_rules import validate_deferred_config_rule_can_enable
+from bisheng.points.domain.constants.rule_display_name import resolve_point_rule_display_name
+from bisheng.points.domain.constants.seed_rules import seed_default_name
 from bisheng.points.domain.constants.tier_rule_score_expr import validate_g3_tier_score_expr
 from bisheng.points.domain.models import PointRule
 from bisheng.points.domain.schemas.points_schema import (
@@ -46,6 +48,7 @@ class PointsRuleService:
             rule_code=rule.rule_code,
             rule_type=rule.rule_type,
             name=rule.name,
+            display_name=resolve_point_rule_display_name(rule),
             score_expr=rule.score_expr or {},
             daily_cap=rule.daily_cap,
             beneficiary=rule.beneficiary,
@@ -81,9 +84,13 @@ class PointsRuleService:
     async def create_rule(self, tenant_id: int, user: UserPayload, body: PointRuleRequest) -> PointRuleResponse:
         """创建规则；rule_code 租户内唯一。"""
         require_platform_admin(user)
-        if not body.rule_code or not body.rule_type or not body.name:
+        if not body.rule_code or not body.rule_type:
             raise PointsRuleConflictError(msg="创建规则缺少必填字段")
         code = body.rule_code.strip().upper()
+        default_name = seed_default_name(code) or (body.name or "").strip()
+        display_name = (body.display_name or body.name or default_name or "").strip()
+        if not default_name or not display_name:
+            raise PointsRuleConflictError(msg="创建规则缺少必填字段")
         if await self.repository.get_rule(tenant_id, code):
             raise PointsRuleConflictError(msg=f"规则编码 {code} 已存在")
         self.validate_beneficiary(code, body.rule_type, body.beneficiary)
@@ -92,7 +99,8 @@ class PointsRuleService:
             tenant_id=tenant_id,
             rule_code=code,
             rule_type=body.rule_type,
-            name=body.name,
+            name=default_name,
+            display_name=display_name,
             score_expr=body.score_expr or {},
             daily_cap=body.daily_cap,
             beneficiary=body.beneficiary,
@@ -117,8 +125,17 @@ class PointsRuleService:
         if rule is None or int(rule.tenant_id) != tenant_id:
             raise PointsRuleNotFoundError()
         fields = body.model_fields_set
-        if "name" in fields and body.name is not None:
-            rule.name = body.name
+        if "display_name" in fields and body.display_name is not None:
+            display_name = body.display_name.strip()
+            if not display_name:
+                raise PointsRuleConflictError(msg="积分项展示名称不能为空")
+            rule.display_name = display_name
+        elif "name" in fields and body.name is not None:
+            # 兼容旧客户端：name 字段视为展示名写入。
+            display_name = body.name.strip()
+            if not display_name:
+                raise PointsRuleConflictError(msg="积分项展示名称不能为空")
+            rule.display_name = display_name
         if "score_expr" in fields and body.score_expr is not None:
             self.validate_score_expr(rule.rule_code, body.score_expr)
             rule.score_expr = body.score_expr

--- a/src/backend/test/points/test_points_rule_display_name.py
+++ b/src/backend/test/points/test_points_rule_display_name.py
@@ -1,0 +1,57 @@
+"""积分规则 display_name 与默认 name 分离。"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from bisheng.points.domain.constants.rule_display_name import resolve_point_rule_display_name
+from bisheng.points.domain.schemas.points_schema import PointRuleRequest
+from bisheng.points.domain.services.points_rule_service import PointsRuleService
+
+
+def test_resolve_point_rule_display_name_prefers_display_name():
+    rule = SimpleNamespace(rule_code="G1", name="发布/上传到公共库", display_name="公共库上传")
+    assert resolve_point_rule_display_name(rule) == "公共库上传"
+
+
+def test_resolve_point_rule_display_name_falls_back_to_default_name():
+    rule = SimpleNamespace(rule_code="G1", name="发布/上传到公共库", display_name=None)
+    assert resolve_point_rule_display_name(rule) == "发布/上传到公共库"
+
+
+@pytest.mark.asyncio
+async def test_update_rule_persists_display_name_not_default_name():
+    rule = SimpleNamespace(
+        id=1,
+        tenant_id=1,
+        rule_code="G1",
+        rule_type="earn",
+        name="发布/上传到公共库",
+        display_name="发布/上传到公共库",
+        score_expr={"mode": "fixed", "score": 3},
+        daily_cap=15,
+        beneficiary="uploader",
+        status="enabled",
+        remark=None,
+        sort_order=1,
+    )
+    repo = SimpleNamespace(
+        get_rule_by_id=AsyncMock(return_value=rule),
+        save_rule=AsyncMock(side_effect=lambda r: r),
+    )
+    session = SimpleNamespace(commit=AsyncMock())
+    service = PointsRuleService(session=session, repository=repo)
+    body = PointRuleRequest(display_name="运营自定义名")
+
+    out = await service.update_rule(
+        1,
+        SimpleNamespace(is_admin=lambda: True, is_global_super=True),
+        1,
+        body,
+    )
+
+    assert rule.display_name == "运营自定义名"
+    assert rule.name == "发布/上传到公共库"
+    assert out.display_name == "运营自定义名"
+    assert out.name == "发布/上传到公共库"


### PR DESCRIPTION
## Summary
- `point_rule` 新增 `display_name`（运营可改展示名）；`name` 为种子默认名，管理端更新接口不再修改。
- 流水标题、扣减通知、发分/月奖等用户可见文案统一走 `resolve_point_rule_display_name()`。
- Alembic：`f092_merge_points_display_name_heads` → `f093_point_rule_display_name`（存量 `display_name=name`，再按 rule_code 写回默认 `name`）。

**涉及数据表：** `point_rule`（新增 `display_name`；`name` COMMENT 调整；无其它表 DDL）

## Test plan
- [x] `uv run pytest test/points/test_points_rule_display_name.py -q`
- [ ] 部署后 `alembic upgrade head`
- [ ] 门户积分管理联调：改展示名、列表/流水/规则弹窗一致


Made with [Cursor](https://cursor.com)