### PR TITLE
feat(qa_expert): 关联文档按问答角色上下文只读放行

### DIFF
--- a/src/backend/bisheng/knowledge/api/endpoints/shougang_portal.py
+++ b/src/backend/bisheng/knowledge/api/endpoints/shougang_portal.py
@@ -28,11 +28,11 @@ from bisheng.knowledge.domain.schemas.knowledge_space_schema import (
     ShougangPortalAdvancedFileSearchReq,
     ShougangPortalAdvancedUploaderSearchReq,
     ShougangPortalAdvancedUploaderSearchResp,
+    ShougangPortalCategoryFileCountReq,
+    ShougangPortalCategoryFileCountResp,
     ShougangPortalDomainBindableSpacesResp,
     ShougangPortalDomainFileCountReq,
     ShougangPortalDomainFileCountResp,
-    ShougangPortalCategoryFileCountReq,
-    ShougangPortalCategoryFileCountResp,
     ShougangPortalFavoriteCreateReq,
     ShougangPortalFavoriteCreateResp,
     ShougangPortalFavoriteFilesResp,
@@ -72,6 +72,9 @@ from bisheng.knowledge.domain.schemas.portal_hot_search_schema import (
     PortalHotSearchTriggerRebuildResp,
 )
 from bisheng.knowledge.domain.schemas.portal_pdf_download_schema import PortalPdfDownloadRequest
+from bisheng.knowledge.domain.services.knowledge_fulltext_engagement_service import (
+    project_knowledge_fulltext_engagement_best_effort,
+)
 from bisheng.knowledge.domain.services.knowledge_space_chat_service import (
     KnowledgeSpaceChatService,
 )
@@ -80,9 +83,6 @@ from bisheng.knowledge.domain.services.portal_hot_search_admin_service import (
 )
 from bisheng.telemetry.domain.mid_table.realtime_qa_question import (
     RealtimeQaQuestionFact,
-)
-from bisheng.knowledge.domain.services.knowledge_fulltext_engagement_service import (
-    project_knowledge_fulltext_engagement_best_effort,
 )
 from bisheng.utils import generate_uuid
 
@@ -335,9 +335,7 @@ async def count_shougang_portal_files(
     svc: Any = Depends(get_knowledge_space_service),
 ) -> Any:
     result = await svc.count_shougang_portal_files(req)
-    return resp_200(
-        ShougangPortalFileCountResp(**result).model_dump(mode="json")
-    )
+    return resp_200(ShougangPortalFileCountResp(**result).model_dump(mode="json"))
 
 
 @router.post("/home")
@@ -424,11 +422,15 @@ async def get_shougang_portal_home_stats(
 async def get_shougang_portal_file_preview(
     space_id: int,
     file_id: int,
+    qa_question_id: int | None = Query(default=None, ge=1),
+    qa_doc_source: Literal["question", "answer"] | None = Query(default=None),
     svc: Any = Depends(get_knowledge_space_service),
 ) -> Any:
     result = await svc.get_shougang_portal_file_preview(
         space_id=space_id,
         file_id=file_id,
+        qa_question_id=qa_question_id,
+        qa_doc_source=qa_doc_source,
     )
     return resp_200(result)
 
@@ -439,6 +441,8 @@ async def get_shougang_portal_file_chunks(
     file_id: int,
     page: int = Query(default=1, ge=1),
     limit: int = Query(default=100, ge=1, le=100),
+    qa_question_id: int | None = Query(default=None, ge=1),
+    qa_doc_source: Literal["question", "answer"] | None = Query(default=None),
     svc: Any = Depends(get_knowledge_space_service),
 ) -> Any:
     result = await svc.get_shougang_portal_file_chunks(
@@ -446,6 +450,8 @@ async def get_shougang_portal_file_chunks(
         file_id=file_id,
         page=page,
         limit=limit,
+        qa_question_id=qa_question_id,
+        qa_doc_source=qa_doc_source,
     )
     return resp_200(result)
 
@@ -501,9 +507,16 @@ async def list_shougang_portal_related_files(
 async def get_shougang_portal_file(
     space_id: int,
     file_id: int,
+    qa_question_id: int | None = Query(default=None, ge=1),
+    qa_doc_source: Literal["question", "answer"] | None = Query(default=None),
     svc: Any = Depends(get_knowledge_space_service),
 ) -> Any:
-    item = await svc.get_shougang_portal_file(space_id=space_id, file_id=file_id)
+    item = await svc.get_shougang_portal_file(
+        space_id=space_id,
+        file_id=file_id,
+        qa_question_id=qa_question_id,
+        qa_doc_source=qa_doc_source,
+    )
     raw = item.model_dump(mode="json") if hasattr(item, "model_dump") else item
     return resp_200(ShougangPortalFileDetailResp(data=raw).model_dump(mode="json"))
 
@@ -532,9 +545,7 @@ async def search_shougang_portal_advanced_uploaders(
     svc: Any = Depends(get_knowledge_space_service),
 ) -> Any:
     result = await svc.search_shougang_portal_advanced_uploaders(req)
-    return resp_200(
-        ShougangPortalAdvancedUploaderSearchResp(**result).model_dump(mode="json")
-    )
+    return resp_200(ShougangPortalAdvancedUploaderSearchResp(**result).model_dump(mode="json"))
 
 
 @router.post("/files/browse")

--- a/src/backend/bisheng/knowledge/domain/services/department_file_view_access_service.py
+++ b/src/backend/bisheng/knowledge/domain/services/department_file_view_access_service.py
@@ -52,6 +52,7 @@ class DepartmentFileAccessSource:
     DEPARTMENT_APPROVER = "department_approver"
     PERMISSION_TEMPLATE = "permission_template"
     APPROVAL_GRANT = "approval_grant"
+    EXPERT_QA = "expert_qa"
 
 
 @dataclass(frozen=True)
@@ -135,14 +136,10 @@ class DepartmentFileViewAccessService:
         if (
             level == KnowledgeSpaceLevelEnum.DEPARTMENT.value
             and owner_type == KnowledgeSpaceOwnerTypeEnum.DEPARTMENT.value
-            and int(getattr(scope, "owner_id", 0) or 0)
-            == int(getattr(binding, "department_id", 0) or 0)
+            and int(getattr(scope, "owner_id", 0) or 0) == int(getattr(binding, "department_id", 0) or 0)
         ):
             return "department"
-        if (
-            KnowledgeSpaceLevelEnum.is_team_level(level)
-            and owner_type == KnowledgeSpaceOwnerTypeEnum.USER.value
-        ):
+        if KnowledgeSpaceLevelEnum.is_team_level(level) and owner_type == KnowledgeSpaceOwnerTypeEnum.USER.value:
             return "clinic"
         return None
 
@@ -324,11 +321,7 @@ class DepartmentFileViewAccessService:
         binding_rows_by_space: dict[int, list[DepartmentKnowledgeSpace]] = {}
         for row in bindings_result.scalars().all():
             binding_rows_by_space.setdefault(int(row.space_id), []).append(row)
-        bindings = {
-            space_id: rows[0]
-            for space_id, rows in binding_rows_by_space.items()
-            if len(rows) == 1
-        }
+        bindings = {space_id: rows[0] for space_id, rows in binding_rows_by_space.items() if len(rows) == 1}
         department_ids = {int(binding.department_id) for binding in bindings.values()}
         department_result = await self.session.execute(
             select(Department).where(Department.id.in_(sorted(department_ids)))
@@ -352,11 +345,7 @@ class DepartmentFileViewAccessService:
                     department=None,
                     valid=False,
                     applicable=False,
-                    invalid_reason=(
-                        "ambiguous_binding"
-                        if len(binding_rows_by_space.get(space_id, [])) > 1
-                        else None
-                    ),
+                    invalid_reason=("ambiguous_binding" if len(binding_rows_by_space.get(space_id, [])) > 1 else None),
                 )
                 continue
             department = departments.get(int(binding.department_id)) if binding is not None else None
@@ -493,9 +482,7 @@ class DepartmentFileViewAccessService:
             "file_name": file_name,
             "space_name": space_name,
             "folder_path": (
-                folder_path
-                if folder_path is not None
-                else str(getattr(file_record, "file_level_path", "") or "")
+                folder_path if folder_path is not None else str(getattr(file_record, "file_level_path", "") or "")
             ),
             "file_source": getattr(file_record, "file_source", None),
             "file_ext": suffix,

--- a/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
+++ b/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
@@ -104,20 +104,21 @@ from bisheng.core.openfga.client import (
     finish_fga_read_stats,
 )
 from bisheng.core.storage.minio.minio_manager import get_minio_storage_sync
+from bisheng.database.models.audit_log import AuditLogDao
 from bisheng.database.models.department import DepartmentDao, UserDepartment, UserDepartmentDao
 from bisheng.database.models.department_admin_grant import DepartmentAdminGrantDao
-from bisheng.database.models.audit_log import AuditLogDao
 from bisheng.database.models.group import GroupDao
 from bisheng.database.models.group_resource import ResourceTypeEnum
 from bisheng.database.models.review_tags import ReviewTag, ReviewTagDao
 from bisheng.database.models.tag import Tag, TagBusinessTypeEnum, TagDao, TagResourceTypeEnum
 from bisheng.database.models.tenant import TenantDao
 from bisheng.database.models.user_group import UserGroupDao
-from bisheng.department.domain.services.department_service import DepartmentService
 from bisheng.department.domain.services.department_display_service import (
     build_department_name_projection,
     get_department_display_name,
 )
+from bisheng.department.domain.services.department_service import DepartmentService
+from bisheng.knowledge.domain import knowledge_fulltext_constants as fulltext_constants
 from bisheng.knowledge.domain.constants import (
     BUSINESS_DOMAIN_CODE_KEY,
     BUSINESS_DOMAIN_OPTIONS,
@@ -126,7 +127,6 @@ from bisheng.knowledge.domain.constants import (
     parse_shougang_file_encoding_codes,
 )
 from bisheng.knowledge.domain.knowledge_rag import KnowledgeRag
-from bisheng.knowledge.domain import knowledge_fulltext_constants as fulltext_constants
 from bisheng.knowledge.domain.models.department_knowledge_space import (
     DepartmentKnowledgeSpaceDao,
 )
@@ -190,6 +190,8 @@ from bisheng.knowledge.domain.schemas.knowledge_fulltext_search_schema import (
     KnowledgeFulltextAdvancedSearchQuery,
 )
 from bisheng.knowledge.domain.schemas.knowledge_space_schema import (
+    BatchAliasActionResult,
+    BatchAliasFailure,
     GroupedKnowledgeSpacesResp,
     KnowledgeSpaceCreateOptionDepartment,
     KnowledgeSpaceCreateOptionDepartmentsResp,
@@ -241,8 +243,6 @@ from bisheng.knowledge.domain.schemas.knowledge_space_schema import (
     UploadFolderRecommendationItemResp,
     UploadFolderRecommendationResp,
     UploadFolderRecommendFileReq,
-    BatchAliasActionResult,
-    BatchAliasFailure,
 )
 from bisheng.knowledge.domain.services.department_file_view_access_service import (
     DepartmentFileAccessDecision,
@@ -352,11 +352,11 @@ if TYPE_CHECKING:
     from bisheng.knowledge.domain.repositories.interfaces.knowledge_document_version_repository import (
         KnowledgeDocumentVersionRepository,
     )
-    from bisheng.knowledge.domain.repositories.interfaces.knowledge_file_similarity_candidate_repository import (
-        KnowledgeFileSimilarityCandidateRepository,
-    )
     from bisheng.knowledge.domain.repositories.interfaces.knowledge_file_repository import (
         KnowledgeFileRepository,
+    )
+    from bisheng.knowledge.domain.repositories.interfaces.knowledge_file_similarity_candidate_repository import (
+        KnowledgeFileSimilarityCandidateRepository,
     )
     from bisheng.knowledge.domain.repositories.interfaces.knowledge_space_scope_repository import (
         KnowledgeSpaceScopeRepository,
@@ -792,14 +792,10 @@ class KnowledgeSpaceService(KnowledgeUtils):
     ) -> bool:
         if file_record.reference_document_id is None:
             return False
-        if (
-            file_record.entry_status == KnowledgeFileEntryStatus.INVALID.value
-            and file_record.entry_type
-            in {
-                KnowledgeFileEntryType.PUBLISH.value,
-                KnowledgeFileEntryType.SHARE.value,
-            }
-        ):
+        if file_record.entry_status == KnowledgeFileEntryStatus.INVALID.value and file_record.entry_type in {
+            KnowledgeFileEntryType.PUBLISH.value,
+            KnowledgeFileEntryType.SHARE.value,
+        }:
             if self.document_distribution_service is None:
                 raise KnowledgeDocumentStateConflictError(msg="文档分发生命周期服务不可用")
             return True
@@ -1059,9 +1055,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
         if resolved is not None:
             return resolved
 
-        ancestor_folder_ids = [
-            int(part) for part in (file_record.file_level_path or "").split("/") if part
-        ]
+        ancestor_folder_ids = [int(part) for part in (file_record.file_level_path or "").split("/") if part]
         parent_folder_id = ancestor_folder_ids[-1] if ancestor_folder_ids else None
         if parent_folder_id:
             await self._require_permission_id(
@@ -1704,9 +1698,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
             DepartmentAdminGrantDao.aget_department_ids_by_user_id(self.login_user.user_id),
         )
         root_department_ids = {
-            int(row.department_id)
-            for row in user_departments
-            if getattr(row, "department_id", None) is not None
+            int(row.department_id) for row in user_departments if getattr(row, "department_id", None) is not None
         }
         root_department_ids.update(int(department_id) for department_id in admin_department_ids)
         if not root_department_ids:
@@ -1714,9 +1706,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
 
         all_departments = await DepartmentDao.aget_active_by_tenant(int(self.login_user.tenant_id))
         visible_root_paths = {
-            dept.path
-            for dept in all_departments
-            if int(dept.id) in root_department_ids and getattr(dept, "path", None)
+            dept.path for dept in all_departments if int(dept.id) in root_department_ids and getattr(dept, "path", None)
         }
         if not visible_root_paths:
             return []
@@ -2168,13 +2158,13 @@ class KnowledgeSpaceService(KnowledgeUtils):
         tree = await self._department_tree_for_create(approval_request=approval_request)
         normalized_keyword = str(keyword or "").strip().casefold()
         if normalized_keyword:
+
             def _filter_tree(nodes: list[dict]) -> list[dict]:
                 filtered: list[dict] = []
                 for node in nodes:
                     children = _filter_tree(node.get("children", []))
                     search_text = " ".join(
-                        str(node.get(field) or "")
-                        for field in ("name", "short_name", "display_name")
+                        str(node.get(field) or "") for field in ("name", "short_name", "display_name")
                     ).casefold()
                     if normalized_keyword in search_text or children:
                         filtered.append({**node, "children": children})
@@ -2265,9 +2255,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
 
             discovery_kind = self._portal_discovery_kind(scope, binding)
             space.portal_discovery_enabled = (
-                bool(scope.portal_discovery_enabled)
-                if scope is not None and discovery_kind is not None
-                else None
+                bool(scope.portal_discovery_enabled) if scope is not None and discovery_kind is not None else None
             )
 
             if space.owner_type in {
@@ -2313,10 +2301,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
             return None
         if scope.level == KnowledgeSpaceLevelEnum.PUBLIC:
             return "public"
-        binding_matches_space = (
-            binding is not None
-            and int(getattr(binding, "space_id", 0) or 0) == int(scope.space_id)
-        )
+        binding_matches_space = binding is not None and int(getattr(binding, "space_id", 0) or 0) == int(scope.space_id)
         if (
             scope.level == KnowledgeSpaceLevelEnum.DEPARTMENT
             and scope.owner_type == KnowledgeSpaceOwnerTypeEnum.DEPARTMENT
@@ -2345,9 +2330,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
             raise RuntimeError("DepartmentSpaceBindingRepository is not configured")
 
         tenant_id = int(self.login_user.tenant_id)
-        scopes = await self.knowledge_space_scope_repo.list_portal_candidates(
-            tenant_id=tenant_id
-        )
+        scopes = await self.knowledge_space_scope_repo.list_portal_candidates(tenant_id=tenant_id)
         space_ids = sorted({int(item.space_id) for item in scopes})
         bindings = await self.department_space_binding_repo.find_by_space_ids(space_ids)
         bindings_by_space: dict[int, list[Any]] = {}
@@ -2355,9 +2338,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
             bindings_by_space.setdefault(int(binding.space_id), []).append(binding)
 
         department_ids = {
-            int(binding.department_id)
-            for binding in bindings
-            if getattr(binding, "department_id", None) is not None
+            int(binding.department_id) for binding in bindings if getattr(binding, "department_id", None) is not None
         }
         departments = await DepartmentDao.aget_by_ids(sorted(department_ids))
         valid_department_ids = {
@@ -2378,13 +2359,8 @@ class KnowledgeSpaceService(KnowledgeUtils):
             matching_bindings = bindings_by_space.get(space_id, [])
             binding = matching_bindings[0] if len(matching_bindings) == 1 else None
             if binding is not None:
-                binding_tenant_id = int(
-                    getattr(binding, "tenant_id", tenant_id) or tenant_id
-                )
-                if (
-                    binding_tenant_id != tenant_id
-                    or int(binding.department_id) not in valid_department_ids
-                ):
+                binding_tenant_id = int(getattr(binding, "tenant_id", tenant_id) or tenant_id)
+                if binding_tenant_id != tenant_id or int(binding.department_id) not in valid_department_ids:
                     binding = None
                 else:
                     valid_binding_by_space_id[space_id] = binding
@@ -2415,16 +2391,12 @@ class KnowledgeSpaceService(KnowledgeUtils):
         if scope == "portal_configured":
             is_global_admin = bool(self.login_user.is_admin())
             if is_global_admin:
-                memberships = await SpaceChannelMemberDao.async_get_user_space_members(
-                    int(self.login_user.user_id)
-                )
+                memberships = await SpaceChannelMemberDao.async_get_user_space_members(int(self.login_user.user_id))
                 readable_ids: list[str] = []
                 manageable_ids: list[str] = []
             else:
                 memberships, readable_ids, manageable_ids = await asyncio.gather(
-                    SpaceChannelMemberDao.async_get_user_space_members(
-                        int(self.login_user.user_id)
-                    ),
+                    SpaceChannelMemberDao.async_get_user_space_members(int(self.login_user.user_id)),
                     PermissionService.list_accessible_ids(
                         user_id=int(self.login_user.user_id),
                         relation="can_read",
@@ -2444,25 +2416,17 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 for member in memberships
                 if str(getattr(member, "business_id", "")).isdigit()
                 and int(member.business_id) in scope_by_space_id
-                and (
-                    not is_global_admin
-                    or space_kind_by_id.get(int(member.business_id)) != "personal"
-                )
+                and (not is_global_admin or space_kind_by_id.get(int(member.business_id)) != "personal")
             )
             explicit_space_ids.update(
                 int(item.space_id)
                 for item in scopes
-                if int(getattr(item, "created_by", 0) or 0)
-                == int(self.login_user.user_id)
+                if int(getattr(item, "created_by", 0) or 0) == int(self.login_user.user_id)
             )
 
             if is_global_admin:
                 binding_candidate_ids = sorted(
-                    {
-                        space_id
-                        for space_id, kind in space_kind_by_id.items()
-                        if kind != "personal"
-                    }
+                    {space_id for space_id, kind in space_kind_by_id.items() if kind != "personal"}
                     - discoverable_space_ids
                     - explicit_space_ids
                 )
@@ -2479,17 +2443,13 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 manageable_space_ids = {
                     int(space_id)
                     for space_id in manageable_ids or []
-                    if str(space_id).isdigit()
-                    and int(space_id) in scope_by_space_id
+                    if str(space_id).isdigit() and int(space_id) in scope_by_space_id
                 }
-                explicit_space_ids.update(
-                    manageable_space_ids
-                )
+                explicit_space_ids.update(manageable_space_ids)
                 readable_space_ids = {
                     int(space_id)
                     for space_id in readable_ids or []
-                    if str(space_id).isdigit()
-                    and int(space_id) in scope_by_space_id
+                    if str(space_id).isdigit() and int(space_id) in scope_by_space_id
                 }
                 closed_public_readable_ids = sorted(
                     space_id
@@ -2526,10 +2486,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                     if space_kind_by_id.get(parent_space_id) not in {"department", "clinic"}:
                         continue
                     binding = valid_binding_by_space_id.get(parent_space_id)
-                    if (
-                        binding is None
-                        or int(binding.department_id) != int(grant.department_id)
-                    ):
+                    if binding is None or int(binding.department_id) != int(grant.department_id):
                         continue
                     candidate_grants.append(grant)
 
@@ -2537,11 +2494,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                     granted_files = await KnowledgeFileDao.aget_file_by_ids(
                         sorted({int(grant.file_id) for grant in candidate_grants})
                     )
-                    file_by_id = {
-                        int(file.id): file
-                        for file in granted_files
-                        if getattr(file, "id", None) is not None
-                    }
+                    file_by_id = {int(file.id): file for file in granted_files if getattr(file, "id", None) is not None}
                     try:
                         decisions = await access_service.evaluate_files(
                             login_user=self.login_user,
@@ -2549,8 +2502,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                         )
                     except Exception as exc:
                         logger.warning(
-                            "portal discovery grant revalidation failed closed: "
-                            "tenant_id={} user_id={} error={}",
+                            "portal discovery grant revalidation failed closed: tenant_id={} user_id={} error={}",
                             tenant_id,
                             int(self.login_user.user_id),
                             type(exc).__name__,
@@ -2571,9 +2523,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                         explicit_file_space_by_id[file_id] = parent_space_id
                         grant_parent_space_ids.add(parent_space_id)
 
-        query_space_ids = sorted(
-            discoverable_space_ids | explicit_space_ids | grant_parent_space_ids
-        )
+        query_space_ids = sorted(discoverable_space_ids | explicit_space_ids | grant_parent_space_ids)
         snapshot = self.knowledge_space_scope_repo.build_discovery_snapshot(
             scopes=configurable_scope_rows,
             explicit_space_ids=sorted(explicit_space_ids),
@@ -2819,11 +2769,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
         Verify that the current user has can_delete permission on the space.
         """
         space = await KnowledgeDao.aquery_by_id(space_id)
-        if (
-            not space
-            or space.type != KnowledgeTypeEnum.SPACE.value
-            or space.state == KnowledgeState.DELETING.value
-        ):
+        if not space or space.type != KnowledgeTypeEnum.SPACE.value or space.state == KnowledgeState.DELETING.value:
             raise SpaceNotFoundError()
         allowed = await PermissionService.check(
             user_id=self.login_user.user_id,
@@ -3754,11 +3700,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
         if space_id is None:
             return set()
         space = await KnowledgeDao.aquery_by_id(int(space_id))
-        if (
-            not space
-            or space.type != KnowledgeTypeEnum.SPACE.value
-            or space.state == KnowledgeState.DELETING.value
-        ):
+        if not space or space.type != KnowledgeTypeEnum.SPACE.value or space.state == KnowledgeState.DELETING.value:
             return set()
         space_level = getattr(space, "space_level", None)
         if space_level is None:
@@ -3808,11 +3750,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
 
     async def _require_read_permission(self, space_id: int) -> Knowledge:
         space = await KnowledgeDao.aquery_by_id(space_id)
-        if (
-            not space
-            or space.type != KnowledgeTypeEnum.SPACE.value
-            or space.state == KnowledgeState.DELETING.value
-        ):
+        if not space or space.type != KnowledgeTypeEnum.SPACE.value or space.state == KnowledgeState.DELETING.value:
             raise SpaceNotFoundError()
         effective_permissions = await self._get_effective_permission_ids("knowledge_space", space_id)
         if "view_space" not in effective_permissions:
@@ -3841,11 +3779,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
 
     async def _require_space_info_permission(self, space_id: int) -> tuple[Knowledge, bool]:
         space = await KnowledgeDao.aquery_by_id(space_id)
-        if (
-            not space
-            or space.type != KnowledgeTypeEnum.SPACE.value
-            or space.state == KnowledgeState.DELETING.value
-        ):
+        if not space or space.type != KnowledgeTypeEnum.SPACE.value or space.state == KnowledgeState.DELETING.value:
             raise SpaceNotFoundError()
         effective_permissions = await self._get_effective_permission_ids("knowledge_space", space_id)
         if "view_space" in effective_permissions:
@@ -5469,23 +5403,16 @@ class KnowledgeSpaceService(KnowledgeUtils):
         visible_scopes: dict[str, set[int]] = {}
         if discovery_scope in {"portal_public", "portal_configured"}:
             discovery = await self.resolve_portal_discovery(scope=discovery_scope)
-            full_space_ids = set(discovery.discoverable_space_ids) | set(
-                discovery.explicitly_visible_space_ids
-            )
+            full_space_ids = set(discovery.discoverable_space_ids) | set(discovery.explicitly_visible_space_ids)
             grant_only_parent_ids = set(discovery.grant_parent_space_ids) - full_space_ids
             visible_file_ids: dict[str, set[int]] = {}
             for domain in domains:
-                requested_ids = {
-                    int(space_id) for space_id in domain.space_ids if int(space_id) > 0
-                }
-                visible_scopes.setdefault(domain.code, set()).update(
-                    requested_ids & full_space_ids
-                )
+                requested_ids = {int(space_id) for space_id in domain.space_ids if int(space_id) > 0}
+                visible_scopes.setdefault(domain.code, set()).update(requested_ids & full_space_ids)
                 visible_file_ids.setdefault(domain.code, set()).update(
                     file_id
                     for file_id, parent_space_id in discovery.explicit_file_space_by_id.items()
-                    if parent_space_id in requested_ids
-                    and parent_space_id in grant_only_parent_ids
+                    if parent_space_id in requested_ids and parent_space_id in grant_only_parent_ids
                 )
             return await KnowledgeFileDao.async_count_files_by_domain_scopes(
                 visible_scopes,
@@ -5512,23 +5439,16 @@ class KnowledgeSpaceService(KnowledgeUtils):
         visible_scopes: dict[str, set[int]] = {}
         if discovery_scope in {"portal_public", "portal_configured"}:
             discovery = await self.resolve_portal_discovery(scope=discovery_scope)
-            full_space_ids = set(discovery.discoverable_space_ids) | set(
-                discovery.explicitly_visible_space_ids
-            )
+            full_space_ids = set(discovery.discoverable_space_ids) | set(discovery.explicitly_visible_space_ids)
             grant_only_parent_ids = set(discovery.grant_parent_space_ids) - full_space_ids
             visible_file_ids: dict[str, set[int]] = {}
             for category in categories:
-                requested_ids = {
-                    int(space_id) for space_id in category.space_ids if int(space_id) > 0
-                }
-                visible_scopes.setdefault(category.code, set()).update(
-                    requested_ids & full_space_ids
-                )
+                requested_ids = {int(space_id) for space_id in category.space_ids if int(space_id) > 0}
+                visible_scopes.setdefault(category.code, set()).update(requested_ids & full_space_ids)
                 visible_file_ids.setdefault(category.code, set()).update(
                     file_id
                     for file_id, parent_space_id in discovery.explicit_file_space_by_id.items()
-                    if parent_space_id in requested_ids
-                    and parent_space_id in grant_only_parent_ids
+                    if parent_space_id in requested_ids and parent_space_id in grant_only_parent_ids
                 )
             return await KnowledgeFileDao.async_count_files_by_category_scopes(
                 visible_scopes,
@@ -5556,9 +5476,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
             )
             search_payload["limit"] = PORTAL_SEARCH_FINAL_LIMIT
             search_payload["cursor"] = None
-            result = await self.search_shougang_portal_files(
-                ShougangPortalFileSearchReq.model_validate(search_payload)
-            )
+            result = await self.search_shougang_portal_files(ShougangPortalFileSearchReq.model_validate(search_payload))
             discovery = getattr(self, "_portal_discovery_result", None)
             return {
                 "total": len(result.get("data") or []),
@@ -5576,9 +5494,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
             seen_cursors: set[str] = set()
             while True:
                 result = await self.advanced_search_shougang_portal_files(
-                    ShougangPortalAdvancedFileSearchReq.model_validate(
-                        advanced_payload
-                    )
+                    ShougangPortalAdvancedFileSearchReq.model_validate(advanced_payload)
                 )
                 total += len(result.get("data") or [])
                 next_cursor = str(result.get("next_cursor") or "")
@@ -5626,9 +5542,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                     ShougangPortalFileBrowseReq.model_validate(browse_payload)
                 )
                 for item in result.get("data") or []:
-                    canonical_id = int(
-                        item.get("canonical_document_id") or item.get("id") or 0
-                    )
+                    canonical_id = int(item.get("canonical_document_id") or item.get("id") or 0)
                     if canonical_id > 0:
                         seen_documents.add(canonical_id)
                 next_cursor = str(result.get("next_cursor") or "")
@@ -5682,19 +5596,14 @@ class KnowledgeSpaceService(KnowledgeUtils):
             }
         if tag_file_ids is not None and filter_tag_file_ids is not None:
             filter_tag_file_id_set = set(filter_tag_file_ids)
-            tag_file_ids = [
-                file_id for file_id in tag_file_ids if file_id in filter_tag_file_id_set
-            ]
+            tag_file_ids = [file_id for file_id in tag_file_ids if file_id in filter_tag_file_id_set]
         elif filter_tag_file_ids is not None:
             tag_file_ids = filter_tag_file_ids
 
         full_space_ids: list[int] | None = None
         explicit_file_ids: list[int] | None = None
         if req.discovery_scope in {"portal_public", "portal_configured"} and discovery is not None:
-            full_space_id_set = (
-                set(discovery.discoverable_space_ids)
-                | set(discovery.explicitly_visible_space_ids)
-            )
+            full_space_id_set = set(discovery.discoverable_space_ids) | set(discovery.explicitly_visible_space_ids)
             full_space_ids = sorted(full_space_id_set)
             grant_only_parent_ids = set(discovery.grant_parent_space_ids) - full_space_id_set
             explicit_file_ids = sorted(
@@ -5756,9 +5665,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 }
                 for space in spaces
             ]
-        department_space_ids = await self._get_valid_department_space_ids(
-            {int(space.id) for space in spaces}
-        )
+        department_space_ids = await self._get_valid_department_space_ids({int(space.id) for space in spaces})
         return [
             {
                 "id": int(space.id),
@@ -6357,9 +6264,11 @@ class KnowledgeSpaceService(KnowledgeUtils):
         self,
         req: ShougangPortalAdvancedFileSearchReq,
     ) -> dict:
-        spaces, effective_discovery_scope, trusted_public_scope = (
-            await self._resolve_shougang_portal_advanced_search_spaces(req)
-        )
+        (
+            spaces,
+            effective_discovery_scope,
+            trusted_public_scope,
+        ) = await self._resolve_shougang_portal_advanced_search_spaces(req)
         if not spaces:
             return self._build_shougang_portal_cursor_response([], False, None)
 
@@ -6412,18 +6321,13 @@ class KnowledgeSpaceService(KnowledgeUtils):
             ):
                 batch_size = min(
                     fulltext_constants.KNOWLEDGE_FULLTEXT_SEARCH_BATCH_SIZE,
-                    fulltext_constants.KNOWLEDGE_FULLTEXT_SEARCH_MAX_SCAN_HITS
-                    - scanned_hits,
+                    fulltext_constants.KNOWLEDGE_FULLTEXT_SEARCH_MAX_SCAN_HITS - scanned_hits,
                 )
                 batch = await search_service.fetch(query, session, size=batch_size)
                 scanned_batches += 1
                 scanned_hits += len(batch.hits)
                 failure_stage = "database_recheck"
-                raw_files = list(
-                    await file_repository.find_by_ids(
-                        [hit.file_id for hit in batch.hits]
-                    )
-                )
+                raw_files = list(await file_repository.find_by_ids([hit.file_id for hit in batch.hits]))
                 valid_files = self._restore_valid_fulltext_files(
                     raw_files,
                     hits=batch.hits,
@@ -6436,13 +6340,10 @@ class KnowledgeSpaceService(KnowledgeUtils):
                     visible_batch = await self._filter_shougang_portal_search_files(
                         valid_files,
                         spaces=spaces,
-                        defer_department_access=effective_discovery_scope
-                        == "public_and_department",
+                        defer_department_access=effective_discovery_scope == "public_and_department",
                     )
                 visible_ids = {int(file.id) for file in visible_batch}
-                sort_by_file_id = {
-                    hit.file_id: list(hit.sort_values) for hit in batch.hits
-                }
+                sort_by_file_id = {hit.file_id: list(hit.sort_values) for hit in batch.hits}
                 for file in valid_files:
                     file_id = int(file.id)
                     if file_id not in visible_ids:
@@ -6533,9 +6434,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
         self,
         req: ShougangPortalAdvancedUploaderSearchReq,
     ) -> dict:
-        spaces, _, trusted_public_scope = (
-            await self._resolve_shougang_portal_advanced_search_spaces(req)
-        )
+        spaces, _, trusted_public_scope = await self._resolve_shougang_portal_advanced_search_spaces(req)
         if not spaces:
             return {"data": []}
         search_service, file_repository = self._require_shougang_portal_fulltext_dependencies()
@@ -6554,9 +6453,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
             uploader_ids=[int(user.user_id) for user in users],
             per_uploader_limit=fulltext_constants.KNOWLEDGE_FULLTEXT_SEARCH_UPLOADER_SUPPORT_LIMIT,
         )
-        support_file_ids = list(
-            dict.fromkeys(file_id for support in supports for file_id in support.file_ids)
-        )
+        support_file_ids = list(dict.fromkeys(file_id for support in supports for file_id in support.file_ids))
         files = list(await file_repository.find_by_ids(support_file_ids))
         valid_files = self._restore_valid_fulltext_files(
             files,
@@ -6572,11 +6469,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 defer_department_access=False,
             )
         visible_ids = {int(file.id) for file in visible_files}
-        supported_user_ids = {
-            support.user_id
-            for support in supports
-            if visible_ids.intersection(support.file_ids)
-        }
+        supported_user_ids = {support.user_id for support in supports if visible_ids.intersection(support.file_ids)}
         candidates = [
             ShougangPortalAdvancedUploaderItemResp(
                 user_id=int(user.user_id),
@@ -6589,14 +6482,15 @@ class KnowledgeSpaceService(KnowledgeUtils):
         return {
             "data": [
                 item.model_dump(mode="json")
-                for item in candidates[: min(req.limit, fulltext_constants.KNOWLEDGE_FULLTEXT_SEARCH_UPLOADER_RESULT_LIMIT)]
+                for item in candidates[
+                    : min(req.limit, fulltext_constants.KNOWLEDGE_FULLTEXT_SEARCH_UPLOADER_RESULT_LIMIT)
+                ]
             ]
         }
 
     async def _resolve_shougang_portal_advanced_search_spaces(
         self,
-        req: ShougangPortalAdvancedFileSearchReq
-        | ShougangPortalAdvancedUploaderSearchReq,
+        req: ShougangPortalAdvancedFileSearchReq | ShougangPortalAdvancedUploaderSearchReq,
     ) -> tuple[list[Knowledge], str, bool]:
         effective_discovery_scope = (
             req.discovery_scope
@@ -7305,10 +7199,14 @@ class KnowledgeSpaceService(KnowledgeUtils):
         *,
         space_id: int,
         file_id: int,
+        qa_question_id: int | None = None,
+        qa_doc_source: str | None = None,
     ) -> ShougangPortalFileItemResp | None:
         file, spaces = await self._get_authorized_shougang_portal_file(
             space_id=space_id,
             file_id=file_id,
+            qa_question_id=qa_question_id,
+            qa_doc_source=qa_doc_source,
         )
         if file is None:
             return None
@@ -7327,10 +7225,14 @@ class KnowledgeSpaceService(KnowledgeUtils):
         *,
         space_id: int,
         file_id: int,
+        qa_question_id: int | None = None,
+        qa_doc_source: str | None = None,
     ) -> dict:
         file, _ = await self._get_authorized_shougang_portal_file(
             space_id=space_id,
             file_id=file_id,
+            qa_question_id=qa_question_id,
+            qa_doc_source=qa_doc_source,
         )
         if file is None:
             return {}
@@ -7382,12 +7284,17 @@ class KnowledgeSpaceService(KnowledgeUtils):
         file_id: int,
         page: int,
         limit: int,
+        qa_question_id: int | None = None,
+        qa_doc_source: str | None = None,
     ) -> dict:
         file, spaces = await self._get_authorized_shougang_portal_file(
             space_id=space_id,
             file_id=file_id,
+            qa_question_id=qa_question_id,
+            qa_doc_source=qa_doc_source,
         )
-        if file is None or not spaces:
+        qa_decision = self._portal_file_access_decision_map.get(int(file.id)) if file is not None else None
+        if file is None or (not spaces and not (qa_decision and qa_decision.allowed)):
             return {"data": [], "total": 0}
         resolved = await self._resolve_shougang_portal_content_entry(
             file,
@@ -7562,11 +7469,54 @@ class KnowledgeSpaceService(KnowledgeUtils):
         visible_files = await self._filter_shougang_portal_visible_files([file], spaces=spaces)
         return (visible_files[0], spaces) if visible_files else (None, spaces)
 
+    async def _portal_access_via_expert_qa_context(
+        self,
+        *,
+        file: KnowledgeFile,
+        space_id: int,
+        qa_question_id: int | None,
+        qa_doc_source: str | None,
+    ) -> tuple[KnowledgeFile, list[Knowledge]] | None:
+        """专家问答关联文档只读预览：不走部门审批与空间 discover，禁止下载。"""
+        if not qa_question_id or qa_doc_source not in {"question", "answer"}:
+            return None
+        from bisheng.knowledge.domain.services.department_file_view_access_service import (
+            DepartmentFileAccessDecision,
+            DepartmentFileAccessSource,
+            DepartmentFileAccessStatus,
+        )
+        from bisheng.qa_expert.domain.qa_related_doc_context_access import (
+            check_qa_related_doc_context_access,
+        )
+
+        allowed = await check_qa_related_doc_context_access(
+            self.login_user,
+            question_id=int(qa_question_id),
+            space_id=int(space_id),
+            file_id=int(file.id),
+            doc_source=qa_doc_source,  # type: ignore[arg-type]
+        )
+        if not allowed:
+            return None
+        decision = DepartmentFileAccessDecision(
+            file_id=int(file.id),
+            space_id=int(space_id),
+            status=DepartmentFileAccessStatus.ALLOWED,
+            source=DepartmentFileAccessSource.EXPERT_QA,
+            can_download=False,
+        )
+        self._portal_file_access_decision_map[int(file.id)] = decision
+        self._portal_file_download_map[int(file.id)] = False
+        space = await KnowledgeDao.aquery_by_id(int(space_id))
+        return (file, [space] if space else [])
+
     async def _get_authorized_shougang_portal_file(
         self,
         *,
         space_id: int,
         file_id: int,
+        qa_question_id: int | None = None,
+        qa_doc_source: str | None = None,
     ) -> tuple[KnowledgeFile | None, list[Knowledge]]:
         if self.document_durable_reference_resolver is not None:
             from bisheng.knowledge.domain.services.knowledge_document_entry_resolver import (
@@ -7591,6 +7541,15 @@ class KnowledgeSpaceService(KnowledgeUtils):
             or int(file.status) != KnowledgeFileStatus.SUCCESS.value
         ):
             return None, []
+
+        qa_access = await self._portal_access_via_expert_qa_context(
+            file=file,
+            space_id=int(space_id),
+            qa_question_id=qa_question_id,
+            qa_doc_source=qa_doc_source,
+        )
+        if qa_access is not None:
+            return qa_access
 
         access_service = self.department_file_view_access_service
         if access_service is None:
@@ -8917,10 +8876,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
         full_space_ids: list[int] | None = None
         explicit_file_ids: list[int] | None = None
         if req.discovery_scope in {"portal_public", "portal_configured"} and discovery is not None:
-            full_space_ids = sorted(
-                set(discovery.discoverable_space_ids)
-                | set(discovery.explicitly_visible_space_ids)
-            )
+            full_space_ids = sorted(set(discovery.discoverable_space_ids) | set(discovery.explicitly_visible_space_ids))
             explicit_file_ids = list(discovery.explicitly_visible_file_ids)
         while True:
             raw_files = await KnowledgeFileDao.aget_file_by_space_filters_cursor(
@@ -9145,12 +9101,8 @@ class KnowledgeSpaceService(KnowledgeUtils):
             list(space_by_id),
             spaces=spaces,
         )
-        content_space_ids = public_space_ids | {
-            int(space_id) for space_id in discovery.explicitly_visible_space_ids
-        }
-        content_spaces = [
-            space for space in spaces if int(space.id) in content_space_ids
-        ]
+        content_space_ids = public_space_ids | {int(space_id) for space_id in discovery.explicitly_visible_space_ids}
+        content_spaces = [space for space in spaces if int(space.id) in content_space_ids]
 
         recall_jobs: list[Any] = []
         if content_spaces:
@@ -9171,17 +9123,11 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 ]
             )
 
-        explicit_file_ids = {
-            int(file_id) for file_id in discovery.explicitly_visible_file_ids
-        }
+        explicit_file_ids = {int(file_id) for file_id in discovery.explicitly_visible_file_ids}
         if tag_file_ids is not None:
             explicit_file_ids.intersection_update(int(file_id) for file_id in tag_file_ids)
-        grant_parent_ids = {
-            int(space_id) for space_id in discovery.grant_parent_space_ids
-        } - content_space_ids
-        grant_parent_spaces = [
-            space for space in spaces if int(space.id) in grant_parent_ids
-        ]
+        grant_parent_ids = {int(space_id) for space_id in discovery.grant_parent_space_ids} - content_space_ids
+        grant_parent_spaces = [space for space in spaces if int(space.id) in grant_parent_ids]
         if grant_parent_spaces and explicit_file_ids:
             grant_filter_ids = sorted(explicit_file_ids)
             recall_jobs.extend(
@@ -9201,17 +9147,14 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 ]
             )
 
-        recalled_chunks = [
-            chunk
-            for chunk_group in await asyncio.gather(*recall_jobs)
-            for chunk in chunk_group
-        ] if recall_jobs else []
+        recalled_chunks = (
+            [chunk for chunk_group in await asyncio.gather(*recall_jobs) for chunk in chunk_group]
+            if recall_jobs
+            else []
+        )
 
         metadata_space_ids = sorted(
-            {
-                int(space_id) for space_id in discovery.discoverable_space_ids
-            }
-            - content_space_ids
+            {int(space_id) for space_id in discovery.discoverable_space_ids} - content_space_ids
         )
         metadata_files: list[KnowledgeFile] = []
         if metadata_space_ids:
@@ -10521,13 +10464,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
         if discovery_scope in {"portal_public", "portal_configured"}:
             discovery = await self.resolve_portal_discovery(scope=discovery_scope)
             allowed_ids = set(discovery.query_space_ids)
-            requested_ids = list(
-                dict.fromkeys(
-                    int(space_id)
-                    for space_id in requested_space_ids
-                    if int(space_id) > 0
-                )
-            )
+            requested_ids = list(dict.fromkeys(int(space_id) for space_id in requested_space_ids if int(space_id) > 0))
             ordered_ids = (
                 [space_id for space_id in requested_ids if space_id in allowed_ids]
                 if requested_ids
@@ -10542,9 +10479,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                     KnowledgeSpaceLevelEnum.PERSONAL: {"personal"},
                 }.get(space_level, set())
                 ordered_ids = [
-                    space_id
-                    for space_id in ordered_ids
-                    if discovery.space_kind_by_id.get(space_id) in expected_kinds
+                    space_id for space_id in ordered_ids if discovery.space_kind_by_id.get(space_id) in expected_kinds
                 ]
             if not ordered_ids:
                 return []
@@ -10555,17 +10490,12 @@ class KnowledgeSpaceService(KnowledgeUtils):
             space_map = {
                 int(space.id): space
                 for space in spaces
-                if space.id is not None
-                and int(space.type) == KnowledgeTypeEnum.SPACE.value
+                if space.id is not None and int(space.type) == KnowledgeTypeEnum.SPACE.value
             }
-            public_can_download = "download_file" in default_permission_ids_for_relation(
-                "viewer"
-            )
+            public_can_download = "download_file" in default_permission_ids_for_relation("viewer")
             for space_id in ordered_ids:
                 self._portal_space_download_map[space_id] = (
-                    public_can_download
-                    if discovery.space_kind_by_id.get(space_id) == "public"
-                    else False
+                    public_can_download if discovery.space_kind_by_id.get(space_id) == "public" else False
                 )
             return [space_map[space_id] for space_id in ordered_ids if space_id in space_map]
         if discovery_scope not in {"public", "public_and_department"}:
@@ -10750,11 +10680,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
             ).casefold()
             if normalized_keyword and normalized_keyword not in search_text:
                 continue
-            label = (
-                f"{space_name} ({projection.display_name})"
-                if projection.display_name
-                else space_name
-            )
+            label = f"{space_name} ({projection.display_name})" if projection.display_name else space_name
             options.append(
                 {
                     "value": str(space_id),
@@ -11071,9 +10997,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
         department_space_ids = await self._get_valid_department_space_ids(set(grouped_files) - public_space_ids)
         portal_space_kind_map = getattr(self, "_portal_space_kind_map", {})
         guarded_space_ids = department_space_ids | {
-            space_id
-            for space_id in grouped_files
-            if portal_space_kind_map.get(space_id) in {"department", "clinic"}
+            space_id for space_id in grouped_files if portal_space_kind_map.get(space_id) in {"department", "clinic"}
         }
         visible_files: list[KnowledgeFile] = []
         for space_id, items in grouped_files.items():
@@ -11088,9 +11012,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 )
                 if not has_full_space_access:
                     items = [
-                        item
-                        for item in items
-                        if int(item.id) in getattr(self, "_portal_explicit_file_ids", set())
+                        item for item in items if int(item.id) in getattr(self, "_portal_explicit_file_ids", set())
                     ]
                     if not items:
                         continue
@@ -11164,9 +11086,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
         department_space_ids = await self._get_valid_department_space_ids(space_ids - public_space_ids)
         portal_space_kind_map = getattr(self, "_portal_space_kind_map", {})
         guarded_space_ids = department_space_ids | {
-            space_id
-            for space_id in space_ids
-            if portal_space_kind_map.get(space_id) in {"department", "clinic"}
+            space_id for space_id in space_ids if portal_space_kind_map.get(space_id) in {"department", "clinic"}
         }
 
         public_files: list[KnowledgeFile] = []
@@ -11302,10 +11222,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
             not content_allowed
             and (
                 access_decision is not None
-                or (
-                    discovery is not None
-                    and space_id not in discovery.explicitly_visible_space_ids
-                )
+                or (discovery is not None and space_id not in discovery.explicitly_visible_space_ids)
             )
         )
         space_kind = getattr(self, "_portal_space_kind_map", {}).get(space_id)
@@ -11314,7 +11231,8 @@ class KnowledgeSpaceService(KnowledgeUtils):
             KnowledgeSpaceLevelEnum.TEAM
             if is_clinic
             else KnowledgeSpaceLevelEnum(space_kind)
-            if space_kind in {
+            if space_kind
+            in {
                 "public",
                 "department",
                 "team",
@@ -11360,7 +11278,9 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 capability_payload.get("can_download", False)
                 if capability_payload
                 else self._portal_file_download_map.get(file_id, False)
-            ) if content_allowed else False,
+            )
+            if content_allowed
+            else False,
             content_access=content_access,
             access_source=(
                 str(access_decision.source)
@@ -11787,15 +11707,13 @@ class KnowledgeSpaceService(KnowledgeUtils):
         )
         has_manual_old_department_viewer = False
         if int(old_department.id) != int(target_department.id):
-            has_manual_old_department_viewer = (
-                await FineGrainedPermissionService.has_explicit_relation_binding(
-                    object_type="knowledge_space",
-                    object_id=space_id,
-                    subject_type="department",
-                    subject_id=int(old_department.id),
-                    relation="viewer",
-                    include_children=True,
-                )
+            has_manual_old_department_viewer = await FineGrainedPermissionService.has_explicit_relation_binding(
+                object_type="knowledge_space",
+                object_id=space_id,
+                subject_type="department",
+                subject_id=int(old_department.id),
+                relation="viewer",
+                include_children=True,
             )
         plan = await self.department_space_binding_repo.prepare_rebind_department(
             space_id=space_id,
@@ -11813,9 +11731,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
             raise RuntimeError("DepartmentFileViewLifecycleService is not configured")
         try:
             await self.department_file_view_lifecycle_service.prepare_department_rebind(
-                tenant_id=int(
-                    getattr(space, "tenant_id", None) or self.login_user.tenant_id
-                ),
+                tenant_id=int(getattr(space, "tenant_id", None) or self.login_user.tenant_id),
                 space_id=space_id,
                 old_department_id=plan.old_department_id,
                 new_department_id=plan.new_department_id,
@@ -11838,9 +11754,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 plan = replace(
                     plan,
                     manager_revoke_user_ids=tuple(
-                        user_id
-                        for user_id in plan.manager_revoke_user_ids
-                        if user_id not in protected_manager_ids
+                        user_id for user_id in plan.manager_revoke_user_ids if user_id not in protected_manager_ids
                     ),
                 )
             await self._write_department_rebind_permissions(plan)
@@ -11870,8 +11784,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
             await self._write_department_rebind_permissions(plan, reverse=True)
         except Exception:
             _logger.exception(
-                "Department rebind compensation failed: space_id=%s old_department_id=%s "
-                "new_department_id=%s",
+                "Department rebind compensation failed: space_id=%s old_department_id=%s new_department_id=%s",
                 plan.space_id,
                 plan.old_department_id,
                 plan.new_department_id,
@@ -11917,11 +11830,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 and rebind_scope.owner_type == KnowledgeSpaceOwnerTypeEnum.USER
                 and KnowledgeSpaceLevelEnum.is_team_level(rebind_scope.level)
             )
-            clinic_binding = (
-                await DepartmentKnowledgeSpaceDao.aget_by_space_id(space_id)
-                if is_clinic_scope
-                else None
-            )
+            clinic_binding = await DepartmentKnowledgeSpaceDao.aget_by_space_id(space_id) if is_clinic_scope else None
             is_clinic_space = is_clinic_scope and clinic_binding is not None
             if not is_department_space and not is_clinic_space:
                 raise SpaceInvalidScopeOwnerError(msg="仅部门知识库或科室知识库可以修改所属部门")
@@ -11973,9 +11882,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
             discovery_scope = await self.knowledge_space_scope_repo.find_by_space_id(space_id)
             discovery_binding = await DepartmentKnowledgeSpaceDao.aget_by_space_id(space_id)
             if self._portal_discovery_kind(discovery_scope, discovery_binding) is None:
-                raise SpaceInvalidScopeOwnerError(
-                    msg="仅公共知识库、部门知识库或科室知识库可以配置门户公开范围"
-                )
+                raise SpaceInvalidScopeOwnerError(msg="仅公共知识库、部门知识库或科室知识库可以配置门户公开范围")
 
         old_auth_type = space.auth_type
         normalized_name = self._normalize_space_name(name) if name is not None else None
@@ -12037,11 +11944,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
             space.auto_tag_library_id = resolved_library_id
 
         prepared_portal_rebind_plan = None
-        if (
-            portal_discovery_enabled is not None
-            and department_id is not None
-            and not is_clinic_rebind
-        ):
+        if portal_discovery_enabled is not None and department_id is not None and not is_clinic_rebind:
             prepared_portal_rebind_plan = await self._prepare_department_rebind_for_update(
                 space=space,
                 space_id=space_id,
@@ -12053,34 +11956,25 @@ class KnowledgeSpaceService(KnowledgeUtils):
         if portal_discovery_enabled is not None and discovery_scope is not None:
             old_value = bool(discovery_scope.portal_discovery_enabled)
             atomic_clinic_binding = None
-            if (
-                is_clinic_rebind
-                and int(clinic_binding.department_id) != int(department_id)
-            ):
+            if is_clinic_rebind and int(clinic_binding.department_id) != int(department_id):
                 clinic_binding.department_id = int(department_id)
                 atomic_clinic_binding = clinic_binding
             try:
                 if prepared_portal_rebind_plan is not None:
-                    updated_scope = (
-                        await self.knowledge_space_scope_repo.stage_space_and_portal_discovery(
-                            space=space,
-                            enabled=portal_discovery_enabled,
-                        )
+                    updated_scope = await self.knowledge_space_scope_repo.stage_space_and_portal_discovery(
+                        space=space,
+                        enabled=portal_discovery_enabled,
                     )
                     await self.department_space_binding_repo.commit_prepared_rebind()
                 else:
-                    updated_scope = (
-                        await self.knowledge_space_scope_repo.update_space_and_portal_discovery(
-                            space=space,
-                            enabled=portal_discovery_enabled,
-                            department_binding=atomic_clinic_binding,
-                        )
+                    updated_scope = await self.knowledge_space_scope_repo.update_space_and_portal_discovery(
+                        space=space,
+                        enabled=portal_discovery_enabled,
+                        department_binding=atomic_clinic_binding,
                     )
             except Exception as exc:
                 if prepared_portal_rebind_plan is not None:
-                    await self._rollback_prepared_department_rebind(
-                        prepared_portal_rebind_plan
-                    )
+                    await self._rollback_prepared_department_rebind(prepared_portal_rebind_plan)
                 await self._write_portal_discovery_audit(
                     space=space,
                     old_value=old_value,
@@ -12101,10 +11995,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
             if is_clinic_rebind:
                 # Clinic spaces only need the department_knowledge_space binding updated;
                 # the scope remains TEAM_KS/USER (or legacy TEAM/USER).
-                if (
-                    portal_discovery_enabled is None
-                    and int(clinic_binding.department_id) != int(department_id)
-                ):
+                if portal_discovery_enabled is None and int(clinic_binding.department_id) != int(department_id):
                     clinic_binding.department_id = int(department_id)
                     await DepartmentKnowledgeSpaceDao.aupdate(clinic_binding)
                 await KnowledgeSpaceContentStat.enqueue_space_rename_stat_async(space_id)
@@ -12197,9 +12088,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
         error_type: str | None = None,
     ) -> None:
         request_id = str(
-            getattr(getattr(self.request, "headers", None), "get", lambda _key, _default=None: None)(
-                "X-Request-ID"
-            )
+            getattr(getattr(self.request, "headers", None), "get", lambda _key, _default=None: None)("X-Request-ID")
             or ""
         )
         metadata = {
@@ -13681,14 +13570,12 @@ class KnowledgeSpaceService(KnowledgeUtils):
                     knowledge_id,
                     "",
                 )
-                resolved_metadata[item_id]["source_department_short_name"] = (
-                    source_department_short_name_map.get(knowledge_id)
+                resolved_metadata[item_id]["source_department_short_name"] = source_department_short_name_map.get(
+                    knowledge_id
                 )
-                resolved_metadata[item_id]["source_department_display_name"] = (
-                    source_department_display_name_map.get(
-                        knowledge_id,
-                        source_department_name_map.get(knowledge_id, ""),
-                    )
+                resolved_metadata[item_id]["source_department_display_name"] = source_department_display_name_map.get(
+                    knowledge_id,
+                    source_department_name_map.get(knowledge_id, ""),
                 )
         return resolved_metadata
 
@@ -13706,7 +13593,6 @@ class KnowledgeSpaceService(KnowledgeUtils):
         permission_context: dict | None = None,
     ) -> dict[str, int]:
         from sqlalchemy import or_
-        from sqlmodel import col
 
         prefix = f"{folder.file_level_path or ''}/{folder.id}"
         stmt = (
@@ -13775,7 +13661,6 @@ class KnowledgeSpaceService(KnowledgeUtils):
         ``visible_success_file_num`` here means direct SUCCESS files (not deep, not visibility-filtered);
         precise <=20 enforcement stays in ``resolve_qa_scope_file_ids`` at QA time.
         """
-        from sqlmodel import col
 
         folder_counts: dict[int, dict[str, int | bool]] = {}
         if not folders:
@@ -14132,18 +14017,13 @@ class KnowledgeSpaceService(KnowledgeUtils):
             KnowledgeFileEntryType.SHARE.value,
         }
         original_uploader_ids = sorted(
-            {
-                int(item.original_uploader_id)
-                for item in file_items
-                if item.original_uploader_id is not None
-            }
+            {int(item.original_uploader_id) for item in file_items if item.original_uploader_id is not None}
         )
         original_knowledge_ids = sorted(
             {
                 int(item.original_knowledge_id)
                 for item in file_items
-                if item.entry_type in distributed_entry_types
-                and item.original_knowledge_id is not None
+                if item.entry_type in distributed_entry_types and item.original_knowledge_id is not None
             }
         )
         invalid_manager_space_ids = sorted(
@@ -14152,8 +14032,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 for item in file_items
                 if item.entry_status == KnowledgeFileEntryStatus.INVALID.value
                 and item.reference_document_id is not None
-                and (document := document_map.get(int(item.reference_document_id)))
-                is not None
+                and (document := document_map.get(int(item.reference_document_id))) is not None
                 and document.lifecycle_status
                 in {
                     KnowledgeDocumentLifecycleStatus.DELETING.value,
@@ -14161,27 +14040,16 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 }
             }
         )
-        distribution_space_ids = sorted(
-            set(original_knowledge_ids) | set(invalid_manager_space_ids)
-        )
+        distribution_space_ids = sorted(set(original_knowledge_ids) | set(invalid_manager_space_ids))
         original_users, original_spaces = await asyncio.gather(
-            UserDao.aget_user_by_ids(original_uploader_ids)
-            if original_uploader_ids
-            else asyncio.sleep(0, result=[]),
+            UserDao.aget_user_by_ids(original_uploader_ids) if original_uploader_ids else asyncio.sleep(0, result=[]),
             KnowledgeDao.async_get_spaces_by_ids(distribution_space_ids)
             if distribution_space_ids
             else asyncio.sleep(0, result=[]),
         )
-        original_user_name_map = {
-            int(user.user_id): str(user.user_name or user.user_id) for user in original_users
-        }
-        original_space_name_map = {
-            int(space.id): str(space.name or space.id) for space in original_spaces
-        }
-        distribution_space_state_map = {
-            int(space.id): getattr(space, "state", None)
-            for space in original_spaces
-        }
+        original_user_name_map = {int(user.user_id): str(user.user_name or user.user_id) for user in original_users}
+        original_space_name_map = {int(space.id): str(space.name or space.id) for space in original_spaces}
+        distribution_space_state_map = {int(space.id): getattr(space, "state", None) for space in original_spaces}
 
         info: dict[int, dict] = {}
         for item in file_items:
@@ -14201,9 +14069,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 ),
             )
             capability_payload = capabilities.model_dump()
-            is_invalid = (
-                item.entry_status == KnowledgeFileEntryStatus.INVALID.value
-            )
+            is_invalid = item.entry_status == KnowledgeFileEntryStatus.INVALID.value
             if is_invalid:
                 capability_payload = KnowledgeDocumentEntryCapabilities(
                     can_delete="delete_file" in set(permission_ids)
@@ -14260,9 +14126,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                             KnowledgeDocumentLifecycleStatus.DELETING.value,
                             KnowledgeDocumentLifecycleStatus.INVALID.value,
                         }
-                        and distribution_space_state_map.get(
-                            int(document.knowledge_id)
-                        )
+                        and distribution_space_state_map.get(int(document.knowledge_id))
                         == KnowledgeState.PUBLISHED.value
                         else "manager_space_deleted"
                     )
@@ -16732,11 +16596,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
 
         for file_id in unique_file_ids:
             file_record = file_by_id.get(file_id)
-            if (
-                not file_record
-                or file_record.knowledge_id != space_id
-                or file_record.file_type == FileType.DIR.value
-            ):
+            if not file_record or file_record.knowledge_id != space_id or file_record.file_type == FileType.DIR.value:
                 skipped_ids.append(file_id)
                 continue
             if not file_record.alias_name:
@@ -16748,11 +16608,15 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 alias_name = self._normalize_alias_target_name(file_record, file_record.alias_name)
                 self._check_filename_sensitive_words(alias_name)
 
-                if resolved is None and await SpaceFileDao.count_file_by_name(
-                    file_record.knowledge_id,
-                    alias_name,
-                    exclude_id=file_id,
-                ) > 0:
+                if (
+                    resolved is None
+                    and await SpaceFileDao.count_file_by_name(
+                        file_record.knowledge_id,
+                        alias_name,
+                        exclude_id=file_id,
+                    )
+                    > 0
+                ):
                     raise SpaceFileNameDuplicateError()
 
                 if alias_name in pending_names:
@@ -16845,11 +16709,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
 
         for file_id in unique_file_ids:
             file_record = file_by_id.get(file_id)
-            if (
-                not file_record
-                or file_record.knowledge_id != space_id
-                or file_record.file_type == FileType.DIR.value
-            ):
+            if not file_record or file_record.knowledge_id != space_id or file_record.file_type == FileType.DIR.value:
                 skipped_ids.append(file_id)
                 continue
             if not file_record.alias_name:

--- a/src/backend/bisheng/qa_expert/domain/qa_related_doc_context_access.py
+++ b/src/backend/bisheng/qa_expert/domain/qa_related_doc_context_access.py
@@ -1,0 +1,168 @@
+# ruff: noqa: RUF002
+"""专家问答关联文档上下文只读放行：can_read 不足时按问答角色补预览权。"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from loguru import logger
+
+from bisheng.database.models.qa_expert import (
+    EXPERT_STATUS_ACTIVE,
+    QUESTION_TYPE_DIRECTED,
+    QUESTION_TYPE_PUBLIC,
+)
+from bisheng.qa_expert.domain.capability import CapabilityResolver, CapabilitySnapshot
+from bisheng.qa_expert.domain.question_query import parse_related_doc_ref, parse_related_doc_tokens
+from bisheng.qa_expert.domain.related_docs_access import resolve_related_doc_target
+
+DocSource = Literal["question", "answer"]
+
+
+async def canonical_pairs_in_related_docs(raw: str | None) -> set[tuple[int, int]]:
+    """解析 related_docs 串为 canonical (space_id, file_id) 集合（含收藏引用改写）。"""
+    pairs: set[tuple[int, int]] = set()
+    for token in parse_related_doc_tokens(raw):
+        parsed = parse_related_doc_ref(token)
+        if parsed is None:
+            continue
+        try:
+            resolved = await resolve_related_doc_target(*parsed)
+        except Exception:
+            logger.exception("resolve related doc target failed token=%s", token)
+            resolved = parsed
+        if resolved is None:
+            continue
+        pairs.add((int(resolved[0]), int(resolved[1])))
+    return pairs
+
+
+async def _load_question(question_id: int) -> Any | None:
+    from bisheng.qa_expert.domain.repositories import QuestionRepository
+
+    return await QuestionRepository().get_by_id(int(question_id))
+
+
+async def _load_invited_user_ids(question_id: int) -> frozenset[int]:
+    from bisheng.qa_expert.domain.repositories import QuestionInviteRepository
+
+    invite_map = await QuestionInviteRepository().list_user_ids_by_question_ids([int(question_id)])
+    return frozenset(invite_map.get(int(question_id), set()))
+
+
+async def _is_active_expert_user(user_id: int) -> bool:
+    from bisheng.qa_expert.domain.repositories import ExpertRepository
+
+    expert = await ExpertRepository().get_by_user_id(int(user_id))
+    if expert is None:
+        return False
+    return int(getattr(expert, "status", 0) or 0) == EXPERT_STATUS_ACTIVE
+
+
+def _viewer_user_id(user: Any | None) -> int | None:
+    if user is None:
+        return None
+    value = getattr(user, "user_id", None)
+    return int(value) if value is not None else None
+
+
+def _question_visible_to_viewer(user: Any, question: Any, invited_user_ids: frozenset[int]) -> bool:
+    """与详情页一致：不可见问题不得借 QA 上下文越权读文档。"""
+    snapshot = CapabilitySnapshot(invited_user_ids=invited_user_ids)
+    result = CapabilityResolver().resolve(user, question, snapshot)
+    return bool(result.capabilities.visible)
+
+
+async def _can_view_question_related_doc(
+    user: Any,
+    *,
+    question: Any,
+    invited_user_ids: frozenset[int],
+    space_id: int,
+    file_id: int,
+) -> bool:
+    """提问侧关联文档：定向/公开邀请专家，或公开无邀请时全体在库专家。"""
+    viewer_id = _viewer_user_id(user)
+    if viewer_id is None:
+        return False
+    pairs = await canonical_pairs_in_related_docs(getattr(question, "related_docs", None))
+    if (int(space_id), int(file_id)) not in pairs:
+        return False
+
+    question_type = str(getattr(question, "question_type", QUESTION_TYPE_PUBLIC) or QUESTION_TYPE_PUBLIC)
+    if question_type == QUESTION_TYPE_DIRECTED:
+        return viewer_id in invited_user_ids
+    if invited_user_ids:
+        return viewer_id in invited_user_ids
+    return await _is_active_expert_user(viewer_id)
+
+
+async def _can_view_answer_related_doc(
+    user: Any,
+    *,
+    question: Any,
+    space_id: int,
+    file_id: int,
+) -> bool:
+    """回答侧关联文档：仅提问者可读，且文档须出现在该问题下任一回答的 related_docs。"""
+    viewer_id = _viewer_user_id(user)
+    asker_id = int(getattr(question, "user_id", 0) or 0)
+    if viewer_id is None or asker_id <= 0 or viewer_id != asker_id:
+        return False
+
+    from bisheng.qa_expert.domain.repositories import AnswerRepository
+
+    answers = await AnswerRepository().list_all_by_question_id(int(question.id))
+    target = (int(space_id), int(file_id))
+    for answer in answers:
+        pairs = await canonical_pairs_in_related_docs(getattr(answer, "related_docs", None))
+        if target in pairs:
+            return True
+    return False
+
+
+async def check_qa_related_doc_context_access(
+    user: Any,
+    *,
+    question_id: int,
+    space_id: int,
+    file_id: int,
+    doc_source: DocSource,
+) -> bool:
+    """校验 QA 上下文是否允许只读预览指定文档；失败不抛错。"""
+    try:
+        from bisheng.qa_expert.domain.related_docs_access import _file_belongs_to_space
+
+        if not await _file_belongs_to_space(int(space_id), int(file_id)):
+            return False
+        question = await _load_question(int(question_id))
+        if question is None:
+            return False
+        invited_user_ids = await _load_invited_user_ids(int(question_id))
+        if not _question_visible_to_viewer(user, question, invited_user_ids):
+            return False
+        if doc_source == "question":
+            return await _can_view_question_related_doc(
+                user,
+                question=question,
+                invited_user_ids=invited_user_ids,
+                space_id=int(space_id),
+                file_id=int(file_id),
+            )
+        if doc_source == "answer":
+            return await _can_view_answer_related_doc(
+                user,
+                question=question,
+                space_id=int(space_id),
+                file_id=int(file_id),
+            )
+        return False
+    except Exception:
+        logger.exception(
+            "check_qa_related_doc_context_access failed question_id=%s space=%s file=%s source=%s",
+            question_id,
+            space_id,
+            file_id,
+            doc_source,
+        )
+        return False

--- a/src/backend/bisheng/qa_expert/domain/related_docs_access.py
+++ b/src/backend/bisheng/qa_expert/domain/related_docs_access.py
@@ -184,6 +184,38 @@ async def _space_can_read(user: Any, space_id: int) -> bool:
         return False
 
 
+async def check_related_doc_access_with_qa_context(
+    user: Any,
+    space_id: int,
+    file_id: int,
+    *,
+    space_cache: dict[int, bool] | None = None,
+    question_id: int | None = None,
+    doc_source: str | None = None,
+) -> bool | None:
+    """在知识空间 can_read 之外，按专家问答上下文补只读 accessible。"""
+    base = await check_related_doc_access(user, space_id, file_id, space_cache=space_cache)
+    if base is True:
+        return True
+    if base is None:
+        return None
+    if question_id is None or doc_source not in {"question", "answer"}:
+        return False
+    from bisheng.qa_expert.domain.qa_related_doc_context_access import (
+        check_qa_related_doc_context_access,
+    )
+
+    if await check_qa_related_doc_context_access(
+        user,
+        question_id=int(question_id),
+        space_id=int(space_id),
+        file_id=int(file_id),
+        doc_source=doc_source,  # type: ignore[arg-type]
+    ):
+        return True
+    return False
+
+
 async def check_related_doc_access(
     user: Any,
     space_id: int,

--- a/src/backend/bisheng/qa_expert/domain/services.py
+++ b/src/backend/bisheng/qa_expert/domain/services.py
@@ -797,11 +797,18 @@ class QuestionService:
             )
 
     async def hydrate_related_docs(
-        self, related_docs: str | None, user=None, owner_user_id: int | None = None
+        self,
+        related_docs: str | None,
+        user=None,
+        owner_user_id: int | None = None,
+        *,
+        question_id: int | None = None,
+        doc_source: str | None = None,
     ) -> list[dict]:
         """解析关联文档串。问答可见不等于文档可读；无权 forbidden，缺失 not_found。
 
         owner_user_id 仅为兼容旧调用方，不再按提问者特判。
+        question_id + doc_source 启用 QA 上下文只读放行（邀请专家/公开全体专家/提问者看回答文档）。
         """
         del owner_user_id
         views: list[dict] = []
@@ -809,9 +816,18 @@ class QuestionService:
         space_cache: dict[int, bool] = {}
 
         async def _default_checker(_user, space_id: int, file_id: int):
-            from bisheng.qa_expert.domain.related_docs_access import check_related_doc_access
+            from bisheng.qa_expert.domain.related_docs_access import (
+                check_related_doc_access_with_qa_context,
+            )
 
-            return await check_related_doc_access(_user, space_id, file_id, space_cache=space_cache)
+            return await check_related_doc_access_with_qa_context(
+                _user,
+                space_id,
+                file_id,
+                space_cache=space_cache,
+                question_id=question_id,
+                doc_source=doc_source,
+            )
 
         checker = injected if callable(injected) else _default_checker
         from bisheng.qa_expert.domain.related_docs_access import load_related_doc_title
@@ -980,6 +996,8 @@ class QuestionService:
                 getattr(resolved, "related_docs", None),
                 user=viewer,
                 owner_user_id=int(getattr(resolved, "user_id", 0) or 0),
+                question_id=int(resolved.id),
+                doc_source="question",
             ),
         )
         from bisheng.qa_expert.domain.publish_service import PublishService, serialize_publish_request
@@ -1679,6 +1697,8 @@ class AnswerService:
                 getattr(item, "related_docs", None),
                 user=viewer,
                 owner_user_id=int(getattr(question, "user_id", 0) or 0),
+                question_id=int(question.id),
+                doc_source="answer",
             )
             self._annotate(item, can_delete=can_delete, related_doc_views=related_doc_views)
             resolved.append(item)

--- a/src/backend/test/qa_expert/conftest.py
+++ b/src/backend/test/qa_expert/conftest.py
@@ -223,7 +223,7 @@ async def flow_env(monkeypatch):
         AsyncMock(),
     )
 
-    async def _related_access(_user, _space_id, _file_id):
+    async def _related_access(_user, _space_id, _file_id, *, space_cache=None):
         return False
 
     monkeypatch.setattr(

--- a/src/backend/test/qa_expert/test_data_flow.py
+++ b/src/backend/test/qa_expert/test_data_flow.py
@@ -1844,3 +1844,109 @@ async def test_df_question_created_at_is_beijing_wall_clock(flow_env):
     hit = next((item for item in questions if int(item.get("id")) == qid), None)
     assert hit is not None
     assert str(hit.get("created_at") or "").endswith("+08:00")
+
+
+async def test_df04d_public_no_invite_active_expert_views_question_related_docs(flow_env, monkeypatch):
+    """公开题未指定专家：专家库在库专家可读提问关联文档（无 can_read）。"""
+    from bisheng.qa_expert.domain import related_docs_access as related_docs_access_mod
+
+    env = flow_env
+    monkeypatch.setattr(
+        related_docs_access_mod,
+        "_file_belongs_to_space",
+        AsyncMock(return_value=True),
+    )
+    await env.seed_expert(user_id=201, name="专家公开")
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df04d公开关联",
+            "description": "正文",
+            "business_domain": "steel",
+            "question_type": "public",
+            "related_doc_ids": ["8-15"],
+        },
+    )
+    expert_user = env.user(201, name="expert-user")
+    env.as_user(expert_user)
+    detail = _ok(await env.client.get(f"{PREFIX}/questions/{qid}"))
+    views = (detail.get("data") or {}).get("related_doc_views") or []
+    assert len(views) == 1
+    assert views[0].get("accessible") is True
+
+    env.as_user(env.stranger)
+    stranger = _ok(await env.client.get(f"{PREFIX}/questions/{qid}"))
+    stranger_views = (stranger.get("data") or {}).get("related_doc_views") or []
+    assert stranger_views[0].get("accessible") is False
+
+
+async def test_df04e_directed_invited_expert_views_question_related_docs(flow_env, monkeypatch):
+    """定向题：被邀请专家可读提问关联文档。"""
+    from bisheng.qa_expert.domain import related_docs_access as related_docs_access_mod
+
+    env = flow_env
+    monkeypatch.setattr(
+        related_docs_access_mod,
+        "_file_belongs_to_space",
+        AsyncMock(return_value=True),
+    )
+    expert = await env.seed_expert(user_id=202, name="专家定向")
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df04e定向关联",
+            "description": "正文",
+            "business_domain": "steel",
+            "question_type": "directed",
+            "invited_expert_ids": [expert.id],
+            "related_doc_ids": ["8-16"],
+        },
+    )
+    invited_user = env.user(202, name="invited-expert")
+    env.as_user(invited_user)
+    detail = _ok(await env.client.get(f"{PREFIX}/questions/{qid}"))
+    views = (detail.get("data") or {}).get("related_doc_views") or []
+    assert views[0].get("accessible") is True
+
+
+async def test_df04f_asker_views_answer_related_docs(flow_env, monkeypatch):
+    """提问者可读回答中的关联文档（无 can_read）。"""
+    from bisheng.qa_expert.domain import related_docs_access as related_docs_access_mod
+
+    env = flow_env
+    monkeypatch.setattr(
+        related_docs_access_mod,
+        "_file_belongs_to_space",
+        AsyncMock(return_value=True),
+    )
+    await env.seed_expert(user_id=203, name="答主")
+    expert_user = env.user(203, name="answer-expert")
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df04f回答关联",
+            "description": "正文",
+            "business_domain": "steel",
+            "question_type": "public",
+        },
+    )
+    env.as_user(expert_user)
+    await env.client.post(
+        f"{PREFIX}/answers",
+        json={
+            "question_id": qid,
+            "content": "回答正文",
+            "related_docs": "8-17",
+            "reveal_on_public": True,
+        },
+    )
+    env.as_user(env.asker)
+    answers = _ok(await env.client.get(f"{PREFIX}/answers/{qid}"))
+    items = (answers.get("data") or {}).get("answers") or []
+    assert items
+    views = items[0].get("related_doc_views") or []
+    assert views
+    assert views[0].get("accessible") is True


### PR DESCRIPTION
## Summary

- 新增 QA 上下文只读放行：邀请专家 / 公开未指定专家时全体在库专家可读**提问**关联文档；**提问者**可读**回答**关联文档
- 门户文件 detail/preview/chunks 支持 `qa_question_id`、`qa_doc_source` query，部门文件在 QA 链路上可预览（`can_download=false` 时仍不可下载）
- 补充流转测试 `test_df04d` / `test_df04e` / `test_df04f`

## 涉及数据表

读：`qa_question`、`qa_answer`、`qa_question_invite`、`knowledgefile`；无 DDL。

## Test plan

- [x] `pytest test/qa_expert/test_data_flow.py::test_df04d test_df04e test_df04f test_df04b`
- [ ] 联调：邀请专家预览提问关联文档；提问者预览回答关联文档；路人仍 403

## Merge note

可能与 `feat/2.5.0-sg` 上 `knowledge_space_service.py` 存在冲突，需人工合并 QA 上下文放行逻辑。

Made with [Cursor](https://cursor.com)