### PR TITLE
fix(qa_expert): 修复问答图片水印下载失败

### DIFF
--- a/src/backend/bisheng/qa_expert/domain/watermarked_download.py
+++ b/src/backend/bisheng/qa_expert/domain/watermarked_download.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import re
 import tempfile
 from datetime import datetime
+from io import BytesIO
 from pathlib import Path
 from urllib.parse import unquote, urlparse
 from zoneinfo import ZoneInfo
 
 import fitz
 from loguru import logger
+from PIL import Image, UnidentifiedImageError
 
 from bisheng.knowledge.pdf.watermark import PdfWatermarkError, PdfWatermarkSpec, apply_pdf_watermark
 from bisheng.shougang_portal_config.domain.services.portal_config_service import (
@@ -23,6 +25,7 @@ _PROXY_PREFIXES = (
     "bisheng/",
     "skm-bisheng/",
     "workspace/bisheng/",
+    "workspace/skm-bisheng/",
 )
 _UUID_OBJECT = re.compile(r"^[0-9a-fA-F-]{8,}\.[A-Za-z0-9]{1,8}$")
 _IMAGE_TYPES = {
@@ -33,6 +36,7 @@ _IMAGE_TYPES = {
     ".png": "png",
     ".webp": "webp",
 }
+_IMAGE_SUFFIXES = set(_IMAGE_TYPES)
 
 
 class QaWatermarkDownloadError(ValueError):
@@ -65,21 +69,71 @@ def parse_qa_asset_location(source: str, *, default_bucket: str, tmp_bucket: str
     raise QaWatermarkDownloadError("asset source is not a QA upload")
 
 
+def resolve_conversion_filename(title: str, object_name: str) -> str:
+    """标题无后缀时回退对象名，避免详情页「问题图片 1」丢失扩展名导致转 PDF 失败。"""
+    titled = (title or "").strip()
+    object_base = object_name.rsplit("/", 1)[-1] if object_name else ""
+    if titled and Path(titled).suffix:
+        return titled
+    if object_base and Path(object_base).suffix:
+        if titled:
+            return f"{titled}{Path(object_base).suffix.lower()}"
+        return object_base
+    return titled or object_base or "qa-asset"
+
+
+def _sniff_image_type(data: bytes) -> str | None:
+    if data[:3] == b"\xff\xd8\xff":
+        return "jpeg"
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return "png"
+    if data[:6] in {b"GIF87a", b"GIF89a"}:
+        return "gif"
+    if len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "webp"
+    if data[:2] == b"BM":
+        return "bmp"
+    return None
+
+
+def _image_bytes_to_pdf(data: bytes, image_type: str | None) -> bytes:
+    """优先用 PyMuPDF；WEBP 等当前版本打不开时经 Pillow 转 PNG 再嵌入。"""
+    if image_type and image_type != "webp":
+        try:
+            src = fitz.open(stream=data, filetype=image_type)
+            try:
+                return src.convert_to_pdf()
+            finally:
+                src.close()
+        except Exception:
+            logger.debug("fitz open image failed type={}, fallback to Pillow", image_type)
+
+    try:
+        with Image.open(BytesIO(data)) as image:
+            image.load()
+            if image.mode not in {"RGB", "L"}:
+                image = image.convert("RGB")
+            png_buf = BytesIO()
+            image.save(png_buf, format="PNG")
+            png_bytes = png_buf.getvalue()
+    except (UnidentifiedImageError, OSError, ValueError) as exc:
+        raise QaWatermarkDownloadError("unsupported attachment type for watermarked download") from exc
+
+    src = fitz.open(stream=png_bytes, filetype="png")
+    try:
+        return src.convert_to_pdf()
+    finally:
+        src.close()
+
+
 def _bytes_to_pdf(data: bytes, filename: str) -> bytes:
     suffix = Path(filename).suffix.lower()
     if data[:5] == b"%PDF-" or suffix == ".pdf":
         return data
-    image_type = _IMAGE_TYPES.get(suffix)
-    if image_type is None and data[:3] == b"\xff\xd8\xff":
-        image_type = "jpeg"
-    if image_type is None and data[:8] == b"\x89PNG\r\n\x1a\n":
-        image_type = "png"
-    if image_type:
-        src = fitz.open(stream=data, filetype=image_type)
-        try:
-            return src.convert_to_pdf()
-        finally:
-            src.close()
+
+    image_type = _IMAGE_TYPES.get(suffix) or _sniff_image_type(data)
+    if image_type or suffix in _IMAGE_SUFFIXES:
+        return _image_bytes_to_pdf(data, image_type)
 
     office_suffixes = {".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx", ".et", ".wps", ".dps"}
     if suffix in office_suffixes or suffix in {".txt", ".md", ".csv", ".html", ".htm"}:
@@ -128,7 +182,7 @@ async def build_watermarked_qa_pdf(
     data = await storage.get_object(bucket_name=bucket, object_name=object_name)
     if not data:
         raise QaWatermarkDownloadError("asset not found")
-    filename = title or object_name.rsplit("/", 1)[-1]
+    filename = resolve_conversion_filename(title, object_name)
     pdf_bytes = _bytes_to_pdf(data, filename)
     identity = f"{department_name}-{user_name}" if department_name else user_name
     date_text = datetime.now(SHANGHAI).strftime("%Y/%m/%d")

--- a/src/backend/test/qa_expert/test_watermarked_download.py
+++ b/src/backend/test/qa_expert/test_watermarked_download.py
@@ -1,4 +1,12 @@
-from bisheng.qa_expert.domain.watermarked_download import parse_qa_asset_location
+from io import BytesIO
+
+from PIL import Image
+
+from bisheng.qa_expert.domain.watermarked_download import (
+    _bytes_to_pdf,
+    parse_qa_asset_location,
+    resolve_conversion_filename,
+)
 
 
 def test_parse_permanent_qa_object_and_tmp_uuid():
@@ -7,11 +15,19 @@ def test_parse_permanent_qa_object_and_tmp_uuid():
         default_bucket="bisheng",
         tmp_bucket="tmp-dir",
     ) == ("bisheng", "qa-expert/1/question/attachment/a/a.pdf")
+    assert (
+        parse_qa_asset_location(
+            "/tmp-dir/abcd1234-ef.png?X-Amz-Expires=1",
+            default_bucket="bisheng",
+            tmp_bucket="tmp-dir",
+        )[0]
+        == "tmp-dir"
+    )
     assert parse_qa_asset_location(
-        "/tmp-dir/abcd1234-ef.png?X-Amz-Expires=1",
+        "/workspace/bisheng/qa-expert/1/question/image/u/abc.png?X-Amz-Signature=1",
         default_bucket="bisheng",
         tmp_bucket="tmp-dir",
-    )[0] == "tmp-dir"
+    ) == ("bisheng", "qa-expert/1/question/image/u/abc.png")
 
 
 def test_parse_rejects_unrelated_paths():
@@ -20,3 +36,32 @@ def test_parse_rejects_unrelated_paths():
         raise AssertionError("expected error")
     except ValueError:
         pass
+
+
+def test_resolve_conversion_filename_falls_back_to_object_suffix():
+    assert resolve_conversion_filename("问题图片 1", "qa-expert/1/question/image/u/deadbeef.webp") == (
+        "问题图片 1.webp"
+    )
+    assert resolve_conversion_filename("photo.png", "qa-expert/1/question/image/u/deadbeef.webp") == "photo.png"
+    assert resolve_conversion_filename("", "qa-expert/1/question/image/u/deadbeef.jpg") == "deadbeef.jpg"
+
+
+def _image_bytes(fmt: str) -> bytes:
+    buf = BytesIO()
+    Image.new("RGB", (24, 24), (12, 34, 56)).save(buf, format=fmt)
+    return buf.getvalue()
+
+
+def test_bytes_to_pdf_accepts_display_title_without_extension():
+    png = _image_bytes("PNG")
+    pdf = _bytes_to_pdf(png, "问题图片 1")
+    assert pdf[:5] == b"%PDF-"
+
+
+def test_bytes_to_pdf_converts_webp_via_pillow_fallback():
+    webp = _image_bytes("WEBP")
+    pdf = _bytes_to_pdf(webp, "问题图片 1.webp")
+    assert pdf[:5] == b"%PDF-"
+    # 详情页标题无后缀时，靠 sniff + Pillow
+    pdf2 = _bytes_to_pdf(webp, "问题图片 1")
+    assert pdf2[:5] == b"%PDF-"


### PR DESCRIPTION
## Summary

- 详情预览标题无扩展名时，转 PDF 回退对象路径后缀
- WEBP（及 fitz 打不开的图片）经 Pillow 转 PNG 再嵌入 PDF
- 补齐 gif/bmp/webp 文件头嗅探与单测

## Test plan

- [x] `pytest test/qa_expert/test_watermarked_download.py`
- [ ] 专家问答详情：打开问题/回答图片 → 点下载，应得到带水印 PDF
- [ ] WEBP 上传图亦可下载；失败时后端返回明确错误（门户侧会展示）

Made with [Cursor](https://cursor.com)