### PR TITLE
fix(platform): suppress global toast on first-time tool permission probe (gitee IKB0O4)

### DIFF
--- a/src/frontend/platform/eslint-suppressions.json
+++ b/src/frontend/platform/eslint-suppressions.json
@@ -1172,7 +1172,7 @@
   },
   "src/controllers/API/permission.ts": {
     "@typescript-eslint/no-explicit-any": {
-      "count": 4
+      "count": 5
     }
   },
   "src/controllers/API/pro.ts": {

--- a/src/frontend/platform/src/components/bs-comp/permission/usePermissionLevels.ts
+++ b/src/frontend/platform/src/components/bs-comp/permission/usePermissionLevels.ts
@@ -259,7 +259,12 @@ export function usePermissionIds(
 
       setPermissions(result.permissions)
       setLoading(false)
-      if (result.hasError) {
+      // Only toast when every probe failed AND nothing resolved — i.e. FGA is
+      // genuinely down for this user. A first-time / non-admin user legitimately
+      // has zero `manage_tool_*` permissions and the probe coming back as
+      // `allowed: false` for every tool is not a failure worth surfacing; the
+      // page just renders the list without the "权限管理" shield. (gitee IKB0O4)
+      if (result.hasError && Object.keys(result.permissions).length === 0) {
         toast({
           title: '提示',
           variant: 'error',

--- a/src/frontend/platform/src/controllers/API/permission.ts
+++ b/src/frontend/platform/src/controllers/API/permission.ts
@@ -103,12 +103,20 @@ export async function checkPermission(
   relation: string,
   permissionId?: string,
 ): Promise<{ allowed: boolean }> {
+  // Run silent: the global response interceptor in @/controllers/request turns
+  // any non-200 envelope into a red toast. For a first-time / non-admin user the
+  // per-tool permission probe is supposed to come back with `{ allowed: false }`
+  // (status 200), and a transient FGA error during a probe is not user-actionable.
+  // Surfacing a "权限校验失败" toast in either case is what the first-time user
+  // entering the API/MCP tools page sees today (gitee IKB0O4). The caller
+  // (usePermissionIds) still records hasError / empty permissions and renders
+  // the tool list without the "权限管理" button.
   return await axios.post(`/api/v1/permissions/check`, {
     object_type: objectType,
     object_id: objectId,
     relation,
     permission_id: permissionId,
-  })
+  }, { silent: true } as any)
 }
 
 export async function getRelationModelsApi(): Promise<RelationModel[]> {

--- a/src/frontend/platform/src/test/permissionHookCache.test.tsx
+++ b/src/frontend/platform/src/test/permissionHookCache.test.tsx
@@ -1,7 +1,8 @@
 import { userContext } from "@/contexts/userContext"
 import { usePermissionIds } from "@/components/bs-comp/permission/usePermissionLevels"
 import { render, screen, waitFor } from "@testing-library/react"
-import { describe, expect, it, vi } from "vitest"
+import { toast } from "@/components/bs-ui/toast/use-toast"
+import { describe, expect, it, vi, beforeEach } from "vitest"
 
 const checkPermission = vi.fn()
 
@@ -13,17 +14,21 @@ vi.mock("@/components/bs-ui/toast/use-toast", () => ({
   toast: vi.fn(),
 }))
 
-function PermissionProbe() {
-  const { loading } = usePermissionIds(
-    "workflow",
-    ["workflow-cache-test"],
-    ["edit_app", "publish_app"],
-  )
-
-  return <span>{loading ? "loading" : "ready"}</span>
+type ProbeOptions = {
+  resourceId: string
+  permissionIds: string[]
 }
 
-function renderProbe() {
+function makeProbe({ resourceId, permissionIds }: ProbeOptions) {
+  return function PermissionProbe() {
+    const { loading } = usePermissionIds("workflow", [resourceId], permissionIds)
+
+    return <span>{loading ? "loading" : "ready"}</span>
+  }
+}
+
+function renderProbe(options: ProbeOptions) {
+  const Probe = makeProbe(options)
   return render(
     <userContext.Provider value={{
       user: { user_id: "permission-cache-user", role: "user" },
@@ -33,27 +38,85 @@ function renderProbe() {
       checkComponentsName: vi.fn(),
       delComponent: vi.fn(),
     }}>
-      <PermissionProbe />
+      <Probe />
     </userContext.Provider>,
   )
 }
 
+const CACHE_TEST_ID = "workflow-cache-test"
+const FIRST_TIME_USER_ID = "tool-first-time-user"
+const FGA_OUTAGE_ID = "tool-fga-outage"
+
 describe("usePermissionIds cache", () => {
+  beforeEach(() => {
+    vi.mocked(toast).mockClear()
+    checkPermission.mockReset()
+  })
+
   it("reuses a workflow permission result after the header remounts", async () => {
     checkPermission.mockResolvedValue({ allowed: true })
 
-    const firstRender = renderProbe()
+    const firstRender = renderProbe({
+      resourceId: CACHE_TEST_ID,
+      permissionIds: ["edit_app", "publish_app"],
+    })
     await waitFor(() => {
       expect(screen.getByText("ready")).toBeInTheDocument()
       expect(checkPermission).toHaveBeenCalledTimes(2)
     })
 
     firstRender.unmount()
-    renderProbe()
+    renderProbe({
+      resourceId: CACHE_TEST_ID,
+      permissionIds: ["edit_app", "publish_app"],
+    })
 
     await waitFor(() => {
       expect(screen.getByText("ready")).toBeInTheDocument()
     })
     expect(checkPermission).toHaveBeenCalledTimes(2)
+  })
+
+  // gitee IKB0O4: a first-time / non-admin user legitimately has zero
+  // `manage_tool_*` permissions. The probe resolves to { allowed: false } for
+  // every tool — that is the expected, non-broken outcome and must not raise a
+  // red "权限校验失败" toast on the API/MCP tools page.
+  it("does not toast when every check resolves with allowed:false (first-time user)", async () => {
+    checkPermission.mockResolvedValue({ allowed: false })
+
+    renderProbe({
+      resourceId: FIRST_TIME_USER_ID,
+      permissionIds: ["edit_app", "publish_app"],
+    })
+    await waitFor(() => {
+      expect(screen.getByText("ready")).toBeInTheDocument()
+      expect(checkPermission).toHaveBeenCalledTimes(2)
+    })
+
+    expect(vi.mocked(toast)).not.toHaveBeenCalled()
+  })
+
+  // Companion to the above: when every probe errors out (FGA truly down) AND
+  // nothing resolved, the user-visible toast should still fire exactly once.
+  it("toasts exactly once when every check rejects and nothing resolves", async () => {
+    checkPermission.mockRejectedValue(new Error("fga down"))
+
+    renderProbe({
+      resourceId: FGA_OUTAGE_ID,
+      permissionIds: ["edit_app", "publish_app"],
+    })
+    await waitFor(() => {
+      expect(screen.getByText("ready")).toBeInTheDocument()
+      expect(checkPermission).toHaveBeenCalledTimes(2)
+    })
+
+    expect(vi.mocked(toast)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(toast)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: "error",
+        // eslint-disable-next-line no-restricted-syntax -- mirroring the production toast description (gitee IKB0O4 regression test)
+        description: "权限校验失败，请稍后重试",
+      }),
+    )
   })
 })


### PR DESCRIPTION
## Summary

Fixes gitee issue `IKB0O4` ("第一次进到 API  MCP工具中报错") — a first-time / non-admin user opening
BuildPage → 工具 would see a flood of red "权限校验失败，请稍后重试" toasts on a perfectly legitimate page
render. The probe itself was doing the right thing (`{ allowed: false }` for the tools the user is
not entitled to manage); the user-visible surface was the wrong layer to flag the result.

## Root cause

The global response interceptor in `@/controllers/request.ts` raises a red toast for every
non-200 envelope. `usePermissionIds` fires off an N×M batch of `checkPermission` requests
(2 visible tools × 3 `manage_tool_*` permission IDs = 6 calls, plus the dialog-open
`getGrantableRelationModels` calls). For a first-time user every one of those is a 200 with
`{ allowed: false }` — the per-tool probe is working as designed — but the page-level toast
made the platform look broken.

## Fix (two minimal changes, both reuse existing patterns)

1. `checkPermission` (`src/controllers/API/permission.ts`) now runs in `silent: true` mode.
   The caller already wraps the call in `try/catch` and tracks `hasError`. Pattern is already
   established in `license.ts:25`, `pro.ts:115`, `linsight.ts:62-79`, `index.ts:83,112,497`.
2. `usePermissionIds` (`usePermissionLevels.ts`) only surfaces the existing
   "权限校验失败，请稍后重试" toast when every probe failed AND nothing resolved — i.e.
   FGA is genuinely down. A first-time user with zero `manage_tool_*` permissions is no
   longer punished for it.

Combined: `{ allowed: false }` → no toast, page renders fine without the "权限管理" button;
transient FGA error for one tool → no toast, that tool just doesn't show the button; complete
FGA outage → one toast and the user knows to retry.

## Verification

- Two new regression tests in `src/test/permissionHookCache.test.tsx`:
  - "does not toast when every check resolves with allowed:false (first-time user)"
  - "toasts exactly once when every check rejects and nothing resolves"
- `pnpm test src/test/permissionHookCache.test.tsx` — 3 passed
- `pnpm lint` — clean (bumped `permission.ts` `no-explicit-any` count from 4 to 5 to absorb
  the new `silent: true as any`)
- `pnpm typecheck` — clean
- Manual smoke (out-of-band): open BuildPage → 工具 on a non-admin account. The list of
  API/MCP tools renders normally; the "权限管理" shield does not appear; no red toast.

## Out of scope

The 3.0.0-beta1 `useResourceActions` refactor and the `action=visible` backend parameter
(`a4dd34b5d`) are larger, multi-file changes that land in a different release stream. This
PR is the smallest complete fix on `main` for the reported first-time-user symptom. The
backend `checkPermission` contract is unchanged; only the user-visible surface is quieted.