### PR TITLE
fix(knowledge): 仅关闭移动弹窗背景虚化

### DIFF
--- a/src/frontend/client/src/pages/knowledge/SpaceDetail/MoveFolderDialog.rename.test.tsx
+++ b/src/frontend/client/src/pages/knowledge/SpaceDetail/MoveFolderDialog.rename.test.tsx
@@ -124,6 +124,12 @@ describe("MoveFolderDialog inline folder rename", () => {
         expect(confirmBtn).toBeDisabled();
     });
 
+    it("移动弹窗单独关闭背景虚化", async () => {
+        renderDialog();
+        await screen.findByText("旧名字");
+        expect(document.querySelector(".backdrop-blur-none")).toBeInTheDocument();
+    });
+
     it("重命名与新建互斥：开始新建会关闭重命名", async () => {
         renderDialog();
         expect(await screen.findByText("旧名字")).toBeInTheDocument();

--- a/src/frontend/client/src/pages/knowledge/SpaceDetail/MoveFolderDialog.tsx
+++ b/src/frontend/client/src/pages/knowledge/SpaceDetail/MoveFolderDialog.tsx
@@ -203,7 +203,10 @@ export function MoveFolderDialog({
 
     return (
         <Dialog open={open} onOpenChange={(o) => { if (!o) onCancel(); }}>
-            <DialogContent className="max-w-md w-full">
+            <DialogContent
+                className="max-w-md w-full"
+                overlayClassName="backdrop-blur-none"
+            >
                 <DialogHeader>
                     <DialogTitle>
                         {movingItemCount && movingItemCount > 1


### PR DESCRIPTION
## Summary
- 仅对文件移动弹窗覆写遮罩样式，去掉背景虚化
- 保留发布弹窗与其他 Dialog 默认 blur 行为不变
- 补充移动弹窗局部样式回归测试

## Test plan
- [ ] `pnpm test -- --runInBand src/frontend/client/src/pages/knowledge/SpaceDetail/MoveFolderDialog.rename.test.tsx`（当前环境无 `pnpm`，未执行）
- [ ] 手动验证：知识库文件移动弹窗打开时背景不再虚化，发布弹窗仍保持虚化


Made with [Cursor](https://cursor.com)