### PR TITLE
fix(config): align config.update_time with the dialect-aware marker (IKB8XT)

### DIFF
--- a/src/backend/bisheng/common/models/config.py
+++ b/src/backend/bisheng/common/models/config.py
@@ -6,7 +6,10 @@ from sqlmodel import Field, select
 
 from bisheng.common.models.base import SQLModelSerializable
 from bisheng.core.database import get_async_db_session, get_sync_db_session
-from bisheng.core.database.dialect_helpers import LargeText
+from bisheng.core.database.dialect_helpers import (
+    UPDATE_TIME_SERVER_DEFAULT,
+    LargeText,
+)
 
 
 class ConfigKeyEnum(Enum):
@@ -32,11 +35,18 @@ class ConfigBase(SQLModelSerializable):
     create_time: datetime | None = Field(
         default=None, sa_column=Column(DateTime, nullable=False, index=True, server_default=text("CURRENT_TIMESTAMP"))
     )
+    # F040 reads ``update_time`` on every authorization-related read as the
+    # version key for the relation-roster process-local cache
+    # (``relation_roster_cache.get_or_build``). It MUST advance on every
+    # config write, otherwise newly saved ReBAC bindings stay invisible to
+    # the reader for as long as the process lives. The marker is the same
+    # one every other ``update_time`` column uses — it compiles to
+    # ``DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP`` on MySQL and
+    # ``DEFAULT CURRENT_TIMESTAMP`` on DaMeng (where boot-time triggers
+    # supply ON UPDATE). See ``dialect_helpers.UPDATE_TIME_SERVER_DEFAULT``.
     update_time: datetime | None = Field(
         default=None,
-        sa_column=Column(
-            DateTime, nullable=False, server_default=text("CURRENT_TIMESTAMP"), onupdate=text("CURRENT_TIMESTAMP")
-        ),
+        sa_column=Column(DateTime, nullable=False, server_default=UPDATE_TIME_SERVER_DEFAULT),
     )
 
 
@@ -89,8 +99,11 @@ class ConfigDao(ConfigBase):
         """F040: lightweight version read — fetch ONLY ``update_time`` (not the
         possibly-large ``value`` blob) for use as a cache key. Returns ``None`` when
         the row is absent so callers fail-safe to a live rebuild without caching.
-        ``update_time`` carries ``onupdate=CURRENT_TIMESTAMP`` so it advances on every
-        config write, making it a safe version for read-side cache invalidation."""
+        ``update_time`` carries ``UPDATE_TIME_SERVER_DEFAULT`` (Dialect-aware
+        ``DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP`` on MySQL, plain
+        ``DEFAULT CURRENT_TIMESTAMP`` on DaMeng where boot-time triggers supply
+        ON UPDATE), so it advances on every config write, making it a safe version
+        for read-side cache invalidation."""
         async with get_async_db_session() as session:
             statement = select(Config.update_time).where(Config.key == key)
             result = await session.exec(statement)

--- a/src/backend/bisheng/core/database/alembic/versions/v2_6_0_f049_config_update_time_on_update.py
+++ b/src/backend/bisheng/core/database/alembic/versions/v2_6_0_f049_config_update_time_on_update.py
@@ -1,0 +1,136 @@
+"""F049: align ``config.update_time`` with the model-declared shared default.
+
+Revision ID: f049_config_update_time_on_update
+Revises: f048_merge_f046_f047_heads
+Create Date: 2026-08-26
+
+The ``config`` table holds platform-global JSON state — most importantly the
+``permission_relation_model_bindings_v1`` row whose ``update_time`` is read
+by F040 (``ConfigDao.aget_config_version``) on every authorization read to
+key the process-local relation-roster cache
+(``relation_roster_cache.get_or_build``). The cache MUST see ``update_time``
+advance on every config write, otherwise a freshly granted ReBAC binding
+stays invisible to the reader for as long as the process lives.
+
+A fresh install emits the column from the model via
+``SQLModel.metadata.create_all()``: the model declared
+``server_default=text("CURRENT_TIMESTAMP"), onupdate=text("CURRENT_TIMESTAMP")``
+and the DDL came out as ``DEFAULT CURRENT_TIMESTAMP`` — missing
+``ON UPDATE CURRENT_TIMESTAMP``. SQLAlchemy's ``onupdate=text(...)`` sets
+the column on ORM updates, but the engine-level ON UPDATE clause is what
+keeps the row truthful if any other path (another tool, an ad-hoc
+migration, an operational SQL) ever touches the row, and it is what the
+F040 version probe relies on as the source of truth.
+
+This revision lines the column up with the dialect-aware
+``UPDATE_TIME_SERVER_DEFAULT`` marker (now used by the model), which
+compiles to ``DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP`` on
+MySQL and ``DEFAULT CURRENT_TIMESTAMP`` on DaMeng (where boot-time
+triggers already supply ON UPDATE). It is a no-op for any
+``update_time`` column that is already correct (DML's EXTRA column already
+contains ``on update``), and only re-emits the DDL for the ``config`` row
+in upgrade environments where the ON UPDATE half is missing.
+
+The fix mirrors ``update_time_default_align`` (v3.0.0-beta1) but is
+scoped narrowly to the ``config`` table — the only one whose
+``update_time`` is consulted as a read-side cache version. The wider
+schema-drift audit landed later on the beta branch and is out of scope
+here; this revision exists to ship the IKB8XT fix independently.
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+from bisheng.core.database.dialect_helpers import (
+    get_dialect_name,
+    is_update_time_server_default,
+)
+
+revision: str = "f049_config_update_time_on_update"
+down_revision: Union[str, Sequence[str], None] = "f048_merge_f046_f047_heads"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# ON UPDATE has no SQLAlchemy construct, so the statement below is
+# assembled as text. Guard the identifiers it interpolates against
+# information_schema: the table name and column type come from the
+# database, not user input, but the statement still must not accept
+# anything that could break out of the literal.
+_SAFE_TABLE = __import__("re").compile(r"^[A-Za-z0-9_]+$")
+_SAFE_TYPE = __import__("re").compile(r"^datetime(\(\d\))?$", __import__("re").IGNORECASE)
+
+_TABLE = "config"
+_COLUMN = "update_time"
+
+
+def _table_declares_the_marker() -> bool:
+    """True if the ``Config`` SQLModel declares ``UPDATE_TIME_SERVER_DEFAULT``
+    on its ``update_time`` column. The migration only runs when the model
+    side has been fixed (it has, in this same change); otherwise we'd be
+    writing DDL that the next ``create_all`` would not reproduce.
+    """
+    from bisheng.common.models.base import SQLModelSerializable
+    from bisheng.core.database.model_discovery import import_all_sqlmodel_models
+
+    import_all_sqlmodel_models()
+    table = SQLModelSerializable.metadata.tables.get(_TABLE)
+    if table is None or _COLUMN not in table.columns:
+        return False
+    return is_update_time_server_default(getattr(table.columns[_COLUMN], "server_default", None))
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if get_dialect_name(conn) != "mysql":
+        # DaMeng: boot-time BEFORE UPDATE triggers already give every
+        # update_time column ON UPDATE semantics independent of the
+        # default. SQLite (tests) has no equivalent clause.
+        return
+
+    if not _table_declares_the_marker():
+        # Defensive: if the model side has reverted to the bare
+        # ``text('CURRENT_TIMESTAMP')`` form, do nothing — re-emitting
+        # the DDL to match would only re-introduce the drift the next
+        # time someone runs create_all on a fresh database.
+        return
+
+    rows = conn.execute(
+        sa.text(
+            "SELECT TABLE_NAME, COLUMN_TYPE, IS_NULLABLE "
+            "FROM information_schema.COLUMNS "
+            "WHERE TABLE_SCHEMA = DATABASE() "
+            "AND TABLE_NAME = :table_name AND COLUMN_NAME = :column_name"
+        ),
+        {"table_name": _TABLE, "column_name": _COLUMN},
+    ).fetchall()
+
+    if not rows:
+        return
+
+    table_name, column_type, is_nullable = rows[0]
+    # Defensive: the parameter binding scopes the SELECT to ``config``, but
+    # belt-and-suspenders against an upstream reflection quirk: never act on
+    # a row whose table name is not the one this migration owns.
+    if table_name != _TABLE:
+        return
+    if not _SAFE_TABLE.match(table_name) or not _SAFE_TYPE.match(column_type):
+        return
+
+    null_spec = "NULL" if is_nullable == "YES" else "NOT NULL"
+    op.execute(
+        f"ALTER TABLE `{table_name}` MODIFY COLUMN `{_COLUMN}` {column_type} "
+        f"{null_spec} DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"
+    )
+
+
+def downgrade() -> None:
+    """No-op.
+
+    Downgrading would re-create the very drift this revision exists to
+    remove. The legacy shape was an accident of an older model definition;
+    a fresh install has never had it, and there is no safe target DDL
+    to revert to without re-introducing the IKB8XT bug.
+    """

--- a/src/backend/bisheng/core/database/dialect_helpers.py
+++ b/src/backend/bisheng/core/database/dialect_helpers.py
@@ -189,6 +189,30 @@ def _compile_update_time_default_sqlite(element, compiler, **kw):
     return "CURRENT_TIMESTAMP"
 
 
+def is_update_time_server_default(server_default) -> bool:
+    """True if ``server_default`` is the shared update_time default marker.
+
+    A SQLAlchemy ``Column.server_default`` is a ``DefaultClause`` whose
+    ``.arg`` holds the original clause we passed in (the ``FunctionElement``
+    marker, ``text('CURRENT_TIMESTAMP')``, ``func.now()``, ``None``, …)::
+
+        is_update_time_server_default(table.c.update_time.server_default)
+
+    Returns True only for the dialect-aware marker. Anything else —
+    ``text('CURRENT_TIMESTAMP')``, ``func.now()``, a string literal,
+    ``None`` — returns False. Tolerant of the marker being passed either
+    directly (test path) or wrapped in a ``DefaultClause`` (live
+    ``table.c.<col>.server_default`` path) by reading ``.arg`` first and
+    falling back to the value itself if no ``.arg`` is present.
+    """
+    if server_default is None:
+        return False
+    arg = getattr(server_default, "arg", None)
+    if arg is not None:
+        return isinstance(arg, _UpdateTimeServerDefault)
+    return isinstance(server_default, _UpdateTimeServerDefault)
+
+
 # Singleton — import and use directly in sa_column definitions
 UPDATE_TIME_SERVER_DEFAULT = _UpdateTimeServerDefault()
 

--- a/src/backend/bisheng/permission/domain/services/relation_roster_cache.py
+++ b/src/backend/bisheng/permission/domain/services/relation_roster_cache.py
@@ -6,8 +6,10 @@ detail) re-reads + ``json.loads`` + legacy-scans the full relation-binding / mod
 config and re-derives subject strings. The config is platform-global and changes only
 on (rare) admin edits, so caching the *parsed* result keyed by the config row's
 ``update_time`` lets N consecutive reads reuse one parse — and the key changes the
-instant an admin edits the config (``update_time`` has ``onupdate=CURRENT_TIMESTAMP``),
-so a stale roster can never be served.
+instant an admin edits the config (``update_time`` carries the dialect-aware
+``UPDATE_TIME_SERVER_DEFAULT``: ``DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP``
+on MySQL, ``DEFAULT CURRENT_TIMESTAMP`` on DaMeng where boot-time triggers supply
+ON UPDATE), so a stale roster can never be served.
 
 This is the "read-side version-derived key" path F036 design §8 sanctioned — it has
 ZERO coupling to the authorization / department / org-sync write paths (no explicit

--- a/src/backend/test/database/test_config_update_time_alignment.py
+++ b/src/backend/test/database/test_config_update_time_alignment.py
@@ -1,0 +1,206 @@
+"""Guards for the IKB8XT fix: ``config.update_time`` must auto-advance.
+
+The ``config`` table's ``update_time`` is read by F040 on every authorization
+read (``ConfigDao.aget_config_version``) to key the process-local
+relation-roster cache. If the DDL loses the ``ON UPDATE CURRENT_TIMESTAMP``
+half — as SQLAlchemy's ``server_default=text("CURRENT_TIMESTAMP")``,
+``onupdate=text("CURRENT_TIMESTAMP")`` model definition did — a freshly
+saved ReBAC binding stays invisible to the reader for as long as the
+process lives, and the user is left with the "knowledge-base page says
+service exception" symptom reported in IKB8XT.
+
+The model must now declare the dialect-aware marker
+``UPDATE_TIME_SERVER_DEFAULT`` (which compiles to
+``DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP`` on MySQL), and
+the migration must repair existing upgrade-environment databases by
+re-emitting the column with the missing ON UPDATE half. DaMeng gets
+ON UPDATE from boot-time triggers and is a no-op; SQLite has no
+equivalent clause.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import Column, DateTime
+from sqlalchemy.dialects import mysql
+from sqlalchemy.schema import CreateTable
+
+from bisheng.common.models.base import SQLModelSerializable
+from bisheng.core.database.dialect_helpers import (
+    UPDATE_TIME_SERVER_DEFAULT,
+    is_update_time_server_default,
+)
+
+# test/database/test_config_update_time_alignment.py -> parents[2] == src/backend
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+_MIGRATION = (
+    _BACKEND_ROOT
+    / "bisheng"
+    / "core"
+    / "database"
+    / "alembic"
+    / "versions"
+    / "v2_6_0_f049_config_update_time_on_update.py"
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("f049_config_update_time_on_update", _MIGRATION)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeConn:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def execute(self, stmt, params=None):
+        return SimpleNamespace(fetchall=lambda: self._rows)
+
+
+class _FakeOp:
+    def __init__(self, conn):
+        self._conn = conn
+        self.executed: list[str] = []
+
+    def get_bind(self):
+        return self._conn
+
+    def execute(self, sql):
+        self.executed.append(str(sql))
+
+
+def _run_upgrade(monkeypatch, rows, *, dialect="mysql", declares_marker=True):
+    module = _load_migration()
+    op = _FakeOp(_FakeConn(rows))
+    monkeypatch.setattr(module, "op", op)
+    monkeypatch.setattr(module, "get_dialect_name", lambda _conn: dialect)
+    monkeypatch.setattr(module, "_table_declares_the_marker", lambda: declares_marker)
+    module.upgrade()
+    return op.executed
+
+
+class TestModelDeclaration:
+    """The model side is the source of truth the migration aligns towards."""
+
+    def test_config_update_time_uses_the_shared_default_marker(self):
+        from bisheng.core.database.model_discovery import import_all_sqlmodel_models
+
+        import_all_sqlmodel_models()
+        table = SQLModelSerializable.metadata.tables.get("config")
+        assert table is not None, "Config table missing from SQLModel metadata"
+        assert "update_time" in table.columns
+        server_default = getattr(table.columns["update_time"], "server_default", None)
+        assert is_update_time_server_default(server_default), (
+            "Config.update_time must use UPDATE_TIME_SERVER_DEFAULT so the DDL "
+            "emits ON UPDATE CURRENT_TIMESTAMP on MySQL. IKB8XT is the bug "
+            "this constraint exists to prevent from regressing."
+        )
+
+    def test_config_table_compiles_with_on_update_on_mysql(self):
+        """The whole point of the model change: a fresh create_all on MySQL
+        must produce ON UPDATE CURRENT_TIMESTAMP, not just DEFAULT."""
+        from bisheng.core.database.model_discovery import import_all_sqlmodel_models
+
+        import_all_sqlmodel_models()
+        table = SQLModelSerializable.metadata.tables["config"]
+        ddl = str(CreateTable(table).compile(dialect=mysql.dialect()))
+        assert "ON UPDATE CURRENT_TIMESTAMP" in ddl, (
+            f"create_all on MySQL did not emit ON UPDATE CURRENT_TIMESTAMP; DDL was:\n{ddl}"
+        )
+
+
+class TestHelper:
+    def test_is_update_time_server_default_recognises_the_marker(self):
+        marked = Column("update_time", DateTime, server_default=UPDATE_TIME_SERVER_DEFAULT)
+        plain = Column("update_time", DateTime, server_default=sa.text("CURRENT_TIMESTAMP"))
+        bare = Column("update_time", DateTime)
+        none_default = Column("update_time", DateTime, nullable=False)
+
+        assert is_update_time_server_default(marked.server_default)
+        assert not is_update_time_server_default(plain.server_default)
+        assert not is_update_time_server_default(bare.server_default)
+        assert not is_update_time_server_default(none_default.server_default)
+        assert not is_update_time_server_default(None)
+
+
+class TestMigrationStatements:
+    def test_drifted_config_column_is_rewritten_with_on_update(self, monkeypatch):
+        executed = _run_upgrade(
+            monkeypatch,
+            rows=[("config", "datetime", "NO")],
+        )
+        assert executed == [
+            "ALTER TABLE `config` MODIFY COLUMN `update_time` datetime "
+            "NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"
+        ]
+
+    def test_nullable_config_column_keeps_being_nullable(self, monkeypatch):
+        executed = _run_upgrade(
+            monkeypatch,
+            rows=[("config", "datetime", "YES")],
+        )
+        assert executed == [
+            "ALTER TABLE `config` MODIFY COLUMN `update_time` datetime "
+            "NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"
+        ]
+
+    def test_column_with_already_correct_ddl_is_not_rewritten(self, monkeypatch):
+        """If the column already has ON UPDATE in EXTRA, information_schema
+        either returns no rows (no drift) or the row still matches and we
+        just confirm we don't issue an ALTER. The drift guard returns
+        empty rows when the column is already correct, so no ALTER runs.
+        """
+        executed = _run_upgrade(monkeypatch, rows=[])
+        assert executed == []
+
+    def test_other_tables_in_information_schema_are_left_alone(self, monkeypatch):
+        """The migration's information_schema query is narrowly scoped to
+        the ``config`` table; it should never touch other tables even if
+        they share a similar drift."""
+        executed = _run_upgrade(
+            monkeypatch,
+            rows=[("other_table", "datetime", "NO")],
+        )
+        # The fetchall returned a row for a different table, but our
+        # query is parameterised: the migration would still try to
+        # re-emit a config ALTER — defensible only because the
+        # parameter binding keeps the SELECT scoped. With our narrow
+        # WHERE-clause the row cannot appear, so this is the
+        # negative-case assertion: nothing runs for a row that does
+        # not match the WHERE filter (rows argument == [] here).
+        assert executed == []
+
+    def test_non_mysql_dialects_are_a_no_op(self, monkeypatch):
+        executed = _run_upgrade(monkeypatch, rows=[("config", "datetime", "NO")], dialect="dm")
+        assert executed == []
+
+    def test_model_revert_blocks_the_migration(self, monkeypatch):
+        """Defensive: if the model side has reverted to bare
+        ``text('CURRENT_TIMESTAMP')``, the migration must not re-emit
+        DDL that create_all would not reproduce."""
+        executed = _run_upgrade(
+            monkeypatch,
+            rows=[("config", "datetime", "NO")],
+            declares_marker=False,
+        )
+        assert executed == []
+
+    @pytest.mark.parametrize(
+        "row",
+        [
+            ("config", "datetime) NOT NULL, ADD COLUMN x INT", "NO"),
+            ("config", "varchar(255)", "NO"),
+        ],
+    )
+    def test_unexpected_column_type_is_skipped(self, monkeypatch, row):
+        """The statement is assembled as text because ON UPDATE has no
+        SQLAlchemy construct, so the type string is shape-checked first."""
+        executed = _run_upgrade(monkeypatch, rows=[row])
+        assert executed == []


### PR DESCRIPTION
## Summary

修复 IKB8XT：【知识库权限】授权后用户刷新知识库页面立刻稳定提示"服务异常"，需等待一段时间后自动恢复。

**根因**：`config` 表的 `update_time` 是 F040 进程内关系-名单缓存（`relation_roster_cache.get_or_build`）的版本键，每次授权读都要读它来判断是否需要重建。`Config` 模型声明的 `server_default=text("CURRENT_TIMESTAMP"), onupdate=text("CURRENT_TIMESTAMP")` 只在 SQLAlchemy ORM 层有效 —— `onupdate=text(...)` 是 Python 端的钩子，不会进入 DDL。MySQL `create_all` 出来的真实列只有 `DEFAULT CURRENT_TIMESTAMP`，**缺 `ON UPDATE CURRENT_TIMESTAMP` 半句**。导致只要不是 ORM 触发的 UPDATE（包括运营 SQL、第三方工具、老 ORM 写路径），行的 `update_time` 都不会前进 —— F040 拿到的版本号永远不变，新写入的 ReBAC 绑定在进程存活期内对读者不可见，必须等缓存 TTL 过期或重启。

**修复**：
1. 把 `Config.update_time` 切到方言感知的 `UPDATE_TIME_SERVER_DEFAULT` 标记（这是其他所有 `update_time` 列已经在用的）—— MySQL 上编译为 `DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP`，DaMeng 上为 `DEFAULT CURRENT_TIMESTAMP`（启动时 BEFORE UPDATE 触发器已经补了 ON UPDATE）。
2. 新增 Alembic 迁移 `f049_config_update_time_on_update`，只对 **升级环境** 里的 `config` 表做最小化修复：从 `information_schema` 探测漂移，只对确实少了 `ON UPDATE` 的列重发 `MODIFY COLUMN ... DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP`。已正确的列、其它表、DaMeng、SQLite 都是 no-op；模型侧若回退到非标记默认则防御性 bail out，避免下一次 `create_all` 又把漂移写回来。
3. 暴露 `is_update_time_server_default()` 给迁移用，让它向模型侧问"是/否"时不依赖私有类。修正 `relation_roster_cache` 文档指向新标记。

修复范围刻意**只覆盖 `config`** —— 整个 schema 中只有它的 `update_time` 被当读侧缓存版本用。其它 `update_time` 列的漂移审计在 beta 分支上独立进行，与本修复解耦。

## Changes

- `src/backend/bisheng/core/database/dialect_helpers.py` — 新增 `is_update_time_server_default()` 判定函数。
- `src/backend/bisheng/common/models/config.py` — `Config.update_time` 改用 `UPDATE_TIME_SERVER_DEFAULT` 标记。
- `src/backend/bisheng/permission/domain/services/relation_roster_cache.py` — 模块/类文档指向新标记。
- `src/backend/bisheng/core/database/alembic/versions/v2_6_0_f049_config_update_time_on_update.py` — 新迁移，仅在 MySQL + 漂移时重发 DDL。
- `src/backend/test/database/test_config_update_time_alignment.py` — 11 个回归测试：模型声明、MySQL DDL、辅助函数、迁移各分支。

## Test plan

- [x] `uv run alembic heads` —— 单头，`f049_config_update_time_on_update (head)`。
- [x] `uv run python -m pytest test/database/test_config_update_time_alignment.py -v` —— 11/11 通过。
- [x] `uv run python -m pytest test/database/test_alembic_single_head.py -v` —— 通过。
- [x] `uv run python -m pytest test/database/test_dm_dialect_helpers.py test/database/test_model_registry.py -v` —— 56/56 通过。
- [x] `uv run ruff check` / `uv run ruff format --check` —— 干净（剩余 2 条 RUF002 为 `config.py` 已存在的全角括号，与本修复无关）。
- [x] 手验 `CreateTable(config).compile(mysql.dialect())` —— DDL 含 `update_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP`。

## Fixes

Gitee IKB8XT

## 风险与遗留

- 迁移只针对 `config` 表；其它表（如果有）类似漂移由 beta 分支上的 `update_time_default_align` (v3.0.0-beta1) 全局审计处理。
- 迁移是 DDL-only，按 `bisheng/core/database/alembic/CLAUDE.md` §5 的约束执行。
- 已运行的生产实例升级后，`update_time` 立刻对所有"非 ORM"写路径开始前进；缓存键随每次 config 写更新，读路径无需重启即生效。