### PR TITLE
fix(knowledge): 上传弹框提示 Excel 建议取消合并单元格

### DIFF
--- a/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.module.css
+++ b/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.module.css
@@ -2287,6 +2287,15 @@
   font-size: 13px;
 }
 
+/* Excel 取消合并单元格提示：与格式说明区分，略偏强调色 */
+.uploadExcelTip {
+  color: #b45309;
+  font-size: 12px;
+  line-height: 1.4;
+  text-align: center;
+  max-width: 90%;
+}
+
 .uploadPickActions {
   display: flex;
   align-items: center;

--- a/src/frontend/client/src/pages/knowledge/portal/components/PortalUploadDialog.excelTip.test.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/components/PortalUploadDialog.excelTip.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * PortalUploadDialog：选择文件区域文案与提示。
+ */
+import { createRef } from "react";
+import { render, screen } from "@testing-library/react";
+
+import { PortalUploadDialog } from "./PortalUploadDialog";
+
+function renderSelectStepDialog() {
+  const noop = () => undefined;
+  return render(
+    <PortalUploadDialog
+      open
+      step="select"
+      activeSpaceName="测试库"
+      uploadInputRef={createRef<HTMLInputElement>()}
+      uploadFolderInputRef={createRef<HTMLInputElement>()}
+      uploadFiles={[]}
+      uploadLocalFolderName={null}
+      uploadFolderId={null}
+      uploadFolderName=""
+      uploadFolderSelection={{ mode: "ai" }}
+      uploadFolderNodes={[]}
+      uploadFolderLoading={false}
+      uploadSubmitting={false}
+      uploadImporting={false}
+      uploadReviewRows={[]}
+      uploadFolderOptions={[]}
+      fileSubcategoryCode=""
+      fileCategoryGroups={[]}
+      businessDomainCode=""
+      businessDomainOptions={[]}
+      uploadTagOptions={[]}
+      selectedUploadTagValues={[]}
+      uploadTagLoading={false}
+      fileInputAccept=".pdf,.xlsx"
+      supportedFormatsLabel="pdf、xlsx"
+      maxFileSizeMB={50}
+      onOpen={noop}
+      onClose={noop}
+      onAddUploadFiles={noop}
+      onAddUploadFolder={noop}
+      onRemoveUploadFile={noop}
+      onSelectFileCategory={noop}
+      onSelectBusinessDomain={noop}
+      onToggleUploadTag={noop}
+      onClearUploadTags={noop}
+      onSelectUploadFolder={noop}
+      onUseAiUploadFolder={noop}
+      onToggleUploadFolder={noop}
+      onUploadNext={noop}
+      onReviewRowsChange={noop}
+      onBackToSelect={noop}
+      onStartUploadImport={noop}
+    />,
+  );
+}
+
+describe("PortalUploadDialog excel tip", () => {
+  it("选择文件区域展示 Excel 取消合并单元格提示", () => {
+    renderSelectStepDialog();
+    const dialog = screen.getByTestId("portal-upload-dialog");
+    expect(dialog).toHaveTextContent("点击选择文件或拖拽文件到此处");
+    expect(screen.getByTestId("upload-excel-merge-tip")).toHaveTextContent(
+      "对于excel文档建议取消合并单元格",
+    );
+  });
+});

--- a/src/frontend/client/src/pages/knowledge/portal/components/PortalUploadDialog.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/components/PortalUploadDialog.tsx
@@ -234,6 +234,10 @@ export function PortalUploadDialog({
                                     <Upload size={34} />
                                     <span>点击选择文件或拖拽文件到此处</span>
                                     <small>支持 {supportedFormatsLabel}，单文件最大 {maxFileSizeMB}MB</small>
+                                    {/* Excel 合并单元格会导致解析错乱，上传前先提示用户取消合并 */}
+                                    <small className={s.uploadExcelTip} data-testid="upload-excel-merge-tip">
+                                        对于excel文档建议取消合并单元格
+                                    </small>
                                     <div className={s.uploadPickActions}>
                                         <button
                                             type="button"


### PR DESCRIPTION
## Summary
- 知识库上传弹框「选择文件」区域增加提示：`对于excel文档建议取消合并单元格`
- 补充轻量单测覆盖该提示文案

## Test plan
- [ ] 知识库 → 上传，选文件区域可见 Excel 取消合并单元格提示
- [ ] `npx jest --ci --testPathPattern=PortalUploadDialog.excelTip --no-coverage` 通过


Made with [Cursor](https://cursor.com)