### PR TITLE
fix(workstation): 门户问答取消 20 文件硬限

### DIFF
--- a/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
+++ b/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
@@ -7026,8 +7026,12 @@ class KnowledgeSpaceService(KnowledgeUtils):
         knowledge_space_ids: list[int],
         folder_refs: list,
         file_refs: list,
-        max_files: int = 20,
+        max_files: int | None = None,
     ) -> dict[int, list[int]]:
+        """解析门户问答知识范围。
+
+        max_files 为 None 时不限制文件数（门户已改为软提示）；传入正整数时仍做上限校验。
+        """
         resolved: dict[int, list[int]] = {}
         seen: set[tuple[int, int]] = set()
         readable_spaces: dict[int, bool] = {}
@@ -7176,8 +7180,8 @@ class KnowledgeSpaceService(KnowledgeUtils):
                     add_file(space_id, int(file.id))
 
         deduped_count = len(seen)
-        if mode == "files" and deduped_count > max_files:
-            raise ValueError("一次最多可选择20个文件进行问答。")
+        if mode == "files" and max_files is not None and deduped_count > max_files:
+            raise ValueError(f"一次最多可选择{max_files}个文件进行问答。")
         if denied_resource_count:
             logger.info(
                 f"Portal QA filtered resources outside workbench scope denied_resource_count={denied_resource_count}"
@@ -14624,8 +14628,12 @@ class KnowledgeSpaceService(KnowledgeUtils):
         *,
         folder_refs: list,
         file_refs: list,
-        max_files: int = 20,
+        max_files: int | None = None,
     ) -> dict[int, list[int]]:
+        """解析工作台问答文件范围。
+
+        max_files 为 None 时不限制文件数；传入正整数时在展开过程中做上限校验。
+        """
         resolved: dict[int, list[int]] = {}
         seen: set[tuple[int, int]] = set()
 
@@ -14635,8 +14643,8 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 return
             seen.add(key)
             resolved.setdefault(space_id, []).append(file_id)
-            if len(seen) > max_files:
-                raise ValueError("一次最多可选择20个文件进行问答。")
+            if max_files is not None and len(seen) > max_files:
+                raise ValueError(f"一次最多可选择{max_files}个文件进行问答。")
 
         for ref in file_refs or []:
             space_id = self._scope_ref_int(ref, "knowledge_space_id")

--- a/src/backend/bisheng/workstation/domain/services/chat_service.py
+++ b/src/backend/bisheng/workstation/domain/services/chat_service.py
@@ -1037,13 +1037,6 @@ async def _resolve_user_kb_file_filters(
     if portal_context and scope_mode not in {'files', 'knowledge_space'}:
         return None
 
-    unique_file_refs = {
-        (int(ref.knowledge_space_id), int(ref.file_id))
-        for ref in file_refs
-        if int(ref.knowledge_space_id or 0) > 0 and int(ref.file_id or 0) > 0
-    }
-    if len(unique_file_refs) > 20:
-        raise ValueError('一次最多可选择20个文件进行问答。')
     if not folder_refs and not file_refs:
         if not portal_context or scope_mode == 'files':
             raise ValueError('请选择可用于问答的文件。')
@@ -1066,12 +1059,12 @@ async def _resolve_user_kb_file_filters(
             knowledge_space_ids=selected_space_ids,
             folder_refs=folder_refs,
             file_refs=file_refs,
-            max_files=20,
+            max_files=None,
         )
     return await service.resolve_qa_scope_file_ids(
         folder_refs=folder_refs,
         file_refs=file_refs,
-        max_files=20,
+        max_files=None,
     )
 
 

--- a/src/backend/test/knowledge/test_portal_qa_tree_selection.py
+++ b/src/backend/test/knowledge/test_portal_qa_tree_selection.py
@@ -82,7 +82,7 @@ async def test_resolve_qa_scope_file_ids_expands_folders_and_dedupes(monkeypatch
 
 
 @pytest.mark.asyncio
-async def test_resolve_qa_scope_file_ids_rejects_more_than_twenty_files(monkeypatch):
+async def test_resolve_qa_scope_file_ids_rejects_when_max_files_exceeded(monkeypatch):
     service = object.__new__(svc_mod.KnowledgeSpaceService)
     service.login_user = SimpleNamespace(user_id=7, user_name="tester")
     service.version_repo = None
@@ -107,6 +107,35 @@ async def test_resolve_qa_scope_file_ids_rejects_more_than_twenty_files(monkeypa
             file_refs=[],
             max_files=20,
         )
+
+
+@pytest.mark.asyncio
+async def test_resolve_qa_scope_file_ids_allows_more_than_twenty_without_cap(monkeypatch):
+    """门户问答取消硬限后，max_files=None 应允许展开超过 20 个文件。"""
+    service = object.__new__(svc_mod.KnowledgeSpaceService)
+    service.login_user = SimpleNamespace(user_id=7, user_name="tester")
+    service.version_repo = None
+    folder = _file(3001, folder=True, path="")
+    files = [_file(9100 + idx, path="/3001") for idx in range(21)]
+
+    async def _query_by_id(file_id):
+        return folder if file_id == 3001 else None
+
+    async def _children_by_prefix(_space_id, _prefix, file_status=None):
+        return files
+
+    monkeypatch.setattr(service, "_require_read_permission", AsyncMock())
+    monkeypatch.setattr(service, "_require_permission_id", AsyncMock())
+    monkeypatch.setattr(service, "_filter_visible_child_items", AsyncMock(side_effect=lambda items, **_kwargs: items))
+    monkeypatch.setattr(svc_mod.KnowledgeFileDao, "query_by_id", _query_by_id)
+    monkeypatch.setattr(svc_mod.SpaceFileDao, "get_children_by_prefix", _children_by_prefix)
+
+    result = await service.resolve_qa_scope_file_ids(
+        folder_refs=[SimpleNamespace(knowledge_space_id=7101, folder_id=3001)],
+        file_refs=[],
+        max_files=None,
+    )
+    assert len(result[7101]) == 21
 
 
 @pytest.mark.asyncio

--- a/src/backend/test/workstation/test_portal_qa_knowledge_scope.py
+++ b/src/backend/test/workstation/test_portal_qa_knowledge_scope.py
@@ -138,7 +138,7 @@ async def test_resolve_user_kb_file_filters_uses_knowledge_space_service(monkeyp
         async def resolve_qa_scope_file_ids(self, *, folder_refs, file_refs, max_files):
             assert folder_refs[0].folder_id == 3001
             assert file_refs[0].file_id == 9001
-            assert max_files == 20
+            assert max_files is None
             return {7101: [9001, 9002]}
 
     monkeypatch.setattr(chat_service, 'KnowledgeSpaceService', _FakeKnowledgeSpaceService, raising=False)
@@ -196,7 +196,7 @@ async def test_portal_context_uses_portal_authorized_scope_resolver(
             assert knowledge_space_ids == [7103]
             assert file_refs[0].file_id == 9301
             assert folder_refs == []
-            assert max_files == 20
+            assert max_files is None
             return {7103: [9301]}
 
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- 门户问答解析知识范围时传 `max_files=None`，不再硬卡 20 个文件
- `resolve_*_qa_scope_file_ids` 仅在显式传入上限时校验
- 配合门户选库软提示改动，避免前端可选而后端仍 400

## Test plan
- [x] `pytest test/knowledge/test_portal_qa_tree_selection.py::test_resolve_qa_scope_file_ids_* test/workstation/test_portal_qa_knowledge_scope.py`
- [ ] 与门户联调：选 >20 文件发问可正常进入检索


Made with [Cursor](https://cursor.com)