### PR TITLE
fix(qa_expert): 编辑定向题追加专家时同步邀请表

### DIFF
--- a/src/backend/bisheng/qa_expert/api/endpoints.py
+++ b/src/backend/bisheng/qa_expert/api/endpoints.py
@@ -354,7 +354,13 @@ async def update_question(
             f"{request.title or ''}\n{question_description_to_plain_text(request.description)}",
         )
 
-    question = await service.update_question(question_id, request, tenant_id=user.tenant_id)
+    question = await service.update_question(
+        question_id,
+        request,
+        tenant_id=user.tenant_id,
+        user_id=user.user_id,
+        user_name=getattr(user, "user_name", None) or "",
+    )
     return resp_200(data=question_detail_payload(question))
 
 

--- a/src/backend/bisheng/qa_expert/domain/repositories.py
+++ b/src/backend/bisheng/qa_expert/domain/repositories.py
@@ -261,6 +261,48 @@ class QuestionInviteRepository:
             session.add_all(invites)
             await session.commit()
 
+    async def list_by_question_id(self, question_id: int) -> list[QuestionInvite]:
+        """读取一题的全部邀请行。"""
+        async with get_async_db_session() as session:
+            stmt = select(QuestionInvite).where(QuestionInvite.question_id == question_id)
+            result = await session.exec(stmt)
+            return list(result.all())
+
+    async def replace_for_question(
+        self,
+        *,
+        question_id: int,
+        tenant_id: int,
+        experts: list,
+    ) -> list:
+        """
+        按目标专家列表全量对齐邀请表（删多余、补新增）。
+        返回本次新增的专家对象列表，供站内信通知。
+        """
+        desired = list(experts or [])
+        desired_ids = {int(expert.id) for expert in desired}
+        async with get_async_db_session() as session:
+            session.expire_on_commit = False
+            stmt = select(QuestionInvite).where(QuestionInvite.question_id == question_id)
+            result = await session.exec(stmt)
+            existing = list(result.all())
+            existing_ids = {int(row.expert_id) for row in existing}
+            for row in existing:
+                if int(row.expert_id) not in desired_ids:
+                    await session.delete(row)
+            added_experts = [expert for expert in desired if int(expert.id) not in existing_ids]
+            for expert in added_experts:
+                session.add(
+                    QuestionInvite(
+                        tenant_id=tenant_id,
+                        question_id=question_id,
+                        expert_id=int(expert.id),
+                        user_id=int(expert.user_id),
+                    )
+                )
+            await session.commit()
+        return added_experts
+
     async def list_user_ids_by_question_ids(self, question_ids: list[int]) -> dict[int, set[int]]:
         """question_id -> 受邀专家 user_id 集合。"""
         mapping: dict[int, set[int]] = {}

--- a/src/backend/bisheng/qa_expert/domain/services.py
+++ b/src/backend/bisheng/qa_expert/domain/services.py
@@ -649,12 +649,15 @@ class QuestionService:
         user_id: int,
         question_type: str,
         invite_ids: list[int],
-        request: QuestionCreateRequest,
+        request,
+        *,
+        require_directed_anon_reveal: bool = True,
     ) -> list:
         """校验邀请人数与专家有效性；定向且匿名时须预选转公开后是否公开姓名。"""
         if question_type == QUESTION_TYPE_DIRECTED:
             if (
-                bool(getattr(request, "asker_anonymous", False))
+                require_directed_anon_reveal
+                and bool(getattr(request, "asker_anonymous", False))
                 and getattr(request, "asker_reveal_on_public", None) is None
             ):
                 raise InvalidInvitationError(msg="定向匿名题须选择转公开后是否公开姓名")
@@ -1290,8 +1293,10 @@ class QuestionService:
         question_id: int,
         request: QuestionUpdateRequest,
         tenant_id: int | None = None,
+        user_id: int | None = None,
+        user_name: str | None = None,
     ) -> Question:
-        """更新问题信息；首答后正文/类型/邀请已锁定。"""
+        """更新问题信息；首答后正文/类型/邀请已锁定。带邀请变更时同步 qa_question_invite。"""
         question = await self.repository.get_by_id(question_id)
         if not question:
             raise QuestionNotFoundError()
@@ -1303,6 +1308,30 @@ class QuestionService:
             update_data.pop("status", None)
         if "related_docs" in update_data:
             update_data["related_docs"] = await self._canonicalize_related_docs(update_data.get("related_docs"))
+
+        # 邀请真相源是 qa_question_invite；只改分号串会导致新专家看不见定向题。
+        invite_experts: list | None = None
+        if "invited_experts" in update_data:
+            invite_ids = parse_invite_expert_ids(
+                invited_expert_ids=None,
+                invited_experts=update_data.get("invited_experts"),
+            )
+            operator_id = int(user_id or getattr(question, "user_id", 0) or 0)
+            question_type = normalize_question_type(getattr(question, "question_type", None))
+            invite_stub = SimpleNamespace(
+                asker_anonymous=bool(int(getattr(question, "asker_anonymous", 0) or 0)),
+                asker_reveal_on_public=getattr(question, "asker_reveal_on_public", None),
+            )
+            invite_experts = await self._validate_invites(
+                operator_id,
+                question_type,
+                invite_ids,
+                invite_stub,
+                require_directed_anon_reveal=False,
+            )
+            update_data["invited_experts"] = serialize_invite_ids(invite_ids)
+            update_data["experts_names"] = serialize_expert_names(invite_experts)
+
         asset_fields = {"image_url", "file_url", "attachments"}
         requested_assets = {name: update_data[name] for name in asset_fields if name in update_data}
         promotion = None
@@ -1323,10 +1352,21 @@ class QuestionService:
             raise
         if promotion is not None:
             await (await self._assets()).cleanup_sources(promotion)
-        # 发送邀请通知
-        # await self._send_expert_invitation_inbox_notice(new_question, user_id,user_name)
 
-        # logger.info(f"Question updated: {new_question.id} by user {user_id}")
+        if invite_experts is not None and new_question is not None:
+            added = await self.invite_repo.replace_for_question(
+                question_id=question_id,
+                tenant_id=int(tenant_id or getattr(question, "tenant_id", 1) or 1),
+                experts=invite_experts,
+            )
+            if added and user_id:
+                await self._send_expert_invitation_inbox_notice(
+                    new_question,
+                    int(user_id),
+                    user_name or "",
+                    only_expert_ids=[int(expert.id) for expert in added],
+                )
+
         return await self._resolve_question(new_question)
 
     async def _send_expert_invitation_inbox_notice(
@@ -1334,8 +1374,16 @@ class QuestionService:
         question: Question,
         sender_id: int,
         sender_name: str,
+        *,
+        only_expert_ids: list[int] | None = None,
     ):
-        expert_ids = [int(item) for item in (question.invited_experts or "").split(";") if item.strip().isdigit()]
+        if only_expert_ids is not None:
+            expert_ids = [int(item) for item in only_expert_ids if int(item) > 0]
+        else:
+            expert_ids = parse_invite_expert_ids(
+                invited_expert_ids=None,
+                invited_experts=getattr(question, "invited_experts", None),
+            )
         if not expert_ids:
             return
 

--- a/src/backend/test/qa_expert/test_data_flow.py
+++ b/src/backend/test/qa_expert/test_data_flow.py
@@ -118,6 +118,67 @@ async def test_df01_directed_persists_question_and_invite(flow_env):
     assert (again.get("data") or {}).get("experts_names") == expert.expert_name
 
 
+async def test_df01b_update_directed_adds_invite_row_and_visibility(flow_env):
+    """编辑定向题追加专家：invite 表补行后，新专家可见且可进详情。"""
+    env = flow_env
+    expert_a = await env.seed_expert(user_id=201, name="专家甲")
+    expert_b = await env.seed_expert(user_id=202, name="专家乙")
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df01b追加邀请",
+            "description": "仅先邀甲",
+            "business_domain": "steel",
+            "question_type": "directed",
+            "invited_expert_ids": [expert_a.id],
+            "asker_reveal_on_public": True,
+        },
+    )
+    invites_before = await env.reload_all(QuestionInvite, question_id=qid)
+    assert {int(row.expert_id) for row in invites_before} == {int(expert_a.id)}
+
+    env.as_user(env.user(202, name="专家乙"))
+    denied = _ok(await env.client.get(f"{PREFIX}/questions/{qid}"))
+    assert denied["status_code"] == 18301
+    assert "仅先邀甲" not in str(denied)
+
+    env.as_user(env.asker)
+    updated = _ok(
+        await env.client.put(
+            f"{PREFIX}/questions/{qid}",
+            json={
+                "title": env.t("df01b追加邀请"),
+                "description": "仅先邀甲",
+                "business_domain": "steel",
+                "invited_experts": f"{expert_a.id};{expert_b.id}",
+                "experts_names": f"{expert_a.expert_name};{expert_b.expert_name}",
+            },
+        )
+    )
+    assert updated["status_code"] == 200
+    question = await env.reload_row(Question, id=qid)
+    invites_after = await env.reload_all(QuestionInvite, question_id=qid)
+    assert question.invited_experts == f"{expert_a.id};{expert_b.id}"
+    assert {int(row.expert_id) for row in invites_after} == {int(expert_a.id), int(expert_b.id)}
+    assert {int(row.user_id) for row in invites_after} == {env.uid(201), env.uid(202)}
+
+    env.as_user(env.user(202, name="专家乙"))
+    detail = _ok(await env.client.get(f"{PREFIX}/questions/{qid}"))
+    assert detail["status_code"] == 200
+    assert "仅先邀甲" in str(detail.get("data"))
+    listed = _ok(
+        await env.client.get(
+            f"{PREFIX}/questions",
+            params={"page": 1, "page_size": 50, "keyword": env.t("df01b追加邀请")},
+        )
+    )
+    assert listed["status_code"] == 200
+    questions = (listed.get("data") or {}).get("questions") or []
+    ids = {int(item["id"]) for item in questions if isinstance(item, dict) and item.get("id")}
+    assert qid in ids
+
+
 async def test_df02_public_visible_to_stranger(flow_env):
     env = flow_env
     env.as_user(env.asker)

--- a/src/backend/test/qa_expert/test_question_service.py
+++ b/src/backend/test/qa_expert/test_question_service.py
@@ -51,6 +51,7 @@ def _service() -> QuestionService:
     svc.invite_repo = MagicMock()
     svc.answer_repo = MagicMock()
     svc.invite_repo.create_many = AsyncMock()
+    svc.invite_repo.replace_for_question = AsyncMock(return_value=[])
     svc.invite_repo.list_user_ids_by_question_ids = AsyncMock(return_value={})
     svc.invite_repo.list_question_ids_for_user = AsyncMock(return_value=[])
     svc._send_expert_invitation_inbox_notice = AsyncMock()
@@ -222,6 +223,84 @@ async def test_create_rejects_self_invite_and_disabled_expert():
         await _create(
             svc, _create_request(question_type="directed", invited_expert_ids=[5], asker_reveal_on_public=False)
         )
+
+
+async def test_update_directed_syncs_invite_table_and_notifies_new_only():
+    """编辑追加专家：双写分号串 + 对齐 invite 表，只通知新增专家。"""
+    from bisheng.qa_expert.domain.schemas import QuestionUpdateRequest
+
+    svc = _service()
+    existing = _question_row(
+        id=10,
+        user_id=1,
+        question_type="directed",
+        invited_experts="5",
+        experts_names="专家甲",
+        content_locked=0,
+        description="定向正文",
+        title="定向题",
+        asker_anonymous=0,
+        asker_reveal_on_public=None,
+    )
+    updated = _question_row(
+        id=10,
+        user_id=1,
+        question_type="directed",
+        invited_experts="5;6",
+        experts_names="专家甲;专家乙",
+        content_locked=0,
+        description="定向正文",
+        title="定向题",
+        asker_anonymous=0,
+        asker_reveal_on_public=None,
+    )
+    svc.repository.get_by_id = AsyncMock(return_value=existing)
+    svc.repository.update = AsyncMock(return_value=updated)
+    svc.invite_repo.replace_for_question = AsyncMock(
+        return_value=[_expert(expert_id=6, user_id=60, expert_name="专家乙")]
+    )
+    svc.expert_repo.get_by_id = AsyncMock(
+        side_effect=[
+            _expert(expert_id=5, user_id=50, expert_name="专家甲"),
+            _expert(expert_id=6, user_id=60, expert_name="专家乙"),
+        ]
+    )
+
+    result = await svc.update_question(
+        10,
+        QuestionUpdateRequest(invited_experts="5;6", experts_names="ignored"),
+        tenant_id=1,
+        user_id=1,
+        user_name="asker",
+    )
+
+    assert result.invited_experts == "5;6"
+    update_kwargs = svc.repository.update.await_args.kwargs
+    assert update_kwargs["invited_experts"] == "5;6"
+    assert update_kwargs["experts_names"] == "专家甲;专家乙"
+    svc.invite_repo.replace_for_question.assert_awaited_once()
+    replace_kwargs = svc.invite_repo.replace_for_question.await_args.kwargs
+    assert replace_kwargs["question_id"] == 10
+    assert [int(e.id) for e in replace_kwargs["experts"]] == [5, 6]
+    svc._send_expert_invitation_inbox_notice.assert_awaited_once()
+    notice_kwargs = svc._send_expert_invitation_inbox_notice.await_args.kwargs
+    assert notice_kwargs["only_expert_ids"] == [6]
+
+
+async def test_update_without_invite_field_skips_invite_sync():
+    from bisheng.qa_expert.domain.schemas import QuestionUpdateRequest
+
+    svc = _service()
+    existing = _question_row(id=10, content_locked=0, title="old", description="d")
+    updated = _question_row(id=10, content_locked=0, title="new", description="d")
+    svc.repository.get_by_id = AsyncMock(return_value=existing)
+    svc.repository.update = AsyncMock(return_value=updated)
+    svc.invite_repo.replace_for_question = AsyncMock()
+
+    await svc.update_question(10, QuestionUpdateRequest(title="new"), tenant_id=1, user_id=1)
+
+    svc.invite_repo.replace_for_question.assert_not_awaited()
+    svc._send_expert_invitation_inbox_notice.assert_not_awaited()
 
 
 async def test_list_hides_directed_title_from_stranger():


### PR DESCRIPTION
## Summary
- 编辑定向题追加专家时，除双写 `qa_question.invited_experts` 外，同步对齐 `qa_question_invite`（可见性真相源），避免新专家看不见该题。
- 仅向本次新增专家发送邀请站内信。

**涉及数据表（无 DDL）：** `qa_question`（读/写邀请串）、`qa_question_invite`（增删对齐）。

## Test plan
- [x] `uv run pytest test/qa_expert/test_question_service.py::test_update_directed_syncs_invite_table_and_notifies_new_only test/qa_expert/test_question_service.py::test_update_without_invite_field_skips_invite_sync test/qa_expert/test_data_flow.py::test_df01b_update_directed_adds_invite_row_and_visibility -q`
- [ ] 手工：定向题先邀 1 专家 → 编辑再加 1 专家 → 新专家列表/详情可见


Made with [Cursor](https://cursor.com)