### PR TITLE
fix(points): 重置 G1–G7 系统默认规则名

### DIFF
--- a/src/backend/bisheng/core/database/alembic/versions/v2_6_0_f096_points_rule_reset_g_default_names.py
+++ b/src/backend/bisheng/core/database/alembic/versions/v2_6_0_f096_points_rule_reset_g_default_names.py
@@ -1,0 +1,64 @@
+# ruff: noqa: RUF002, RUF003
+"""按产品文案重置获取类规则默认名 name（G1–G7）。
+
+Revision ID: f096_points_rule_reset_g_default_names
+Revises: f095_retire_auto_tag_library_id
+
+仅改 point_rule.name；不改 display_name / 分值 / 启停。
+按 rule_code 全租户覆盖写入系统默认名（与 SEED_RULES 对齐）。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+from bisheng.core.database.dialect_helpers import table_exists
+from bisheng.points.domain.constants.seed_rules import SEED_RULES
+
+revision: str = "f096_points_rule_reset_g_default_names"
+down_revision: str | Sequence[str] | None = "f095_retire_auto_tag_library_id"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_G_CODES = frozenset({"G1", "G2", "G3", "G4", "G5", "G6", "G7"})
+
+# 本迁移前 G1–G7 的系统默认名（用于 downgrade）
+_OLD_G_DEFAULT_NAMES: dict[str, str] = {
+    "G1": "发布/上传到公共库",
+    "G2": "发布/上传到部门库",
+    "G3": "文档被收藏",
+    "G4": "问答被采纳",
+    "G5": "上传团队库文档",
+    "G6": "上传科室库文档",
+    "G7": "知识分享",
+}
+
+
+def _apply_names(names: dict[str, str]) -> None:
+    """按编码更新已有规则的系统默认名；缺表则跳过。"""
+    bind = op.get_bind()
+    if not table_exists(bind, "point_rule"):
+        return
+    for code, name in names.items():
+        bind.execute(
+            sa.text("UPDATE point_rule SET name = :name WHERE rule_code = :code"),
+            {"name": name, "code": code},
+        )
+
+
+def upgrade() -> None:
+    """把 G1–G7 的 name 写成当前种子默认名。"""
+    names = {
+        rule["rule_code"]: str(rule["name"])
+        for rule in SEED_RULES
+        if rule["rule_code"] in _G_CODES
+    }
+    _apply_names(names)
+
+
+def downgrade() -> None:
+    """恢复本迁移前的 G1–G7 系统默认名。"""
+    _apply_names(_OLD_G_DEFAULT_NAMES)

--- a/src/backend/bisheng/points/domain/constants/seed_rules.py
+++ b/src/backend/bisheng/points/domain/constants/seed_rules.py
@@ -14,7 +14,7 @@ SEED_RULES = [
     {
         "rule_code": "G1",
         "rule_type": "earn",
-        "name": "发布/上传到公共库",
+        "name": "发布/上传文档到公共库",
         "score_expr": {"mode": "fixed", "score": 3},
         "daily_cap": 15,
         "beneficiary": "uploader",
@@ -24,7 +24,7 @@ SEED_RULES = [
     {
         "rule_code": "G2",
         "rule_type": "earn",
-        "name": "发布/上传到部门库",
+        "name": "发布/上传文档到部门库",
         "score_expr": {"mode": "fixed", "score": 2},
         "daily_cap": 10,
         "beneficiary": "uploader",
@@ -63,7 +63,7 @@ SEED_RULES = [
     {
         "rule_code": "G5",
         "rule_type": "earn",
-        "name": "上传团队库文档",
+        "name": "发布/上传文档团队库",
         "score_expr": {"mode": "fixed", "score": 2},
         "daily_cap": 10,
         "beneficiary": "uploader",
@@ -73,7 +73,7 @@ SEED_RULES = [
     {
         "rule_code": "G6",
         "rule_type": "earn",
-        "name": "上传科室库文档",
+        "name": "发布/上传文档科室库",
         "score_expr": {"mode": "fixed", "score": 2},
         "daily_cap": 10,
         "beneficiary": "uploader",

--- a/src/backend/test/points/test_points_rule_display_name.py
+++ b/src/backend/test/points/test_points_rule_display_name.py
@@ -11,13 +11,13 @@ from bisheng.points.domain.services.points_rule_service import PointsRuleService
 
 
 def test_resolve_point_rule_display_name_prefers_display_name():
-    rule = SimpleNamespace(rule_code="G1", name="发布/上传到公共库", display_name="公共库上传")
+    rule = SimpleNamespace(rule_code="G1", name="发布/上传文档到公共库", display_name="公共库上传")
     assert resolve_point_rule_display_name(rule) == "公共库上传"
 
 
 def test_resolve_point_rule_display_name_falls_back_to_default_name():
-    rule = SimpleNamespace(rule_code="G1", name="发布/上传到公共库", display_name=None)
-    assert resolve_point_rule_display_name(rule) == "发布/上传到公共库"
+    rule = SimpleNamespace(rule_code="G1", name="发布/上传文档到公共库", display_name=None)
+    assert resolve_point_rule_display_name(rule) == "发布/上传文档到公共库"
 
 
 @pytest.mark.asyncio
@@ -27,8 +27,8 @@ async def test_update_rule_persists_display_name_not_default_name():
         tenant_id=1,
         rule_code="G1",
         rule_type="earn",
-        name="发布/上传到公共库",
-        display_name="发布/上传到公共库",
+        name="发布/上传文档到公共库",
+        display_name="发布/上传文档到公共库",
         score_expr={"mode": "fixed", "score": 3},
         daily_cap=15,
         beneficiary="uploader",
@@ -52,6 +52,6 @@ async def test_update_rule_persists_display_name_not_default_name():
     )
 
     assert rule.display_name == "运营自定义名"
-    assert rule.name == "发布/上传到公共库"
+    assert rule.name == "发布/上传文档到公共库"
     assert out.display_name == "运营自定义名"
-    assert out.name == "发布/上传到公共库"
+    assert out.name == "发布/上传文档到公共库"

--- a/src/backend/test/points/test_seed_rule_g_default_names.py
+++ b/src/backend/test/points/test_seed_rule_g_default_names.py
@@ -1,0 +1,23 @@
+"""校验 G1–G7 系统默认名与产品文案一致。"""
+
+from bisheng.points.domain.constants.seed_rules import SEED_RULES, seed_default_name
+
+# 产品给定的获取类规则默认名（point_rule.name）
+EXPECTED_G_DEFAULT_NAMES = {
+    "G1": "发布/上传文档到公共库",
+    "G2": "发布/上传文档到部门库",
+    "G3": "文档被收藏",
+    "G4": "问答被采纳",
+    "G5": "发布/上传文档团队库",
+    "G6": "发布/上传文档科室库",
+    "G7": "知识分享",
+}
+
+
+def test_seed_rules_g1_g7_default_names_match_product_copy():
+    """SEED_RULES 中 G1–G7 的 name 必须与产品文案一致。"""
+    by_code = {r["rule_code"]: r["name"] for r in SEED_RULES}
+    for code, expected in EXPECTED_G_DEFAULT_NAMES.items():
+        assert by_code.get(code) == expected, f"{code} seed name mismatch"
+        assert seed_default_name(code) == expected
+        assert len(expected) <= 40


### PR DESCRIPTION
## Summary
- 按产品文案更新 G1–G7 种子默认名 `name`（如「发布/上传文档到公共库」）。
- 新增迁移 `f096_points_rule_reset_g_default_names`：全租户按 `rule_code` 覆盖 `point_rule.name`。
- **不改** `display_name`（运营展示名仍优先）。
- 补充种子文案单测，并同步 display_name 相关断言中的默认名。

## Test plan
- [ ] `alembic upgrade head` 后查库：`SELECT rule_code, name, display_name FROM point_rule WHERE rule_code IN ('G1','G2','G3','G4','G5','G6','G7')`，确认 `name` 为新产品文案
- [ ] 管理端新增规则下拉展示默认名与文案一致
- [ ] `pytest test/points/test_seed_rule_g_default_names.py test/points/test_points_rule_display_name.py` 通过
- [ ] 确认运营已改过的 `display_name` 未被迁移覆盖


Made with [Cursor](https://cursor.com)