### PR TITLE
fix(permission): tool manager must not inherit manage_tool_owner (IKABS3)

### DIFF
--- a/src/backend/bisheng/permission/domain/tool_permission_template.py
+++ b/src/backend/bisheng/permission/domain/tool_permission_template.py
@@ -4,24 +4,37 @@ from __future__ import annotations
 
 from typing import Dict, List, Set
 
-_RELATION_LEVEL: Dict[str, int] = {
-    'can_read': 1,
-    'can_edit': 2,
-    'can_manage': 3,
-    'can_delete': 4,
-}
-
-_MODEL_LEVEL: Dict[str, int] = {
-    'viewer': 1,
-    'editor': 2,
-    'manager': 3,
-    'owner': 4,
-}
-_COMPUTED_TO_MODEL_RELATION: Dict[str, str] = {
-    'can_read': 'viewer',
-    'can_edit': 'editor',
-    'can_manage': 'manager',
-    'can_delete': 'owner',
+# NOTE: keep these tier lists in lockstep with the channel template
+# (channel_permission_template._DEFAULT_PERMISSION_IDS_BY_RELATION) so a
+# "manager" subject never inherits the "manage_*_owner" permission by default —
+# that would let a manager add or remove owners, breaking the owner/manager
+# hierarchy. The previous level-based calculation gave can_manage-level managers
+# the owner-tier manage permission as well (IKABS3).
+_DEFAULT_PERMISSION_IDS_BY_RELATION: Dict[str, Set[str]] = {
+    'owner': {
+        'view_tool',
+        'use_tool',
+        'edit_tool',
+        'delete_tool',
+        'manage_tool_owner',
+        'manage_tool_manager',
+        'manage_tool_viewer',
+    },
+    'manager': {
+        'view_tool',
+        'use_tool',
+        'edit_tool',
+        'manage_tool_manager',
+        'manage_tool_viewer',
+    },
+    'editor': {
+        'view_tool',
+        'use_tool',
+        'edit_tool',
+    },
+    'viewer': {
+        'view_tool',
+    },
 }
 
 TOOL_PERMISSION_TEMPLATE: dict = {
@@ -61,10 +74,10 @@ def tool_template_permissions() -> List[dict]:
 
 
 def default_permission_ids_for_relation(relation: str) -> Set[str]:
-    normalized = _COMPUTED_TO_MODEL_RELATION.get(relation, relation)
-    relation_level = _MODEL_LEVEL.get(normalized, 0)
-    return {
-        item['id']
-        for item in tool_template_permissions()
-        if relation_level >= _RELATION_LEVEL.get(item['relation'], 99)
-    }
+    """System-model default permissions for owner/manager/editor/viewer.
+
+    A manager is intentionally denied ``manage_tool_owner`` so the manager
+    cannot add or remove owners — only the owner can. This mirrors the
+    channel and application templates.
+    """
+    return set(_DEFAULT_PERMISSION_IDS_BY_RELATION.get(relation, set()))

--- a/src/backend/test/permission/test_permission_relation_defaults.py
+++ b/src/backend/test/permission/test_permission_relation_defaults.py
@@ -33,11 +33,20 @@ def test_application_permission_defaults_accept_computed_relations():
 
 
 def test_tool_permission_defaults_accept_computed_relations():
+    # IKABS3: manager must not inherit manage_tool_owner — only the owner tier
+    # is allowed to add or remove owners.
     assert default_tool_permission_ids_for_relation("can_read") == {"view_tool", "use_tool"}
     assert default_tool_permission_ids_for_relation("can_manage") == {
         "view_tool",
         "use_tool",
         "edit_tool",
+        "manage_tool_manager",
+        "manage_tool_viewer",
+    }
+    assert "manage_tool_owner" not in default_tool_permission_ids_for_relation("can_manage")
+    # owner gets every permission
+    assert default_tool_permission_ids_for_relation("can_delete") >= {
+        "delete_tool",
         "manage_tool_owner",
         "manage_tool_manager",
         "manage_tool_viewer",

--- a/src/backend/test/permission/test_resource_authorization_service.py
+++ b/src/backend/test/permission/test_resource_authorization_service.py
@@ -221,3 +221,39 @@ async def test_default_service_reads_relation_models_and_bindings_from_domain_st
 
     read_models.assert_awaited_once()
     read_bindings.assert_awaited_once()
+
+
+# IKABS3: a tool manager must not be able to revoke an owner-tier grant. The
+# earlier level-based default gave managers manage_tool_owner (same relation
+# level as manage_tool_manager) so the authorization service approved the
+# revoke; the fix moves tool defaults to an explicit per-tier table that omits
+# manage_tool_owner for managers.
+async def test_manager_cannot_revoke_tool_owner_grant():
+    from bisheng.permission.domain.services.resource_authorization_service import (
+        _can_grant_model,
+    )
+    from bisheng.permission.domain.tool_permission_template import (
+        default_permission_ids_for_relation,
+    )
+
+    manager_permissions = default_permission_ids_for_relation("manager")
+    # Regression check: a manager on a tool never inherits manage_tool_owner.
+    assert "manage_tool_owner" not in manager_permissions
+
+    owner_model = {
+        "id": "owner",
+        "name": "所有者",
+        "relation": "owner",
+        "grant_tier": "owner",
+        "permissions": [],
+        "permissions_explicit": False,
+        "is_system": True,
+    }
+    # The revoke check: even if a UI bug forwards the call, the backend must
+    # refuse to grant/revoke an owner-tier relation when the caller only has
+    # the manager-tier permission.
+    assert _can_grant_model("tool", "owner", owner_model, manager_permissions) is False
+
+    # Sanity: an owner still passes the check.
+    owner_permissions = default_permission_ids_for_relation("owner")
+    assert _can_grant_model("tool", "owner", owner_model, owner_permissions) is True


### PR DESCRIPTION
## 根因
- 工具权限模板 `default_permission_ids_for_relation` 采用「按关系等级累加」的通用算法，所有 `can_manage` 级权限的等级相同，导致「管理者」也会被默认授予 `manage_tool_owner`。
- `ResourceAuthorizationService._can_grant_model` 在 `manage_tool_owner` 已在调用方权限集时允许 `owner` 关系的 grant/revoke。
- 前端权限弹窗据此展示「所有者」行的删除（移除）入口，使「管理者」看上去可以删除「所有者」。

## 修复
- `tool_permission_template.py`：将 `default_permission_ids_for_relation` 改为显式分层表（与 `channel_permission_template` 保持一致），「管理者」只继承 `manage_tool_manager` 与 `manage_tool_viewer`，不再包含 `manage_tool_owner`；「所有者」仍然拥有全部三项 `manage_tool_*`。
- 资源授权的 `_can_grant_model` 校验逻辑保持不变。

## 验证
- `test/permission/test_permission_relation_defaults.py::test_tool_permission_defaults_accept_computed_relations` 调整断言，新增对「管理者不含 `manage_tool_owner`」「所有者仍含全部 manage_*」的回归断言。
- `test/permission/test_resource_authorization_service.py` 新增 `test_manager_cannot_revoke_tool_owner_grant`，钉死「管理者」的默认权限集与 `_can_grant_model('tool', 'owner', owner_model, manager_perm)` 行为，确保后续回归可被 CI 捕获。
- 手动调用 `default_permission_ids_for_relation('manager')` 验证：返回 `{edit_tool, manage_tool_manager, manage_tool_viewer, use_tool, view_tool}`，不再含 `manage_tool_owner`。

## 影响范围
- 本次只修工具（tool）模板；同样的「按等级累加」模式也出现在 `application_permission_template`（workflow/assistant）与 `knowledge_library_permission_template`，属于同类隐患但不在本工单范围内，后续单独跟进。
- 历史已存在的「管理者-工具」绑定如果已经带上了 `manage_tool_owner`，本次代码修复不会回收其既有权限（绑定数据未变），仅阻断新写入。

## 关联
- gitee issue: IKABS3（工具-管理者可以删除所有者权限）
- 截图：https://foruda.gitee.com/images/1787313420359566306/7f162ec4_17089646.png