### PR TITLE
fix(telemetry): dashboard query must not 500 on fresh deploy (IKB8XI)

### DIFF
--- a/src/backend/bisheng/telemetry_search/domain/services/search_engine_service.py
+++ b/src/backend/bisheng/telemetry_search/domain/services/search_engine_service.py
@@ -1,20 +1,22 @@
 import json
-from typing import List, Optional, Any, Dict, Set
+from typing import Any
 
+from elasticsearch import NotFoundError
 from loguru import logger
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from bisheng.core.search.elasticsearch.manager import get_es_connection
 from bisheng.telemetry_search.domain.schemas.query_builder import (
     AggregationExpression,
-    FilterExpression,
     AggsTypeEnum,
-    TermOp
+    FilterExpression,
+    TermOp,
 )
 
 
 class Constants:
     """Constants for Elasticsearch query building"""
+
     DEFAULT_SIZE = 10000
     MAX_SIZE = 65535
     DEFAULT_TERMS_SIZE = 65535
@@ -37,13 +39,7 @@ class Constants:
 class AggregationLevel:
     """Represents a single aggregation level in the hierarchy"""
 
-    def __init__(
-            self,
-            key: str,
-            config: AggregationExpression,
-            agg_type: str = "normal",
-            original_index: int = 0
-    ):
+    def __init__(self, key: str, config: AggregationExpression, agg_type: str = "normal", original_index: int = 0):
         self.key = key
         self.config = config
         self.type = agg_type
@@ -51,7 +47,7 @@ class AggregationLevel:
         self.nested_path = self._extract_nested_path(config.field)
 
     @staticmethod
-    def _extract_nested_path(field: Optional[str]) -> Optional[str]:
+    def _extract_nested_path(field: str | None) -> str | None:
         """Extract nested path from field (e.g., 'users.name' -> 'users')"""
         if field and "." in field:
             return field.split(".")[0]
@@ -70,25 +66,18 @@ class AggregationLevel:
 class SearchParameters(BaseModel):
     """Search parameters for Elasticsearch aggregation queries"""
 
-    index_name: Optional[str] = Field(description="Elasticsearch index name")
-    metrics: List[AggregationExpression] = Field(description="Metric aggregations")
-    dimensions: List[AggregationExpression] = Field(description="Dimension aggregations")
-    stack_dimension: Optional[AggregationExpression] = Field(
-        default=None,
-        description="Stack dimension for chart stacking"
+    index_name: str | None = Field(description="Elasticsearch index name")
+    metrics: list[AggregationExpression] = Field(description="Metric aggregations")
+    dimensions: list[AggregationExpression] = Field(description="Dimension aggregations")
+    stack_dimension: AggregationExpression | None = Field(
+        default=None, description="Stack dimension for chart stacking"
     )
-    filters: Optional[List[FilterExpression]] = Field(
-        default=None,
-        description="Query filters"
-    )
-    size: Optional[int] = Field(
-        default=Constants.DEFAULT_SIZE,
-        ge=Constants.MIN_SIZE,
-        le=Constants.MAX_SIZE,
-        description="Result size limit"
+    filters: list[FilterExpression] | None = Field(default=None, description="Query filters")
+    size: int | None = Field(
+        default=Constants.DEFAULT_SIZE, ge=Constants.MIN_SIZE, le=Constants.MAX_SIZE, description="Result size limit"
     )
 
-    @field_validator('metrics')
+    @field_validator("metrics")
     @classmethod
     def validate_metrics(cls, v):
         if not v:
@@ -96,7 +85,7 @@ class SearchParameters(BaseModel):
         return v
 
     @staticmethod
-    def _collect_metric_names(metrics: List[AggregationExpression]) -> Set[str]:
+    def _collect_metric_names(metrics: list[AggregationExpression]) -> set[str]:
         """Recursively collect all metric names including nested ones"""
         names = set()
         for metric in metrics:
@@ -106,7 +95,7 @@ class SearchParameters(BaseModel):
                 names.update(SearchParameters._collect_metric_names(metric.aggs))
         return names
 
-    @model_validator(mode='after')
+    @model_validator(mode="after")
     def validate_pipeline_references(self):
         """Ensure pipeline aggregations reference valid metrics"""
         metric_names = self._collect_metric_names(self.metrics)
@@ -116,23 +105,20 @@ class SearchParameters(BaseModel):
                 continue
 
             if not metric.field:
-                raise ValueError(
-                    f"Pipeline aggregation '{metric.name}' missing field reference"
-                )
+                raise ValueError(f"Pipeline aggregation '{metric.name}' missing field reference")
 
             self._validate_metric_path(metric.field, metric_names, metric.name)
 
         return self
 
     @staticmethod
-    def _validate_metric_path(path: str, available_names: Set[str], metric_name: str):
+    def _validate_metric_path(path: str, available_names: set[str], metric_name: str):
         """Validate that all parts of a metric path exist"""
         parts = path.split(Constants.PATH_SEPARATOR)
         for part in parts:
             if part not in available_names:
                 raise ValueError(
-                    f"Pipeline aggregation '{metric_name}' references "
-                    f"non-existent metric '{part}' in path '{path}'"
+                    f"Pipeline aggregation '{metric_name}' references non-existent metric '{part}' in path '{path}'"
                 )
 
 
@@ -146,20 +132,14 @@ class NestedPathManager:
         """Create a nested aggregation wrapper"""
         self._counter += 1
         key = f"{Constants.NESTED_WRAPPER_PREFIX}{self._counter}_{path}"
-        config = {
-            "nested": {"path": path},
-            "aggs": {}
-        }
+        config = {"nested": {"path": path}, "aggs": {}}
         return key, config
 
     def create_reverse_nested_wrapper(self) -> tuple[str, dict]:
         """Create a reverse_nested aggregation wrapper"""
         self._counter += 1
         key = f"{Constants.REVERSE_NESTED_PREFIX}{self._counter}"
-        config = {
-            "reverse_nested": {},
-            "aggs": {}
-        }
+        config = {"reverse_nested": {}, "aggs": {}}
         return key, config
 
 
@@ -173,12 +153,12 @@ class ResultParser:
         self.num_metrics = len(parameters.metrics)
 
     @property
-    def stack_dim_index(self) -> Optional[int]:
+    def stack_dim_index(self) -> int | None:
         if not self.has_stack:
             return None
         return len(self.parameters.dimensions)
 
-    def parse_to_2d_array(self, es_response: dict) -> List[List[Any]]:
+    def parse_to_2d_array(self, es_response: dict) -> list[list[Any]]:
         """Parse ES response to 2D array format"""
         aggregations = self._extract_aggregations(es_response)
         if not aggregations:
@@ -200,59 +180,38 @@ class ResultParser:
         return {}
 
     def _traverse_buckets(
-            self,
-            current_aggs: dict,
-            current_row_dict: Dict[int, Any],
-            rows: List[List[Any]],
-            metric_keys: List[str]
+        self, current_aggs: dict, current_row_dict: dict[int, Any], rows: list[list[Any]], metric_keys: list[str]
     ) -> None:
         """Recursively traverse aggregation buckets"""
 
         # Check for nested/reverse_nested wrapper
         wrapper_key = self._find_wrapper_key(current_aggs)
         if wrapper_key:
-            self._traverse_buckets(
-                current_aggs[wrapper_key],
-                current_row_dict,
-                rows,
-                metric_keys
-            )
+            self._traverse_buckets(current_aggs[wrapper_key], current_row_dict, rows, metric_keys)
             return
 
         # Process dimension level
         dimension_key = self._find_dimension_key(current_aggs)
         if dimension_key:
-            self._process_dimension_level(
-                dimension_key,
-                current_aggs,
-                current_row_dict,
-                rows,
-                metric_keys
-            )
+            self._process_dimension_level(dimension_key, current_aggs, current_row_dict, rows, metric_keys)
             return
 
         # Process stack dimension
         if Constants.STACK_DIM_KEY in current_aggs:
-            self._process_stack_dimension(
-                current_aggs,
-                current_row_dict,
-                rows,
-                metric_keys
-            )
+            self._process_stack_dimension(current_aggs, current_row_dict, rows, metric_keys)
             return
 
         # Reached metric level, build result row
         self._build_result_row(current_aggs, current_row_dict, rows, metric_keys)
 
-    def _find_wrapper_key(self, aggs: dict) -> Optional[str]:
+    def _find_wrapper_key(self, aggs: dict) -> str | None:
         """Find nested/reverse_nested wrapper key if present"""
         for key in aggs:
-            if (key.startswith(Constants.NESTED_WRAPPER_PREFIX) or
-                    key.startswith(Constants.REVERSE_NESTED_PREFIX)):
+            if key.startswith(Constants.NESTED_WRAPPER_PREFIX) or key.startswith(Constants.REVERSE_NESTED_PREFIX):
                 return key
         return None
 
-    def _find_dimension_key(self, aggs: dict) -> Optional[str]:
+    def _find_dimension_key(self, aggs: dict) -> str | None:
         """Find dimension key in current aggregation level"""
         for key in aggs:
             if key.startswith(Constants.DIMENSION_PREFIX):
@@ -260,12 +219,12 @@ class ResultParser:
         return None
 
     def _process_dimension_level(
-            self,
-            dimension_key: str,
-            current_aggs: dict,
-            current_row_dict: Dict[int, Any],
-            rows: List[List[Any]],
-            metric_keys: List[str]
+        self,
+        dimension_key: str,
+        current_aggs: dict,
+        current_row_dict: dict[int, Any],
+        rows: list[list[Any]],
+        metric_keys: list[str],
     ) -> None:
         """Process a dimension level and recurse into buckets"""
         try:
@@ -283,11 +242,7 @@ class ResultParser:
             self._traverse_buckets(bucket, new_row_dict, rows, metric_keys)
 
     def _process_stack_dimension(
-            self,
-            current_aggs: dict,
-            current_row_dict: Dict[int, Any],
-            rows: List[List[Any]],
-            metric_keys: List[str]
+        self, current_aggs: dict, current_row_dict: dict[int, Any], rows: list[list[Any]], metric_keys: list[str]
     ) -> None:
         """Process stack dimension level"""
         buckets = current_aggs[Constants.STACK_DIM_KEY].get(Constants.BUCKETS_KEY, [])
@@ -297,11 +252,7 @@ class ResultParser:
             self._traverse_buckets(bucket, new_row_dict, rows, metric_keys)
 
     def _build_result_row(
-            self,
-            current_aggs: dict,
-            current_row_dict: Dict[int, Any],
-            rows: List[List[Any]],
-            metric_keys: List[str]
+        self, current_aggs: dict, current_row_dict: dict[int, Any], rows: list[list[Any]], metric_keys: list[str]
     ) -> None:
         """Build a result row from dimension values and metrics"""
         row = [None] * self.num_dims
@@ -331,26 +282,22 @@ class QueryBuilder:
 
     def __init__(self, parameters: SearchParameters):
         self.parameters = parameters
-        self._metric_name_to_key: Dict[str, str] = {}
+        self._metric_name_to_key: dict[str, str] = {}
         self._nested_manager = NestedPathManager()
 
     def build_query_dsl(self) -> dict:
         """Build complete query DSL"""
         try:
-            return {
-                "size": 0,
-                "query": self._build_bool_query(),
-                "aggs": self._build_aggregations()
-            }
+            return {"size": 0, "query": self._build_bool_query(), "aggs": self._build_aggregations()}
         except Exception as e:
-            raise ValueError(f"Failed to build search query: {str(e)}") from e
+            raise ValueError(f"Failed to build search query: {e!s}") from e
 
     def _build_bool_query(self) -> dict:
         """Build bool query from filters"""
         if not self.parameters.filters:
             return {"match_all": {}}
 
-        bool_query: Dict[str, List] = {}
+        bool_query: dict[str, list] = {}
 
         for filter_expr in self.parameters.filters:
             try:
@@ -378,7 +325,7 @@ class QueryBuilder:
 
         return aggs
 
-    def _prepare_aggregation_levels(self) -> List[AggregationLevel]:
+    def _prepare_aggregation_levels(self) -> list[AggregationLevel]:
         """Prepare aggregation levels with original indices"""
         levels = []
 
@@ -389,19 +336,13 @@ class QueryBuilder:
         if self.parameters.stack_dimension:
             levels.append(
                 AggregationLevel(
-                    Constants.STACK_DIM_KEY,
-                    self.parameters.stack_dimension,
-                    "stack",
-                    len(self.parameters.dimensions)
+                    Constants.STACK_DIM_KEY, self.parameters.stack_dimension, "stack", len(self.parameters.dimensions)
                 )
             )
 
         return levels
 
-    def _reorder_for_nested(
-            self,
-            levels: List[AggregationLevel]
-    ) -> List[AggregationLevel]:
+    def _reorder_for_nested(self, levels: list[AggregationLevel]) -> list[AggregationLevel]:
         """Group dimensions by nested path to minimize context switches"""
         if not levels:
             return []
@@ -421,17 +362,13 @@ class QueryBuilder:
                 for j in range(i + 1, len(levels)):
                     if j not in processed:
                         candidate = levels[j]
-                        if (candidate.is_nested() and
-                                candidate.nested_path == target_path):
+                        if candidate.is_nested() and candidate.nested_path == target_path:
                             reordered.append(candidate)
                             processed.add(j)
 
         return reordered
 
-    def _reorder_for_pipeline(
-            self,
-            levels: List[AggregationLevel]
-    ) -> List[AggregationLevel]:
+    def _reorder_for_pipeline(self, levels: list[AggregationLevel]) -> list[AggregationLevel]:
         """Move date histogram to innermost level for pipeline aggregations"""
         if not self._has_histogram_dependent_pipeline():
             return levels
@@ -447,7 +384,7 @@ class QueryBuilder:
     def _has_histogram_dependent_pipeline(self) -> bool:
         """Check if any metric requires histogram parent"""
 
-        def check_metrics(metrics: List[AggregationExpression]) -> bool:
+        def check_metrics(metrics: list[AggregationExpression]) -> bool:
             for metric in metrics:
                 if metric.requires_histogram_parent():
                     return True
@@ -458,10 +395,7 @@ class QueryBuilder:
         return check_metrics(self.parameters.metrics)
 
     def _build_nested_dimensions(
-            self,
-            current_root: dict,
-            levels: List[AggregationLevel],
-            current_path: Optional[str]
+        self, current_root: dict, levels: list[AggregationLevel], current_path: str | None
     ) -> dict:
         """Recursively build dimension chain with automatic nested wrapping"""
 
@@ -480,53 +414,30 @@ class QueryBuilder:
         # Current level matches target nested path
         if target_path == current_path:
             agg_config = self._build_dimension_config(head.config)
-            current_root[head.key] = {
-                head.config.type.value: agg_config,
-                "aggs": {}
-            }
+            current_root[head.key] = {head.config.type.value: agg_config, "aggs": {}}
 
-            return self._build_nested_dimensions(
-                current_root[head.key]["aggs"],
-                levels[1:],
-                current_path
-            )
+            return self._build_nested_dimensions(current_root[head.key]["aggs"], levels[1:], current_path)
 
         # Need to switch nested context
         if target_path is not None and current_path is None:
-            wrapper_key, wrapper_config = self._nested_manager.create_nested_wrapper(
-                target_path
-            )
+            wrapper_key, wrapper_config = self._nested_manager.create_nested_wrapper(target_path)
             current_root[wrapper_key] = wrapper_config
 
-            return self._build_nested_dimensions(
-                current_root[wrapper_key]["aggs"],
-                levels,
-                target_path
-            )
+            return self._build_nested_dimensions(current_root[wrapper_key]["aggs"], levels, target_path)
 
         # Switching from one nested path to another
         if target_path is None and current_path is not None:
             wrapper_key, wrapper_config = self._nested_manager.create_reverse_nested_wrapper()
             current_root[wrapper_key] = wrapper_config
 
-            return self._build_nested_dimensions(
-                current_root[wrapper_key]["aggs"],
-                levels,
-                None
-            )
+            return self._build_nested_dimensions(current_root[wrapper_key]["aggs"], levels, None)
 
         # Switching between different nested paths
-        if (target_path is not None and
-                current_path is not None and
-                target_path != current_path):
+        if target_path is not None and current_path is not None and target_path != current_path:
             wrapper_key, wrapper_config = self._nested_manager.create_reverse_nested_wrapper()
             current_root[wrapper_key] = wrapper_config
 
-            return self._build_nested_dimensions(
-                current_root[wrapper_key]["aggs"],
-                levels,
-                None
-            )
+            return self._build_nested_dimensions(current_root[wrapper_key]["aggs"], levels, None)
 
         return current_root
 
@@ -543,9 +454,7 @@ class QueryBuilder:
         return config
 
     def _build_metric_name_mapping(
-            self,
-            metrics: Optional[List[AggregationExpression]] = None,
-            parent_key: str = ""
+        self, metrics: list[AggregationExpression] | None = None, parent_key: str = ""
     ) -> None:
         """Recursively build metric name to key mapping for pipeline refs"""
         if metrics is None:
@@ -562,28 +471,18 @@ class QueryBuilder:
                 self._build_metric_name_mapping(metric.aggs, key)
 
     def _add_metric_aggregations(
-            self,
-            current_level: dict,
-            metrics: List[AggregationExpression],
-            parent_key: str = ""
+        self, current_level: dict, metrics: list[AggregationExpression], parent_key: str = ""
     ) -> None:
         """Recursively add metric aggregations"""
         for idx, metric in enumerate(metrics):
-            agg_key = (f"{parent_key}_{idx}" if parent_key
-                       else f"{Constants.METRIC_PREFIX}{idx}")
+            agg_key = f"{parent_key}_{idx}" if parent_key else f"{Constants.METRIC_PREFIX}{idx}"
 
             agg_config = self._build_metric_config(metric)
-            current_level[agg_key] = {
-                metric.type.value: agg_config
-            }
+            current_level[agg_key] = {metric.type.value: agg_config}
 
             if metric.aggs:
                 current_level[agg_key]["aggs"] = {}
-                self._add_metric_aggregations(
-                    current_level[agg_key]["aggs"],
-                    metric.aggs,
-                    agg_key
-                )
+                self._add_metric_aggregations(current_level[agg_key]["aggs"], metric.aggs, agg_key)
 
     def _build_metric_config(self, metric: AggregationExpression) -> dict:
         """Build metric aggregation configuration"""
@@ -622,7 +521,7 @@ class SearchEngineService:
         self.query_builder = QueryBuilder(parameters)
         self.result_parser = ResultParser(parameters)
 
-    async def search(self) -> List[List[Any]]:
+    async def search(self) -> list[list[Any]]:
         """Execute search and return parsed results"""
         try:
             query_dsl = self.query_builder.build_query_dsl()
@@ -630,15 +529,20 @@ class SearchEngineService:
 
             es_client = await get_es_connection()
             response = await es_client.search(
-                index=self.parameters.index_name,
-                body=query_dsl,
-                filter_path=Constants.AGGREGATION_KEY
+                index=self.parameters.index_name, body=query_dsl, filter_path=Constants.AGGREGATION_KEY
             )
 
             return self.result_parser.parse_to_2d_array(response)
 
-        except Exception as e:
-            raise RuntimeError(f"Search execution failed: {str(e)}") from e
+        except NotFoundError:
+            # Index does not exist yet — typically a fresh deployment before the
+            # telemetry mid-table Celery workers have populated it. Treat as
+            # empty data so the dashboard renders zeros instead of 500-ing.
+            logger.warning(
+                "Elasticsearch index {} not found; returning empty result for query",
+                self.parameters.index_name,
+            )
+            return []
 
     def build_search_query(self) -> dict:
         """Build query DSL for debugging"""
@@ -667,29 +571,14 @@ async def run_example():
         index_name="mid_knowledge_increment",
         metrics=[
             AggregationExpression(
-                name="document_knowledge_base_count",
-                type=AggsTypeEnum.CARDINALITY,
-                field="knowledge_id"
+                name="document_knowledge_base_count", type=AggsTypeEnum.CARDINALITY, field="knowledge_id"
             ),
         ],
         dimensions=[
-            AggregationExpression(
-                name="用户组",
-                type=AggsTypeEnum.TERMS,
-                field="user_group_infos.user_group_name"
-            ),
-            AggregationExpression(
-                name="用户组id",
-                type=AggsTypeEnum.TERMS,
-                field="user_group_infos.user_group_id"
-            )
+            AggregationExpression(name="用户组", type=AggsTypeEnum.TERMS, field="user_group_infos.user_group_name"),
+            AggregationExpression(name="用户组id", type=AggsTypeEnum.TERMS, field="user_group_infos.user_group_id"),
         ],
-        filters=[
-            FilterExpression(
-                bool_operator="must",
-                filters=[TermOp(field="knowledge_type", value=0)]
-            )
-        ],
+        filters=[FilterExpression(bool_operator="must", filters=[TermOp(field="knowledge_type", value=0)])],
     )
 
     service = SearchEngineService(parameters)
@@ -697,7 +586,7 @@ async def run_example():
     print(rows)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import asyncio
 
     asyncio.run(run_example())

--- a/src/backend/test/telemetry_search/test_search_engine_missing_index.py
+++ b/src/backend/test/telemetry_search/test_search_engine_missing_index.py
@@ -1,0 +1,102 @@
+"""Regression: dashboard queries must not 500 when the underlying ES index
+does not yet exist.
+
+Root cause (gitee IKB8XI — "全新部署点击看板报错"): on a fresh deployment the
+preset dashboards query Elasticsearch indices (``mid_user_increment``,
+``mid_knowledge_increment``, ``mid_app_increment``, ``mid_user_interact_dtl``, …)
+that the telemetry mid-table Celery workers have not yet created. The
+underlying ``AsyncElasticsearch.search`` raises ``NotFoundError`` (HTTP 404),
+which the dashboard's ``SearchEngineService.search`` wrapped as a generic
+``RuntimeError`` — every dashboard component then 500'd with the frontend's
+generic "服务器错误" toast.
+
+The fix: ``SearchEngineService.search`` catches ``NotFoundError`` and returns
+an empty result (so the dashboard renders zeros/empty charts instead of
+failing the whole page), and lets every other error propagate with its
+original traceback.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from elasticsearch import NotFoundError
+
+from bisheng.telemetry_search.domain.schemas.query_builder import (
+    AggregationExpression,
+    AggsTypeEnum,
+)
+from bisheng.telemetry_search.domain.services.search_engine_service import (
+    SearchEngineService,
+    SearchParameters,
+)
+
+
+def _make_params(index_name: str = "mid_user_increment") -> SearchParameters:
+    return SearchParameters(
+        index_name=index_name,
+        metrics=[AggregationExpression(name="total", type=AggsTypeEnum.CARDINALITY, field="user_id")],
+        dimensions=[],
+    )
+
+
+def _not_found_error() -> NotFoundError:
+    return NotFoundError(
+        message="index_not_found_exception",
+        meta=MagicMock(),
+        body={"error": {"type": "index_not_found_exception"}},
+    )
+
+
+async def test_search_returns_empty_when_index_missing():
+    """NotFoundError (index missing) must yield an empty result, not raise."""
+    service = SearchEngineService(_make_params())
+
+    mock_es = MagicMock()
+    mock_es.search = AsyncMock(side_effect=_not_found_error())
+
+    with patch(
+        "bisheng.telemetry_search.domain.services.search_engine_service.get_es_connection",
+        new=AsyncMock(return_value=mock_es),
+    ):
+        result = await service.search()
+
+    assert result == []
+    mock_es.search.assert_awaited_once()
+
+
+async def test_search_propagates_other_errors():
+    """Non-NotFoundError exceptions must still surface (no silent swallow)."""
+    service = SearchEngineService(_make_params())
+
+    mock_es = MagicMock()
+    # ConnectionError / mapping / other genuine failures → still 500
+    mock_es.search = AsyncMock(side_effect=RuntimeError("connection refused"))
+
+    with patch(
+        "bisheng.telemetry_search.domain.services.search_engine_service.get_es_connection",
+        new=AsyncMock(return_value=mock_es),
+    ):
+        with pytest.raises(RuntimeError, match="connection refused"):
+            await service.search()
+
+
+async def test_search_returns_parsed_rows_on_success():
+    """Happy path: a normal ES response is parsed into a 2D array as before."""
+    service = SearchEngineService(_make_params())
+
+    fake_response = {
+        "aggregations": {
+            "metric_0": {"value": 42},
+        }
+    }
+    mock_es = MagicMock()
+    mock_es.search = AsyncMock(return_value=fake_response)
+
+    with patch(
+        "bisheng.telemetry_search.domain.services.search_engine_service.get_es_connection",
+        new=AsyncMock(return_value=mock_es),
+    ):
+        result = await service.search()
+
+    # Single-metric, no-dimension query → one row, one column.
+    assert result == [[42]]


### PR DESCRIPTION
## Summary

Fixes the "全新部署点击看板报错" bug (gitee IKB8XI): on a fresh deployment, opening the preset 统计看板 page shows a "服务器错误" toast and every dashboard component's `/api/v1/telemetry/dashboard/component/query` call returns HTTP 500.

### Root cause

The preset dashboard components query Elasticsearch mid-table indices (`mid_user_increment`, `mid_knowledge_increment`, `mid_app_increment`, `mid_user_interact_dtl`, ...). On a brand-new install those indices are created lazily by the telemetry mid-table Celery workers — before the workers have run, `AsyncElasticsearch.search` raises `NotFoundError` (HTTP 404) for each query.

`SearchEngineService.search` previously caught every exception and re-raised as `RuntimeError(f"Search execution failed: {str(e)}")`, which the FastAPI global handler turned into a 500. The frontend's response interceptor then showed the generic "服务器错误" toast for every component, and the user couldn't see the dashboard at all.

### Fix

`src/backend/bisheng/telemetry_search/domain/services/search_engine_service.py:537`

Catch `NotFoundError` specifically and return `[]` (the same shape `parse_to_2d_array` returns for an empty aggregation result). Every other error continues to propagate with its original traceback — only the "index not yet created" case is treated as empty data, so genuine failures (ES down, mapping conflict, ...) still surface as 500s that an operator can debug.

### Verification

Repro confirmed against `origin/main` (commit `3f2764198`) — a `NotFoundError` from a mocked `AsyncElasticsearch` flowed up as `RuntimeError("Search execution failed: NotFoundError(...)")`, exactly the 500 path the issue reports.

After the fix, the same mocked ES yields `[]` and a warning log entry; the rest of the dashboard pipeline (`DataQueryService.query_telemetry_data` → `query_all_metrics` → `query_one_metric` / `query_sum_metric` / `query_index_metric` / `query_formula_metric`) already handles empty search results — every consumer iterates the result with a `for one in result` loop, so the empty list short-circuits cleanly and the dashboard renders zeros/empty charts instead of erroring.

New regression test: `src/backend/test/telemetry_search/test_search_engine_missing_index.py` — three cases:

1. `test_search_returns_empty_when_index_missing` — the original bug: now returns `[]`.
2. `test_search_propagates_other_errors` — non-`NotFoundError` still raises (no silent swallow).
3. `test_search_returns_parsed_rows_on_success` — happy path unchanged.

All three pass (`uv run pytest test/telemetry_search/...`).

### Out of scope

- The Beat schedule that creates the indices is unchanged. The fix only makes the *read* path resilient; the indices still need to be populated by the existing `sync_mid_*_increment` Celery workers for the data to actually appear.
- `get_dataset_field_enums` (used by the dashboard editor's autocomplete, not by the rendered dashboard) is not touched — the editor's path is a different code path and was not in scope of the reported issue.

### Refs

- gitee IKB8XI — "【全新部署】点击看板报错"