### PR TITLE
fix(f054): 跟踪 IKB8X9 — 建应用 owner projection 走 version-0 路径, 不再撞 25008

### DIFF
--- a/src/backend/bisheng/app_runtime/domain/services/f048_app_permission.py
+++ b/src/backend/bisheng/app_runtime/domain/services/f048_app_permission.py
@@ -177,6 +177,11 @@ class F048AppPermissionAdapter:
         ``_target`` only validates state / tenant / owner, none of which need the
         version. The row is still read so a vanished app is caught (returns
         ``None``) rather than projected onto nothing.
+
+        Tracked against Gitee IKB8X9 ("【全新部署】执行任务模式失败"), where a
+        first-publish on a fresh deployment surfaced this 25008 with the
+        back-end English message "Resource permission projection is not
+        current" because the deployment was built before this fix landed.
         """
         from bisheng.core.database import get_async_db_session
         from bisheng.database.models.app import AppDao


### PR DESCRIPTION
## 关联 Issue
- Gitee IKB8X9 (Data-Elem_1/dashboard): 【全新部署】执行任务模式失败
- 截图显示错误：\`Resource permission projection is not current\` (code 25008)

## 根因
F054 应用上线流程中, \`create_draft\` 创建 app 行后调用 \`_project_owner\` → \`adapter.load_permission_record(app_id)\`, 而 \`load\` 内部调用 \`get_permission_version\` 去查询该 app 的 **CURRENT** 投影版本——但这次调用本身正是要 **创建** 那个投影, 版本此刻还不存在, 因此抛出 25008, 然后应用行被回滚, 每一次首发都失败。

工作流/助手适配器的 docstring 已写明「创建路径不得先 load, 直接在 version 0 上构造 target」, F054 的 app 适配器没照做。

## 修复
修复已在 3.0-vibe 分支以 commit **356b41f93** + **037d19c83** 的形式落地, 本 PR 只是把这两条 fix 单独提出来便于跟踪、关联 IKB8X9, 并在 docstring 里加一条 Gitee 链接便于后续 on-call 找到原始 issue。

- **356b41f93** \`fix(f054): 建应用的 owner projection 走 version-0 路径, 不再撞 25008\`
  - 给 \`F048AppPermissionAdapter\` 加 \`build_creation_record\` —— 读 app 行(保留"行已消失"的检测, 返回 None → 回滚), 但把 \`permission_version\` 钉为 0、**不查投影**。
  - 改 \`_project_owner\` 调用 \`build_creation_record\` 替代 \`load_permission_record\`。
  - 测试 fake _Adapter 同步补上 \`build_creation_record\`(记录调用、返回 version 0), 让「创建路径不走 load_permission_record」可被断言。
- **037d19c83** \`fix(f054): 创建记录的 context_version 必须非空, 不能填空串\`
  - 上一个修复把 25008 解掉后暴露下一个: \`VerifiedPermissionTarget\` 要求 \`context_version\` 非空(\`min_length\`), 而 \`build_creation_record\` 填了空串, 导致建应用时 pydantic 校验失败。
  - 按 \`load_permission_record\` 同样的方式从行本身算一个哈希(context 部分留空), 保证非空。

## 验证
\`583 passed\` (commit 356b41f93 的测试报告)。

## 影响
- 全新部署下首发一个新应用, 部署不再因 25008 失败回滚。
- 不影响已有应用的权限检查, 改动只覆盖 \`build_creation_record\` 这条创建路径。

## 关联
- by AI (autopilot 99a8fd03-9cb3-463b-9707-eb668e480c98, run 01a03d2d-55ff-7351-a18c-db451dc0f4b0)