### PR TITLE
fix(qa_expert): 超管删除自己的已答问题不扣分

### DIFF
--- a/src/backend/bisheng/qa_expert/domain/moderate_delete_service.py
+++ b/src/backend/bisheng/qa_expert/domain/moderate_delete_service.py
@@ -1,3 +1,4 @@
+# ruff: noqa: RUF002, RUF003
 """平台超管在专家问答违规删除：先删内容，再扣分（失败入补扣队列）。"""
 
 from __future__ import annotations
@@ -65,7 +66,8 @@ class ModerateDeleteService:
     ) -> ModerateDeleteResult:
         """删除问题、回答或评论/追问；若传入启用中的 R* 则对内容作者扣分。
 
-        未选规则 = 只删不扣。扣分失败不回滚删除, 写入 point_pending_deduct 供 Beat 补扣.
+        未选规则 = 只删不扣。作者即操作人（超管删自己）强制不扣。
+        扣分失败不回滚删除, 写入 point_pending_deduct 供 Beat 补扣.
         删回答时级联硬删其下评论，扣分仅针对回答作者。
         """
         require_platform_admin(operator)
@@ -75,6 +77,18 @@ class ModerateDeleteService:
             raise QuestionNotFoundError()
 
         author_id, biz_type, biz_id = await self._resolve_and_delete(target_type, int(target_id))
+        operator_id = int(getattr(operator, "user_id", 0) or 0)
+        # 超管删自己的内容：不参与积分排行，强制不扣，避免误选 R* 写脏账本。
+        if operator_id and int(author_id) == operator_id:
+            return ModerateDeleteResult(
+                deleted=True,
+                target_type=target_type,
+                target_id=int(target_id),
+                target_user_id=author_id,
+                deducted=False,
+                pending_deduct=False,
+                reason="self_author",
+            )
         code = (rule_code or "").strip().upper()
         if not code:
             return ModerateDeleteResult(
@@ -107,9 +121,7 @@ class ModerateDeleteService:
             reason=attempt.reason,
         )
 
-    async def _resolve_and_delete(
-        self, target_type: TargetType, target_id: int
-    ) -> tuple[int, str, str]:
+    async def _resolve_and_delete(self, target_type: TargetType, target_id: int) -> tuple[int, str, str]:
         """解析作者并删除, 返回 (author_user_id, biz_type, biz_id)."""
         if target_type == "question":
             return await self._delete_question(target_id)

--- a/src/backend/test/qa_expert/test_moderate_delete_answer.py
+++ b/src/backend/test/qa_expert/test_moderate_delete_answer.py
@@ -1,3 +1,4 @@
+# ruff: noqa: RUF002
 """平台超管违规删除回答：作者解析、软删、级联评论、采纳指针与可选扣分。"""
 
 from types import SimpleNamespace
@@ -63,9 +64,7 @@ async def test_delete_answer_no_rule_cascades_and_clears_adopted():
             status=2,
         )
     )
-    svc.expert_repo.get_by_id = AsyncMock(
-        return_value=SimpleNamespace(id=5, user_id=55)
-    )
+    svc.expert_repo.get_by_id = AsyncMock(return_value=SimpleNamespace(id=5, user_id=55))
     svc.answer_repo.delete = AsyncMock(return_value=True)
     svc.comment_repo.delete_by_answer_id = AsyncMock(return_value=3)
     svc.question_repo.get_by_id = AsyncMock(
@@ -112,9 +111,7 @@ async def test_delete_answer_with_rule_uses_qa_answer_biz_type():
             status=1,
         )
     )
-    svc.expert_repo.get_by_id = AsyncMock(
-        return_value=SimpleNamespace(id=6, user_id=66)
-    )
+    svc.expert_repo.get_by_id = AsyncMock(return_value=SimpleNamespace(id=6, user_id=66))
     svc.answer_repo.delete = AsyncMock(return_value=True)
     svc.comment_repo.delete_by_answer_id = AsyncMock(return_value=0)
     svc.question_repo.get_by_id = AsyncMock(
@@ -126,9 +123,7 @@ async def test_delete_answer_with_rule_uses_qa_answer_biz_type():
         )
     )
     svc.question_repo.update = AsyncMock(return_value=True)
-    pending.deduct_or_enqueue = AsyncMock(
-        return_value=SimpleNamespace(applied=True, pending=False, reason=None)
-    )
+    pending.deduct_or_enqueue = AsyncMock(return_value=SimpleNamespace(applied=True, pending=False, reason=None))
 
     result = await svc.moderate_delete(
         operator=_admin_user(user_id=9),
@@ -149,6 +144,62 @@ async def test_delete_answer_with_rule_uses_qa_answer_biz_type():
     assert kwargs["operator_id"] == 9
     assert kwargs["remark"] == "违规"
     svc.question_repo.update.assert_awaited_once_with(101, answer_count=0)
+
+
+@pytest.mark.asyncio
+async def test_delete_own_question_skips_deduct_even_with_rule(monkeypatch):
+    """超管删自己的问题：即使带 R* 也不扣分。"""
+    svc, pending = _service_with_mocks()
+    svc.question_repo.get_by_id = AsyncMock(return_value=SimpleNamespace(id=8, user_id=1))
+    svc.question_repo.delete = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "bisheng.qa_expert.domain.moderate_delete_service.RealtimeQaQuestionFact.delete_question",
+        AsyncMock(),
+    )
+
+    result = await svc.moderate_delete(
+        operator=_admin_user(user_id=1),
+        target_type="question",
+        target_id=8,
+        rule_code="R1",
+        remark="测试",
+    )
+
+    assert result.deleted is True
+    assert result.deducted is False
+    assert result.pending_deduct is False
+    assert result.reason == "self_author"
+    pending.deduct_or_enqueue.assert_not_called()
+    svc.question_repo.delete.assert_awaited_once_with(8)
+
+
+@pytest.mark.asyncio
+async def test_delete_others_question_with_rule_deducts(monkeypatch):
+    """超管删别人的问题：仍按 R* 对提问者扣分。"""
+    svc, pending = _service_with_mocks()
+    svc.question_repo.get_by_id = AsyncMock(return_value=SimpleNamespace(id=9, user_id=2))
+    svc.question_repo.delete = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "bisheng.qa_expert.domain.moderate_delete_service.RealtimeQaQuestionFact.delete_question",
+        AsyncMock(),
+    )
+    pending.deduct_or_enqueue = AsyncMock(return_value=SimpleNamespace(applied=True, pending=False, reason=None))
+
+    result = await svc.moderate_delete(
+        operator=_admin_user(user_id=1),
+        target_type="question",
+        target_id=9,
+        rule_code="r1",
+        remark="违规",
+    )
+
+    assert result.deducted is True
+    pending.deduct_or_enqueue.assert_awaited_once()
+    kwargs = pending.deduct_or_enqueue.await_args.kwargs
+    assert kwargs["user_id"] == 2
+    assert kwargs["rule_code"] == "R1"
+    assert kwargs["biz_type"] == "qa_question"
+    assert kwargs["biz_id"] == "9"
 
 
 @pytest.mark.asyncio

--- a/src/backend/test/qa_expert/test_moderate_delete_points_notify_flow.py
+++ b/src/backend/test/qa_expert/test_moderate_delete_points_notify_flow.py
@@ -193,3 +193,105 @@ async def test_moderate_delete_unadopted_answer_writes_log_and_inbox(flow_env, m
         assert len(inbox_after) == 1
     finally:
         await _cleanup_points_rows(env.engine, user_id=expert_uid, remark=remark)
+
+
+async def test_moderate_delete_own_answered_question_skips_deduct(flow_env, monkeypatch):
+    """超管删自己的已答问题：题被删、即使带 R1 也不写扣分流水；再删不得脏写。"""
+    env = flow_env
+
+    @asynccontextmanager
+    async def patched_session():
+        session = AsyncSession(bind=env.engine, expire_on_commit=False)
+        try:
+            yield session
+        finally:
+            await session.close()
+
+    monkeypatch.setattr(
+        "bisheng.points.domain.services.points_pending_deduct_service.get_async_db_session",
+        patched_session,
+    )
+    await env.seed_expert(user_id=201, name="回答专家")
+    admin = env.user(501, name="super-admin", super_admin=True)
+    admin_uid = env.uid(501)
+    remark = env.t("超管自删已答问题")
+    env.as_user(admin)
+    qid = await _create_question(
+        env,
+        {
+            "title": "df超管自删已答",
+            "description": "已回答后锁定",
+            "business_domain": "steel",
+            "question_type": "public",
+        },
+    )
+    env.as_user(env.user(201, name="回答专家"))
+    await _create_answer(env, qid, "锁定用首答")
+    locked = await env.reload_row(Question, id=qid)
+    assert locked is not None
+    assert int(locked.content_locked) == 1
+    key = stable_deduct_idempotency_key("R1", "qa_question", str(qid))
+
+    try:
+        env.as_user(admin)
+        body = _ok(
+            await env.client.post(
+                f"{PREFIX}/admin/moderate-delete",
+                json={
+                    "target_type": "question",
+                    "target_id": qid,
+                    "rule_code": "R1",
+                    "remark": remark,
+                },
+            )
+        )
+        assert body.get("status_code") == 200, body
+        data = body.get("data") or {}
+        assert data.get("deleted") is True
+        assert data.get("deducted") is False
+        assert data.get("pending_deduct") is False
+        assert data.get("reason") == "self_author"
+        assert data.get("target_user_id") == admin_uid
+
+        gone = await env.reload_row(Question, id=qid)
+        assert gone is None
+
+        logs = await _select_maps(
+            env.engine,
+            "SELECT id FROM user_point_log WHERE idempotency_key = :k OR (user_id = :u AND remark = :r)",
+            {"k": key, "u": admin_uid, "r": remark},
+        )
+        pending = await _select_maps(
+            env.engine,
+            "SELECT id FROM point_pending_deduct WHERE user_id = :u",
+            {"u": admin_uid},
+        )
+        assert logs == []
+        assert pending == []
+
+        again = _ok(
+            await env.client.post(
+                f"{PREFIX}/admin/moderate-delete",
+                json={
+                    "target_type": "question",
+                    "target_id": qid,
+                    "rule_code": "R1",
+                    "remark": remark,
+                },
+            )
+        )
+        assert again.get("status_code") != 200
+        logs_after = await _select_maps(
+            env.engine,
+            "SELECT id FROM user_point_log WHERE idempotency_key = :k OR (user_id = :u AND remark = :r)",
+            {"k": key, "u": admin_uid, "r": remark},
+        )
+        pending_after = await _select_maps(
+            env.engine,
+            "SELECT id FROM point_pending_deduct WHERE user_id = :u",
+            {"u": admin_uid},
+        )
+        assert logs_after == []
+        assert pending_after == []
+    finally:
+        await _cleanup_points_rows(env.engine, user_id=admin_uid, remark=remark)


### PR DESCRIPTION
## Summary
- 超管违规删除自己的问题/回答/评论时跳过 R* 扣分（`reason=self_author`），避免超管误写入积分账本与补扣队列。
- 删别人的内容仍按原规则扣分；不回滚专家 G4，不清理问答子表孤儿行。

## Test plan
- [x] `pytest test/qa_expert/test_moderate_delete_answer.py`：自删跳过扣分、删他人仍扣分
- [x] `pytest test/qa_expert/test_moderate_delete_points_notify_flow.py::test_moderate_delete_own_answered_question_skips_deduct`：已答问题删除后无 `user_point_log` / `point_pending_deduct` 脏行
- [ ] 配合门户 PR：超管对自己的已锁定问题点删除，确认不出现扣减规则且能删掉


Made with [Cursor](https://cursor.com)