### PR TITLE
fix(knowledge): 门户 document_type 浏览与计数统一走 ES 全文

### DIFF
--- a/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
+++ b/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
@@ -188,6 +188,7 @@ from bisheng.knowledge.domain.schemas.knowledge_document_distribution_schema imp
 )
 from bisheng.knowledge.domain.schemas.knowledge_fulltext_search_schema import (
     KnowledgeFulltextAdvancedSearchQuery,
+    KnowledgeFulltextSearchSort,
 )
 from bisheng.knowledge.domain.schemas.knowledge_space_schema import (
     BatchAliasActionResult,
@@ -5564,6 +5565,58 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 "discovery_snapshot": discovery.snapshot if discovery else "",
             }
 
+        if (
+            req.query_type == "browse"
+            and self._normalize_shougang_document_type_code(req.document_type)
+        ):
+            # 与列表一致：document_type 浏览走 ES 全文，不能用 MySQL file_encoding LIKE 计数。
+            browse_payload = req.model_dump(
+                exclude={
+                    "query_type",
+                    "q",
+                    "conditions",
+                    "filter_tag",
+                    "all_keywords",
+                    "exact_phrase",
+                    "any_keywords",
+                    "exclude_keywords",
+                    "search_field",
+                    "original_uploader_id",
+                    "original_knowledge_id",
+                    "preview_count_min",
+                    "preview_count_max",
+                    "download_count_min",
+                    "download_count_max",
+                    "updated_from",
+                    "updated_to",
+                },
+                exclude_unset=True,
+            )
+            browse_payload["limit"] = 100
+            browse_payload["cursor"] = None
+            total = 0
+            seen_cursors: set[str] = set()
+            while True:
+                result = await self.browse_shougang_portal_files(
+                    ShougangPortalFileBrowseReq.model_validate(browse_payload)
+                )
+                total += len(result.get("data") or [])
+                next_cursor = str(result.get("next_cursor") or "")
+                if not result.get("has_more") or not next_cursor:
+                    break
+                if next_cursor in seen_cursors:
+                    logger.warning(
+                        "portal document_type browse count stopped on repeated cursor"
+                    )
+                    break
+                seen_cursors.add(next_cursor)
+                browse_payload["cursor"] = next_cursor
+            discovery = getattr(self, "_portal_discovery_result", None)
+            return {
+                "total": total,
+                "discovery_snapshot": discovery.snapshot if discovery else "",
+            }
+
         effective_discovery_scope = (
             req.discovery_scope
             if req.discovery_scope in {"portal_public", "portal_configured"}
@@ -8864,6 +8917,11 @@ class KnowledgeSpaceService(KnowledgeUtils):
         tag_file_ids: list[int] | None,
         trusted_public_scope: bool = False,
     ) -> dict:
+        # 有一级文件分类时走 ES keyword 等值过滤，避免 MySQL file_encoding LIKE。
+        # 无回退：全文服务不可用时直接失败，避免与 LIKE/标签结果集不一致。
+        if self._normalize_shougang_document_type_code(req.document_type):
+            return await self._list_shougang_portal_files_via_fulltext_document_type(req)
+
         from bisheng.common.cursor import CursorDecodeError, decode_cursor
 
         space_ids = [int(space.id) for space in spaces]
@@ -8959,6 +9017,36 @@ class KnowledgeSpaceService(KnowledgeUtils):
         if has_more and page_files:
             next_cursor = self._encode_shougang_portal_file_cursor(page_files[-1], cursor_context)
         return self._build_shougang_portal_cursor_response(page_items, has_more, next_cursor)
+
+    async def _list_shougang_portal_files_via_fulltext_document_type(
+        self,
+        req: ShougangPortalFileBrowseReq,
+    ) -> dict:
+        """无关键词浏览在带 document_type 时复用高级全文检索（ES term 过滤）。"""
+        sort = self._map_browse_sort_to_fulltext_sort(req.sort)
+        payload = req.model_dump()
+        payload["sort"] = sort
+        payload["document_type"] = self._normalize_shougang_document_type_code(req.document_type)
+        advanced_req = ShougangPortalAdvancedFileSearchReq.model_validate(payload)
+        return await self.advanced_search_shougang_portal_files(advanced_req)
+
+    @staticmethod
+    def _map_browse_sort_to_fulltext_sort(sort: str | None) -> str:
+        """将 browse 排序映射为全文检索可接受的 sort 字面量。"""
+        normalized = (sort or "updated_at_desc").strip().lower()
+        if normalized == "updated_at_asc":
+            return KnowledgeFulltextSearchSort.UPDATED_AT_ASC.value
+        if normalized in {
+            KnowledgeFulltextSearchSort.PREVIEW_COUNT_DESC.value,
+            KnowledgeFulltextSearchSort.PREVIEW_COUNT_ASC.value,
+            KnowledgeFulltextSearchSort.DOWNLOAD_COUNT_DESC.value,
+            KnowledgeFulltextSearchSort.DOWNLOAD_COUNT_ASC.value,
+            KnowledgeFulltextSearchSort.UPDATED_AT_DESC.value,
+            KnowledgeFulltextSearchSort.UPDATED_AT_ASC.value,
+        }:
+            return normalized
+        # browse 默认与历史 updated_at 别名统一为时间倒序
+        return KnowledgeFulltextSearchSort.UPDATED_AT_DESC.value
 
     async def _semantic_search_shougang_portal_files(
         self,

--- a/src/backend/test/knowledge/test_portal_browse_document_type_uses_fulltext.py
+++ b/src/backend/test/knowledge/test_portal_browse_document_type_uses_fulltext.py
@@ -1,0 +1,107 @@
+"""无关键词 browse 带 document_type 时应走 ES 全文检索，而非 MySQL LIKE。"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from bisheng.knowledge.domain.models.knowledge_file import KnowledgeFileDao
+from bisheng.knowledge.domain.schemas.knowledge_space_schema import (
+    ShougangPortalAdvancedFileSearchReq,
+    ShougangPortalFileBrowseReq,
+    ShougangPortalFileCountReq,
+)
+from bisheng.knowledge.domain.services.knowledge_space_service import KnowledgeSpaceService
+
+
+@pytest.mark.asyncio
+async def test_list_without_keyword_routes_document_type_to_fulltext_helper():
+    """用途：有 document_type 时短路到 ES 路径，避免 MySQL file_encoding LIKE。"""
+    service = object.__new__(KnowledgeSpaceService)
+    routed = AsyncMock(return_value={"data": [], "has_more": False, "next_cursor": None})
+    service._list_shougang_portal_files_via_fulltext_document_type = routed
+
+    req = ShougangPortalFileBrowseReq(document_type="NEW", limit=6)
+    result = await KnowledgeSpaceService._list_shougang_portal_files_without_keyword(
+        service,
+        req=req,
+        spaces=[SimpleNamespace(id=1)],
+        tag_file_ids=None,
+        trusted_public_scope=True,
+    )
+
+    assert result["data"] == []
+    routed.assert_awaited_once_with(req)
+
+
+@pytest.mark.asyncio
+async def test_list_via_fulltext_document_type_delegates_to_advanced_search():
+    """用途：document_type 浏览复用高级全文检索，并映射为 updated_at_desc。"""
+    service = object.__new__(KnowledgeSpaceService)
+    advanced = AsyncMock(return_value={"data": [{"id": 1}], "has_more": False, "next_cursor": None})
+    service.advanced_search_shougang_portal_files = advanced
+
+    req = ShougangPortalFileBrowseReq(
+        document_type="new",
+        public_only=True,
+        discovery_scope="public",
+        sort="updated_at",
+        limit=6,
+    )
+    result = await KnowledgeSpaceService._list_shougang_portal_files_via_fulltext_document_type(
+        service, req
+    )
+
+    assert result["data"][0]["id"] == 1
+    advanced.assert_awaited_once()
+    advanced_req = advanced.await_args.args[0]
+    assert isinstance(advanced_req, ShougangPortalAdvancedFileSearchReq)
+    assert advanced_req.document_type == "NEW"
+    assert advanced_req.sort == "updated_at_desc"
+    assert advanced_req.public_only is True
+
+
+def test_map_browse_sort_to_fulltext_sort():
+    """用途：browse 排序别名映射到全文检索字面量。"""
+    assert (
+        KnowledgeSpaceService._map_browse_sort_to_fulltext_sort("updated_at")
+        == "updated_at_desc"
+    )
+    assert (
+        KnowledgeSpaceService._map_browse_sort_to_fulltext_sort("updated_at_asc")
+        == "updated_at_asc"
+    )
+    assert (
+        KnowledgeSpaceService._map_browse_sort_to_fulltext_sort(None) == "updated_at_desc"
+    )
+
+
+@pytest.mark.asyncio
+async def test_count_browse_with_document_type_paginates_browse_not_mysql(monkeypatch):
+    """用途：document_type 计数与列表同走 browse/ES，避免 MySQL LIKE 虚高。"""
+    service = object.__new__(KnowledgeSpaceService)
+    browse_mock = AsyncMock(
+        side_effect=[
+            {"data": [{"id": 1}], "has_more": True, "next_cursor": "cursor-1"},
+            {"data": [{"id": 2}], "has_more": False, "next_cursor": None},
+        ]
+    )
+    service.browse_shougang_portal_files = browse_mock
+    service._portal_discovery_result = SimpleNamespace(snapshot="snap-1")
+
+    acount_mock = AsyncMock(return_value=999)
+    monkeypatch.setattr(KnowledgeFileDao, "acount_portal_files", acount_mock)
+
+    req = ShougangPortalFileCountReq(
+        query_type="browse",
+        document_type="NEW",
+        discovery_scope="portal_public",
+    )
+    result = await KnowledgeSpaceService.count_shougang_portal_files(service, req)
+
+    assert result["total"] == 2
+    assert result["discovery_snapshot"] == "snap-1"
+    assert browse_mock.await_count == 2
+    acount_mock.assert_not_awaited()


### PR DESCRIPTION
## Summary
- 无关键词 `browse` 且带 `document_type` 时改走 `advanced_search`（ES term 过滤），不再用 MySQL `file_encoding LIKE`。
- `count_shougang_portal_files` 在同类条件下分页累加 `browse` 结果，修复「共 N 篇」与列表条数不一致。
- 补充单测覆盖 browse/count 全文路径。

## 涉及数据表
- 无 DDL。读 `knowledge_file`（经 ES 索引）；不写库。

## Test plan
- [x] `uv run pytest test/knowledge/test_portal_browse_document_type_uses_fulltext.py`
- [ ] 联调：首页「行业情报」与 `/category/NEW` 列表/计数一致（需配合门户 PR）


Made with [Cursor](https://cursor.com)