### PR TITLE
fix(qa_expert): 专家问答视频附件原文件直下

### DIFF
--- a/src/backend/bisheng/qa_expert/api/endpoints.py
+++ b/src/backend/bisheng/qa_expert/api/endpoints.py
@@ -752,19 +752,19 @@ async def download_watermarked_asset(
     title: str = Query("", description="原始文件名"),
     user: UserPayload = Depends(UserPayload.get_login_user),
 ):
-    """将专家问答上传的图片/附件转为带水印 PDF 后下载。"""
+    """问答附件下载：视频原文件直下，其余转带水印 PDF。"""
     from urllib.parse import quote
 
     from bisheng.core.context.tenant import get_current_tenant_id
     from bisheng.qa_expert.domain.watermarked_download import (
         QaWatermarkDownloadError,
-        build_watermarked_qa_pdf,
+        build_qa_asset_download,
     )
 
     storage = await get_minio_storage()
     user_name = str(getattr(user, "user_name", "") or user.user_id)
     try:
-        payload, filename = await build_watermarked_qa_pdf(
+        payload, filename, media_type = await build_qa_asset_download(
             source=source,
             title=title,
             user_name=user_name,
@@ -776,16 +776,19 @@ async def download_watermarked_asset(
     except QaWatermarkDownloadError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     except Exception as exc:
-        logger.exception("QA watermarked download failed")
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="水印下载失败") from exc
+        logger.exception("QA asset download failed")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="下载失败") from exc
 
     # HTTP 头须 latin-1；中文文件名走 RFC 5987 filename*
     encoded_filename = quote(filename, safe="")
+    fallback_name = "qa-asset.pdf" if media_type == "application/pdf" else "qa-asset.bin"
     return Response(
         content=payload,
-        media_type="application/pdf",
+        media_type=media_type,
         headers={
-            "Content-Disposition": (f"attachment; filename=\"qa-asset.pdf\"; filename*=UTF-8''{encoded_filename}"),
+            "Content-Disposition": (
+                f"attachment; filename=\"{fallback_name}\"; filename*=UTF-8''{encoded_filename}"
+            ),
         },
     )
 

--- a/src/backend/bisheng/qa_expert/domain/watermarked_download.py
+++ b/src/backend/bisheng/qa_expert/domain/watermarked_download.py
@@ -37,6 +37,13 @@ _IMAGE_TYPES = {
     ".webp": "webp",
 }
 _IMAGE_SUFFIXES = set(_IMAGE_TYPES)
+# 问答附件视频：无法转 PDF 打水印，允许原文件直下（mp4/mov/webm）
+_VIDEO_SUFFIXES = {".mp4", ".mov", ".webm"}
+_VIDEO_MEDIA_TYPES = {
+    ".mp4": "video/mp4",
+    ".mov": "video/quicktime",
+    ".webm": "video/webm",
+}
 
 
 class QaWatermarkDownloadError(ValueError):
@@ -67,6 +74,31 @@ def parse_qa_asset_location(source: str, *, default_bucket: str, tmp_bucket: str
     if _UUID_OBJECT.fullmatch(file_name) and "/" not in object_name:
         return bucket, object_name
     raise QaWatermarkDownloadError("asset source is not a QA upload")
+
+
+def _sniff_video_suffix(data: bytes) -> str | None:
+    """根据文件头识别 mp4/mov/webm，供展示名无后缀时仍能直下原视频。"""
+    if len(data) >= 12 and data[4:8] == b"ftyp":
+        brand = data[8:12]
+        if brand in {b"qt  ", b"moov", b"wide"}:
+            return ".mov"
+        return ".mp4"
+    if len(data) >= 4 and data[:4] == b"\x1aE\xdf\xa3":
+        return ".webm"
+    return None
+
+
+def resolve_qa_video_suffix(filename: str, data: bytes) -> str | None:
+    """若附件为支持直下的视频格式则返回小写后缀，否则 None。"""
+    suffix = Path(filename).suffix.lower()
+    if suffix in _VIDEO_SUFFIXES:
+        return suffix
+    return _sniff_video_suffix(data)
+
+
+def is_qa_video_asset(filename: str, data: bytes) -> bool:
+    """判断问答上传附件是否应按原视频文件下载（不打水印）。"""
+    return resolve_qa_video_suffix(filename, data) is not None
 
 
 def resolve_conversion_filename(title: str, object_name: str) -> str:
@@ -281,17 +313,16 @@ def _safe_pdf_filename(title: str) -> str:
     return f"{cleaned.strip('.') or 'qa-asset'}.pdf"
 
 
-async def build_watermarked_qa_pdf(
-    *,
-    source: str,
-    title: str,
-    user_name: str,
-    account: str,
-    department_name: str,
-    tenant_id: int | None,
-    storage,
-) -> tuple[bytes, str]:
-    """拉取问答对象、转 PDF、打水印。"""
+def _safe_attachment_filename(title: str, suffix: str) -> str:
+    """保留原扩展名的安全下载文件名（视频等非 PDF 附件）。"""
+    stem = Path((title or "qa-asset").strip()).stem or "qa-asset"
+    cleaned = re.sub(r'[\\/<>:"|?*\x00-\x1f]', "_", stem)
+    normalized = suffix if suffix.startswith(".") else f".{suffix}"
+    return f"{cleaned.strip('.') or 'qa-asset'}{normalized.lower()}"
+
+
+async def _load_qa_asset(source: str, title: str, storage) -> tuple[bytes, str]:
+    """从 MinIO 读取问答上传对象，并解析用于类型识别的文件名。"""
     bucket, object_name = parse_qa_asset_location(
         source,
         default_bucket=storage.bucket,
@@ -301,7 +332,19 @@ async def build_watermarked_qa_pdf(
     if not data:
         raise QaWatermarkDownloadError("asset not found")
     filename = resolve_conversion_filename(title, object_name)
-    pdf_bytes = _bytes_to_pdf(data, filename)
+    return data, filename
+
+
+async def _apply_qa_pdf_watermark(
+    pdf_bytes: bytes,
+    *,
+    filename: str,
+    user_name: str,
+    account: str,
+    department_name: str,
+    tenant_id: int | None,
+) -> tuple[bytes, str]:
+    """对已是 PDF 的字节叠门户水印，返回 (payload, 下载文件名)。"""
     identity = f"{department_name}-{user_name}" if department_name else user_name
     date_text = datetime.now(SHANGHAI).strftime("%Y/%m/%d")
     horizontal = await ShougangPortalConfigService.get_watermark_horizontal_text(tenant_id=tenant_id)
@@ -316,3 +359,56 @@ async def build_watermarked_qa_pdf(
             logger.warning("QA watermark failed: {}", exc)
             raise QaWatermarkDownloadError("watermark generation failed") from exc
         return output_path.read_bytes(), _safe_pdf_filename(filename)
+
+
+async def build_qa_asset_download(
+    *,
+    source: str,
+    title: str,
+    user_name: str,
+    account: str,
+    department_name: str,
+    tenant_id: int | None,
+    storage,
+) -> tuple[bytes, str, str]:
+    """拉取问答附件：视频原文件直下，其余转带水印 PDF。返回 (内容, 文件名, media_type)。"""
+    data, filename = await _load_qa_asset(source, title, storage)
+    video_suffix = resolve_qa_video_suffix(filename, data)
+    if video_suffix:
+        safe_name = _safe_attachment_filename(filename, video_suffix)
+        media_type = _VIDEO_MEDIA_TYPES.get(video_suffix, "application/octet-stream")
+        return data, safe_name, media_type
+
+    pdf_bytes = _bytes_to_pdf(data, filename)
+    payload, pdf_name = await _apply_qa_pdf_watermark(
+        pdf_bytes,
+        filename=filename,
+        user_name=user_name,
+        account=account,
+        department_name=department_name,
+        tenant_id=tenant_id,
+    )
+    return payload, pdf_name, "application/pdf"
+
+
+async def build_watermarked_qa_pdf(
+    *,
+    source: str,
+    title: str,
+    user_name: str,
+    account: str,
+    department_name: str,
+    tenant_id: int | None,
+    storage,
+) -> tuple[bytes, str]:
+    """拉取问答对象、转 PDF、打水印。"""
+    data, filename = await _load_qa_asset(source, title, storage)
+    pdf_bytes = _bytes_to_pdf(data, filename)
+    return await _apply_qa_pdf_watermark(
+        pdf_bytes,
+        filename=filename,
+        user_name=user_name,
+        account=account,
+        department_name=department_name,
+        tenant_id=tenant_id,
+    )

--- a/src/backend/test/qa_expert/test_watermarked_download.py
+++ b/src/backend/test/qa_expert/test_watermarked_download.py
@@ -5,8 +5,10 @@ from PIL import Image
 from bisheng.qa_expert.domain.watermarked_download import (
     QaWatermarkDownloadError,
     _bytes_to_pdf,
+    is_qa_video_asset,
     parse_qa_asset_location,
     resolve_conversion_filename,
+    resolve_qa_video_suffix,
 )
 
 
@@ -108,3 +110,25 @@ def test_bytes_to_pdf_converts_plain_text_via_fallback(monkeypatch):
     )
     pdf = _bytes_to_pdf("hello\n第二行".encode(), "note.txt")
     assert pdf[:5] == b"%PDF-"
+
+
+def test_resolve_qa_video_suffix_from_filename():
+    assert resolve_qa_video_suffix("demo.mp4", b"") == ".mp4"
+    assert resolve_qa_video_suffix("clip.mov", b"") == ".mov"
+    assert resolve_qa_video_suffix("screen.webm", b"") == ".webm"
+    assert resolve_qa_video_suffix("report.docx", b"PK") is None
+
+
+def test_resolve_qa_video_suffix_sniffs_ftyp_when_title_has_no_extension():
+    mp4_header = b"\x00" * 4 + b"ftyp" + b"isom" + b"\x00" * 4
+    assert resolve_qa_video_suffix("现场录像", mp4_header) == ".mp4"
+    assert is_qa_video_asset("现场录像", mp4_header) is True
+
+
+def test_bytes_to_pdf_rejects_mp4():
+    mp4_header = b"\x00" * 4 + b"ftyp" + b"isom" + b"\x00" * 4
+    try:
+        _bytes_to_pdf(mp4_header, "demo.mp4")
+        raise AssertionError("expected error")
+    except QaWatermarkDownloadError:
+        pass


### PR DESCRIPTION
## Summary
- 专家问答「附件文档」为 mp4/mov/webm 时，`/assets/watermarked-download` 返回原视频字节（`video/*`），不再尝试转 PDF 打水印。
- 文档类附件（docx/pdf/Office 等）行为不变，仍返回带门户水印的 PDF。
- 展示名无后缀时可通过 `ftyp`/EBML 文件头识别视频类型。

## 涉及数据表
- 无 DDL。只读 MinIO 问答上传对象（`tmp-dir/`、`qa-expert/...`）。

## Test plan
- [x] `uv run pytest test/qa_expert/test_watermarked_download.py`
- [ ] 联调：详情页上传 mp4 附件 → 预览弹窗下载得到原视频文件
- [ ] 回归：docx 附件仍下载为水印 PDF


Made with [Cursor](https://cursor.com)