### PR TITLE
fix(knowledge): 预览文档摘要支持选中复制

### DIFF
--- a/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.module.css
+++ b/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.module.css
@@ -1277,7 +1277,6 @@
   position: relative;
   font: inherit;
   text-align: left;
-  cursor: pointer;
 }
 
 .summaryBar:hover {
@@ -1298,6 +1297,13 @@
   gap: var(--summary-title-gap);
   min-width: 0;
   flex: 0 0 auto;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
 }
 
 .summaryIcon {
@@ -1341,6 +1347,8 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 14px;
+  user-select: text;
+  cursor: pointer;
 }
 
 .summaryBarExpanded .summaryText {
@@ -1351,6 +1359,7 @@
   text-overflow: clip;
   white-space: pre-wrap;
   line-height: 1.7;
+  cursor: text;
 }
 
 .summaryDetail {

--- a/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.test.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.test.tsx
@@ -4733,22 +4733,23 @@ describe("PortalKnowledgeWorkbench", () => {
 
         expect(screen.queryByText("保存摘要")).not.toBeInTheDocument();
 
-        const summaryButton = await screen.findByRole("button", { name: "查看文档摘要" });
-        fireEvent.click(summaryButton);
+        const summaryToggle = await screen.findByRole("button", { name: "查看文档摘要" });
+        const summaryBar = screen.getByTestId("portal-summary-bar");
+        fireEvent.click(summaryToggle);
 
-        expect(summaryButton).toHaveAttribute("aria-expanded", "true");
-        expect(summaryButton).toHaveAccessibleName("收起文档摘要");
-        const summaryHeader = within(summaryButton).getByTestId("portal-summary-header");
-        const summaryContent = within(summaryButton).getByTestId("portal-summary-content");
+        expect(summaryToggle).toHaveAttribute("aria-expanded", "true");
+        expect(summaryToggle).toHaveAccessibleName("收起文档摘要");
+        const summaryHeader = within(summaryBar).getByTestId("portal-summary-header");
+        const summaryContent = within(summaryBar).getByTestId("portal-summary-content");
         expect(summaryHeader).toHaveTextContent("文档摘要");
         expect(summaryContent).toHaveTextContent("这是一段完整的文档摘要内容");
-        expect(Array.from(summaryButton.children)).toEqual([summaryHeader, summaryContent]);
+        expect(Array.from(summaryBar.children)).toEqual([summaryHeader, summaryContent]);
         expect(screen.queryByTestId("portal-summary-detail")).not.toBeInTheDocument();
 
-        fireEvent.click(summaryButton);
+        fireEvent.click(summaryToggle);
 
-        expect(summaryButton).toHaveAttribute("aria-expanded", "false");
-        expect(summaryButton).toHaveAccessibleName("查看文档摘要");
+        expect(summaryToggle).toHaveAttribute("aria-expanded", "false");
+        expect(summaryToggle).toHaveAccessibleName("查看文档摘要");
         expect(screen.queryByText("摘要内容")).not.toBeInTheDocument();
     });
 
@@ -4757,12 +4758,15 @@ describe("PortalKnowledgeWorkbench", () => {
         const expandedRule = css.match(/\.summaryBarExpanded\s*\{(?<body>[^}]*)\}/)?.groups?.body ?? "";
         const expandedHeaderRule = css.match(/\.summaryBarExpanded\s+\.summaryHeader\s*\{(?<body>[^}]*)\}/)?.groups?.body ?? "";
         const expandedTextRule = css.match(/\.summaryBarExpanded\s+\.summaryText\s*\{(?<body>[^}]*)\}/)?.groups?.body ?? "";
+        const summaryTextRule = css.match(/\.summaryText\s*\{(?<body>[^}]*)\}/)?.groups?.body ?? "";
 
         expect(expandedRule).toMatch(/flex-direction\s*:\s*column/);
         expect(expandedRule).toMatch(/background\s*:\s*#eef4ff/);
         expect(expandedHeaderRule).not.toMatch(/display\s*:\s*contents/);
         expect(expandedTextRule).toMatch(/margin-left\s*:\s*calc\(var\(--summary-icon-size\)\s*\+\s*var\(--summary-title-gap\)\)/);
         expect(expandedTextRule).toMatch(/white-space\s*:\s*pre-wrap/);
+        expect(expandedTextRule).toMatch(/cursor\s*:\s*text/);
+        expect(summaryTextRule).toMatch(/user-select\s*:\s*text/);
         expect(expandedTextRule).not.toMatch(/padding-left\s*:/);
         expect(expandedTextRule).not.toMatch(/grid-column\s*:/);
         expect(expandedTextRule).not.toMatch(/max-height\s*:/);

--- a/src/frontend/client/src/pages/knowledge/portal/components/DocumentPreview.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/components/DocumentPreview.tsx
@@ -110,15 +110,20 @@ export function DocumentPreview({
                     {selectedFile.summary ? (
                         <>
                             <div className={s.divider} />
-                            <button
-                                type="button"
+                            {/* 外层不用 button：浏览器默认禁止在 button 内选中文字，摘要需可复制 */}
+                            <div
                                 className={`${s.summaryBar} ${summaryExpanded ? s.summaryBarExpanded : ""}`}
-                                aria-label={summaryExpanded ? "收起文档摘要" : "查看文档摘要"}
-                                aria-expanded={summaryExpanded}
-                                aria-controls="portal-summary-content"
-                                onClick={onToggleSummary}
+                                data-testid="portal-summary-bar"
                             >
-                                <div className={s.summaryHeader} data-testid="portal-summary-header">
+                                <button
+                                    type="button"
+                                    className={s.summaryHeader}
+                                    data-testid="portal-summary-header"
+                                    aria-label={summaryExpanded ? "收起文档摘要" : "查看文档摘要"}
+                                    aria-expanded={summaryExpanded}
+                                    aria-controls="portal-summary-content"
+                                    onClick={onToggleSummary}
+                                >
                                     <span className={s.summaryIcon}>
                                         <FileText size={16} />
                                     </span>
@@ -128,11 +133,16 @@ export function DocumentPreview({
                                     <span className={s.summaryToggleIcon}>
                                         {summaryExpanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
                                     </span>
-                                </div>
-                                <div id="portal-summary-content" data-testid="portal-summary-content" className={s.summaryText}>
+                                </button>
+                                <div
+                                    id="portal-summary-content"
+                                    data-testid="portal-summary-content"
+                                    className={s.summaryText}
+                                    onClick={summaryExpanded ? undefined : onToggleSummary}
+                                >
                                     {selectedFile.summary}
                                 </div>
-                            </button>
+                            </div>
                         </>
                     ) : null}
                     <div className={s.previewHost}>


### PR DESCRIPTION
## Summary
- 知识库文件预览的「文档摘要」不再整块包在 `<button>` 内，避免浏览器禁止按钮内选中文字。
- 展开后摘要正文 `user-select: text`，可拖选复制；展开/收起仍由标题按钮控制。

**涉及数据表：** 不涉及。

## Test plan
- [x] `npx jest --testPathPattern='PortalKnowledgeWorkbench.test' --testNamePattern='expands summary|styles expanded summary' --forceExit`
- [ ] 门户/知识库打开带摘要文件 → 展开文档摘要 → 可拖选复制正文


Made with [Cursor](https://cursor.com)