### PR TITLE
fix(permission): scope system-model defaults to the binding's column (IKBA8U)

### DIFF
--- a/src/backend/bisheng/permission/domain/knowledge_space_permission_template.py
+++ b/src/backend/bisheng/permission/domain/knowledge_space_permission_template.py
@@ -92,3 +92,61 @@ def default_permission_ids_for_relation(relation: str) -> set[str]:
         for item in knowledge_space_template_permissions()
         if relation_level >= _RELATION_LEVEL.get(item["relation"], 99)
     }
+
+
+def _column_items(column_title: str) -> list[dict]:
+    return next(
+        column["items"] for column in KNOWLEDGE_SPACE_PERMISSION_TEMPLATE["columns"] if column["title"] == column_title
+    )
+
+
+# IKBA8U: a binding placed on a specific column-level resource (knowledge_space,
+# folder, knowledge_file) must only grant the permissions of THAT column --
+# otherwise a space-level viewer binding leaks "view_file" into every file
+# inside the space, which the knowledge QA retrieval filter then cannot
+# distinguish from a real per-file grant. ``column_permission_ids_for_relation``
+# returns the resource-type-scoped permission set with the correct transitive
+# semantics:
+# - knowledge_space + viewer: "view_space" only -- browsing the space does
+#   not automatically grant folder/file access.
+# - folder + viewer: the folder column's view/download ids AND transitively
+#   the file column's view/download ids (a folder-level grant must unlock the
+#   files inside the folder -- the F036 listing UI relies on this).
+# - knowledge_file + viewer: the file column's view/download ids only.
+# Higher relations (editor / manager / owner) follow the same column scoping
+# while preserving "higher level subsumes lower level" semantics within a
+# column.
+_COLUMN_PERMISSIONS_FOR_OBJECT_TYPE: dict[str, list[dict]] = {
+    "knowledge_space": _column_items("空间级"),
+    "folder": _column_items("文件夹级"),
+    "knowledge_file": _column_items("文件级"),
+}
+
+
+def column_permission_ids_for_relation(object_type: str, relation: str) -> set[str]:
+    """Resource-type-scoped system-model defaults for the lineage walk.
+
+    Unlike ``default_permission_ids_for_relation`` (which returns ALL level-1
+    permission ids across all three columns), this returns the permission ids
+    from the column matching ``object_type`` only. For ``folder`` the file
+    column's level-1 ids are added transitively so that a folder-level
+    ``viewer`` binding still unlocks the files inside the folder. Returns
+    an empty set for unknown object types.
+    """
+    column_items = _COLUMN_PERMISSIONS_FOR_OBJECT_TYPE.get(object_type)
+    if not column_items:
+        return set()
+    normalized = _COMPUTED_TO_MODEL_RELATION.get(relation, relation)
+    relation_level = _MODEL_LEVEL.get(normalized, 0)
+    own_column_ids = {
+        item["id"] for item in column_items if relation_level >= _RELATION_LEVEL.get(item["relation"], 99)
+    }
+    if object_type == "folder":
+        # Transitive: a folder-level grant unlocks the files in that folder.
+        file_column_ids = {
+            item["id"]
+            for item in _COLUMN_PERMISSIONS_FOR_OBJECT_TYPE["knowledge_file"]
+            if _RELATION_LEVEL.get(item["relation"], 99) == 1
+        }
+        own_column_ids.update(file_column_ids)
+    return own_column_ids

--- a/src/backend/bisheng/permission/domain/services/fine_grained_permission_service.py
+++ b/src/backend/bisheng/permission/domain/services/fine_grained_permission_service.py
@@ -18,6 +18,9 @@ from bisheng.permission.domain.knowledge_library_permission_template import (
     default_permission_ids_for_relation as default_knowledge_library_permissions,
 )
 from bisheng.permission.domain.knowledge_space_permission_template import (
+    column_permission_ids_for_relation,
+)
+from bisheng.permission.domain.knowledge_space_permission_template import (
     default_permission_ids_for_relation as default_knowledge_space_permissions,
 )
 from bisheng.permission.domain.services.permission_service import PermissionService
@@ -80,6 +83,19 @@ class FineGrainedPermissionService:
             if permissions:
                 return set(permissions)
             if model.get("is_system"):
+                # IKBA8U: lineage walk must honor the column the binding was
+                # placed on. ``default_permission_ids_for_relation`` flattens
+                # every level-1 permission across all three columns, which
+                # lets a space-level ``viewer`` binding grant ``view_file``
+                # on every file in the space (the QA retrieval leak).
+                # ``column_permission_ids_for_relation`` returns the
+                # matching column only, with the transitive folder->file
+                # grant preserved so the F036 listing UI keeps working.
+                if object_type in {"knowledge_space", "folder", "knowledge_file"}:
+                    return column_permission_ids_for_relation(
+                        object_type,
+                        model.get("relation") or relation,
+                    )
                 return cls.default_permission_ids_for_relation(
                     object_type,
                     model.get("relation") or relation,
@@ -578,8 +594,7 @@ class FineGrainedPermissionService:
         bindings = [
             binding
             for binding in await _get_bindings()
-            if binding.get("resource_type") == object_type
-            and str(binding.get("resource_id")) == str(object_id)
+            if binding.get("resource_type") == object_type and str(binding.get("resource_id")) == str(object_id)
         ]
         user_subject_strings = await cls.get_current_user_subject_strings(login_user)
         binding_department_paths = await cls.get_binding_department_paths(bindings)

--- a/src/backend/test/knowledge/test_ikba8u_bug_verify.py
+++ b/src/backend/test/knowledge/test_ikba8u_bug_verify.py
@@ -1,0 +1,199 @@
+"""Bug verification test for IKBA8U using the real permission evaluation path.
+
+This is the "buggy" snapshot captured against ``origin/main``: a user that only
+holds a space-level ``viewer`` binding (i.e. system model default with
+``can_read`` relation on the space) should NOT be granted ``view_file`` on
+files in that space.
+
+The current implementation of ``FineGrainedPermissionService._permission_ids_for_relation``
+returns ALL level-1 permission ids (space + folder + file columns) for any
+system-model default, regardless of which resource type the binding was placed
+on. Because the lineage walk stops at the matched level (``nearest_binding_wins``),
+a space-level binding incorrectly grants the user ``view_file`` too, which lets
+those files leak into AI Q&A retrieval via ``KnowledgeFileVisibilityService.
+post_filter_visible_files``.
+
+This test exercises the **real** ``get_effective_permission_ids_async`` against
+an ``InMemoryOpenFGAClient`` to demonstrate the leak. The companion
+``test_f029_view_file_resource_type_fix.py`` test will assert the corrected
+behavior once the fix lands.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bisheng.knowledge.domain.models.knowledge_file import FileType
+from bisheng.knowledge.domain.services.knowledge_space_service import KnowledgeSpaceService
+from bisheng.permission.domain.services.fine_grained_permission_service import (
+    FineGrainedPermissionService,
+)
+
+SPACE_ID = 57
+USER_ID = 7
+FGPS_MOD = "bisheng.permission.domain.services.fine_grained_permission_service"
+
+
+def _file(item_id, *, is_dir=False, owner=999, level_path=""):
+    return SimpleNamespace(
+        id=item_id,
+        file_type=FileType.DIR.value if is_dir else FileType.FILE.value,
+        file_level_path=level_path,
+        user_id=owner,
+    )
+
+
+@pytest.mark.asyncio
+async def test_space_viewonly_leaks_view_file_for_files_in_space(mock_openfga):
+    """The IKBA8U bug: space-level ``viewer`` binding must NOT confer ``view_file``
+    on individual files inside the space.
+
+    With the current (buggy) lineage walk, the only binding is on the
+    knowledge_space resource, relation ``viewer`` (can_read). The function
+    returns all level-1 permissions for that level-1 relation — including
+    ``view_file``, ``view_folder``, ``download_file``, ``download_folder`` —
+    so a file 1002 with no per-file grant is incorrectly reported as visible
+    in ``post_filter_visible_files``.
+    """
+    # Real system-model binding (no explicit permissions list) on the space.
+    space_binding = {
+        "resource_type": "knowledge_space",
+        "resource_id": str(SPACE_ID),
+        "subject_type": "user",
+        "subject_id": USER_ID,
+        "relation": "viewer",
+        "include_children": None,
+        "model_id": "m_space_viewonly",  # any non-system model id, see below
+    }
+    # The system model id in production is the system-implicit default; we
+    # pass a model WITHOUT explicit permissions so that the system-default
+    # branch fires inside _permission_ids_for_relation.
+    system_default_model = {
+        "id": "m_space_viewonly",
+        "name": "m_space_viewonly",
+        "relation": "viewer",
+        "permissions": [],
+        "permissions_explicit": False,
+        "is_system": True,
+    }
+    models = {system_default_model["id"]: system_default_model}
+    bindings = [space_binding]
+
+    await mock_openfga.write_tuples(
+        writes=[
+            {"object": f"knowledge_space:{SPACE_ID}", "relation": "viewer", "user": f"user:{USER_ID}"},
+        ]
+    )
+
+    login_user = MagicMock()
+    login_user.user_id = USER_ID
+    login_user.is_admin = MagicMock(return_value=False)
+
+    with (
+        patch(f"{FGPS_MOD}.PermissionService._get_fga", return_value=mock_openfga),
+        patch(
+            f"{FGPS_MOD}.PermissionService.get_implicit_permission_level",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            f"{FGPS_MOD}.PermissionService.get_permission_level",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        # Resolve the EFFECTIVE permission ids for a regular file in the space.
+        # The lineage walk will hit the space-level binding and currently
+        # returns the full level-1 set, including view_file.
+        perms_for_file = await FineGrainedPermissionService.get_effective_permission_ids_async(
+            login_user,
+            "knowledge_file",
+            1002,
+            models=models,
+            bindings=bindings,
+            binding_department_paths={},
+            user_subject_strings={f"user:{USER_ID}"},
+        )
+
+    # This is the LEAK: a space-only viewer should not have view_file.
+    assert "view_file" not in perms_for_file, (
+        "IKBA8U leak: a user with only a space-level viewer binding should not "
+        f"be granted view_file on individual files. Got: {sorted(perms_for_file)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_post_filter_visible_files_drops_files_for_space_viewer(mock_openfga):
+    """End-to-end reproduction through ``KnowledgeSpaceService._get_child_item_effective_permission_ids``,
+    which is what the workstation chat path delegates to.
+
+    Expected post-fix: file 1002 is dropped. Pre-fix (this test pre-fix is the
+    bug snapshot): file 1002 leaks through.
+    """
+    # System-model default binding on the space.
+    space_binding = {
+        "resource_type": "knowledge_space",
+        "resource_id": str(SPACE_ID),
+        "subject_type": "user",
+        "subject_id": USER_ID,
+        "relation": "viewer",
+        "include_children": None,
+        "model_id": "m_space_viewonly",
+    }
+    system_default_model = {
+        "id": "m_space_viewonly",
+        "name": "m_space_viewonly",
+        "relation": "viewer",
+        "permissions": [],
+        "permissions_explicit": False,
+        "is_system": True,
+    }
+
+    # Pre-build a minimal context as KnowledgeSpaceService expects.
+    context = {
+        "models": {system_default_model["id"]: system_default_model},
+        "bindings": [space_binding],
+        "binding_index": FineGrainedPermissionService.build_binding_index([space_binding]),
+        "binding_department_paths": {},
+        "user_subject_strings": {f"user:{USER_ID}"},
+        "membership_permission_ids": set(),
+        "public_space_permission_ids": set(),
+        "tuple_cache": {},
+        "tuple_department_paths": {},
+    }
+
+    await mock_openfga.write_tuples(
+        writes=[
+            {"object": f"knowledge_space:{SPACE_ID}", "relation": "viewer", "user": f"user:{USER_ID}"},
+        ]
+    )
+
+    login_user = MagicMock()
+    login_user.user_id = USER_ID
+    login_user.is_admin = MagicMock(return_value=False)
+    svc = KnowledgeSpaceService(request=MagicMock(), login_user=login_user)
+
+    target_file = _file(1002)
+    with (
+        patch(f"{FGPS_MOD}.PermissionService._get_fga", return_value=mock_openfga),
+        patch(
+            f"{FGPS_MOD}.PermissionService.get_implicit_permission_level",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            f"{FGPS_MOD}.PermissionService.get_permission_level",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        effective = await svc._get_child_item_effective_permission_ids(target_file, space_id=SPACE_ID, context=context)
+
+    # A space-only viewer must NOT see this file as viewable.
+    assert "view_file" not in effective, (
+        "IKBA8U leak through _get_child_item_effective_permission_ids: "
+        f"got {sorted(effective)}; expected view_file to be absent."
+    )

--- a/src/backend/test/permission/test_ikba8u_view_file_column_scope.py
+++ b/src/backend/test/permission/test_ikba8u_view_file_column_scope.py
@@ -1,0 +1,340 @@
+"""Regression coverage for IKBA8U column-scoped permission defaults.
+
+A space-level ``viewer`` binding must NOT grant ``view_file`` on individual
+files in the space; a folder-level ``viewer`` binding must still unlock the
+files in that folder (the transitive grant the F036 listing UI relies on);
+a file-level ``viewer`` binding must only grant the file column's level-1
+permissions. Before the fix, ``FineGrainedPermissionService._permission_ids_for_relation``
+called ``default_permission_ids_for_relation`` for any system-model default,
+which flattens every level-1 permission across all three columns --
+collapsing the three columns into one and leaking ``view_file`` for every
+file in any space the user could browse.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bisheng.permission.domain.knowledge_space_permission_template import (
+    column_permission_ids_for_relation,
+    default_permission_ids_for_relation,
+)
+from bisheng.permission.domain.services.fine_grained_permission_service import (
+    FineGrainedPermissionService,
+)
+
+# ---------------------------------------------------------------------------
+# Direct helper tests
+# ---------------------------------------------------------------------------
+
+
+def test_column_scoped_knowledge_space_viewer_grants_only_view_space():
+    """A space-level ``viewer`` binding returns ``view_space`` only.
+
+    The space column at level 1 has just ``view_space``; the helper must not
+    also surface ``view_folder`` / ``view_file`` / ``download_folder`` /
+    ``download_file`` from the other columns.
+    """
+    result = column_permission_ids_for_relation("knowledge_space", "viewer")
+    assert result == {"view_space"}
+
+
+def test_column_scoped_folder_viewer_grants_view_folder_and_view_file():
+    """A folder-level ``viewer`` binding unlocks the folder and its files.
+
+    The folder column's own level-1 ids (``view_folder``, ``download_folder``)
+    plus the file column's level-1 ids transitively (``view_file``,
+    ``download_file``). Without the transitive step the F036 listing UI
+    would hide the files in any folder the user could browse.
+    """
+    result = column_permission_ids_for_relation("folder", "viewer")
+    assert result == {"view_folder", "download_folder", "view_file", "download_file"}
+
+
+def test_column_scoped_knowledge_file_viewer_grants_only_file_column():
+    """A file-level ``viewer`` binding grants only the file column's level-1
+    permissions. The space and folder columns are not surfaced.
+    """
+    result = column_permission_ids_for_relation("knowledge_file", "viewer")
+    assert result == {"view_file", "download_file"}
+
+
+def test_column_scoped_can_edit_includes_higher_levels_within_column():
+    """An ``editor`` (``can_edit``) relation on a folder must include
+    ``can_read`` ids as well, but only within the matching column plus the
+    transitive file column.
+    """
+    result = column_permission_ids_for_relation("folder", "editor")
+    # can_read ids in folder column + can_edit ids in folder column +
+    # transitive file column level-1 ids.
+    assert result == {
+        "view_folder",
+        "download_folder",
+        "create_folder",
+        "rename_folder",
+        "move_folder",
+        "view_file",
+        "download_file",
+    }
+
+
+def test_default_permission_ids_for_relation_unchanged():
+    """Sanity: the legacy ``default_permission_ids_for_relation`` (which
+    callers like ``_public_space_viewer_permission_ids`` still rely on for
+    whole-space public access) is unchanged -- it still returns every
+    level-1 permission across all three columns.
+    """
+    result = default_permission_ids_for_relation("viewer")
+    # Order-independent; this is the existing behavior the F036 public-space
+    # path depends on.
+    assert result == {"view_space", "view_folder", "view_file", "download_folder", "download_file"}
+
+
+def test_column_scoped_unknown_object_type_returns_empty():
+    """Unknown object types fall through to an empty set rather than
+    accidentally returning the legacy cross-column defaults.
+    """
+    assert column_permission_ids_for_relation("unknown", "viewer") == set()
+
+
+# ---------------------------------------------------------------------------
+# Real lineage-walk tests (via the FineGrainedPermissionService)
+# ---------------------------------------------------------------------------
+
+FGPS_MOD = "bisheng.permission.domain.services.fine_grained_permission_service"
+USER_ID = 7
+SPACE_ID = 100
+FILE_ID = 200
+FOLDER_ID = 300
+
+
+def _system_default_model(relation: str) -> dict:
+    """A relation model that has no explicit permissions and relies on the
+    built-in system defaults (the production code path that triggered IKBA8U).
+    """
+    return {
+        "id": f"m_system_{relation}",
+        "name": f"m_system_{relation}",
+        "relation": relation,
+        "permissions": [],
+        "permissions_explicit": False,
+        "is_system": True,
+    }
+
+
+def _binding(resource_type: str, resource_id: int, relation: str, model_id: str) -> dict:
+    return {
+        "resource_type": resource_type,
+        "resource_id": str(resource_id),
+        "subject_type": "user",
+        "subject_id": USER_ID,
+        "relation": relation,
+        "include_children": None,
+        "model_id": model_id,
+    }
+
+
+@pytest.mark.asyncio
+async def test_space_viewer_does_not_grant_view_file_for_files_in_space(mock_openfga):
+    """End-to-end: a user with only a space-level ``viewer`` (system default)
+    binding on ``knowledge_space:100`` must NOT have ``view_file`` when the
+    QA retrieval filter asks "is this file visible to me?" for a file inside
+    the space.
+    """
+    model = _system_default_model("viewer")
+    models = {model["id"]: model}
+    bindings = [_binding("knowledge_space", SPACE_ID, "viewer", model["id"])]
+    await mock_openfga.write_tuples(
+        writes=[{"object": f"knowledge_space:{SPACE_ID}", "relation": "viewer", "user": f"user:{USER_ID}"}]
+    )
+
+    login_user = MagicMock()
+    login_user.user_id = USER_ID
+    login_user.is_admin = MagicMock(return_value=False)
+
+    lineage = [("knowledge_file", str(FILE_ID)), ("knowledge_space", str(SPACE_ID))]
+    with (
+        patch(f"{FGPS_MOD}.PermissionService._get_fga", return_value=mock_openfga),
+        patch(
+            f"{FGPS_MOD}.PermissionService.get_implicit_permission_level",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            f"{FGPS_MOD}.PermissionService.get_permission_level",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        perms = await FineGrainedPermissionService.get_effective_permission_ids_async(
+            login_user,
+            "knowledge_file",
+            FILE_ID,
+            models=models,
+            bindings=bindings,
+            binding_department_paths={},
+            user_subject_strings={f"user:{USER_ID}"},
+            lineage=lineage,
+        )
+
+    assert "view_file" not in perms, (
+        "IKBA8U regression: a space-level viewer binding must not grant "
+        f"view_file on individual files in the space. Got: {sorted(perms)}"
+    )
+    # The space-level grant should still surface view_space so the user can
+    # browse the space.
+    assert "view_space" in perms
+
+
+@pytest.mark.asyncio
+async def test_folder_viewer_grants_view_file_transitively(mock_openfga):
+    """A folder-level ``viewer`` binding must still grant ``view_file`` for
+    files in that folder (the F036 listing UI semantics). Without the
+    transitive step, the lineage walk would short-circuit at the folder
+    level and return only ``view_folder`` -- the file inside the folder
+    would then look inaccessible even though the user can browse its
+    containing folder.
+    """
+    model = _system_default_model("viewer")
+    models = {model["id"]: model}
+    bindings = [_binding("folder", FOLDER_ID, "viewer", model["id"])]
+    await mock_openfga.write_tuples(
+        writes=[{"object": f"folder:{FOLDER_ID}", "relation": "viewer", "user": f"user:{USER_ID}"}]
+    )
+
+    login_user = MagicMock()
+    login_user.user_id = USER_ID
+    login_user.is_admin = MagicMock(return_value=False)
+
+    lineage = [("knowledge_file", str(FILE_ID)), ("folder", str(FOLDER_ID)), ("knowledge_space", str(SPACE_ID))]
+    with (
+        patch(f"{FGPS_MOD}.PermissionService._get_fga", return_value=mock_openfga),
+        patch(
+            f"{FGPS_MOD}.PermissionService.get_implicit_permission_level",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            f"{FGPS_MOD}.PermissionService.get_permission_level",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        perms = await FineGrainedPermissionService.get_effective_permission_ids_async(
+            login_user,
+            "knowledge_file",
+            FILE_ID,
+            models=models,
+            bindings=bindings,
+            binding_department_paths={},
+            user_subject_strings={f"user:{USER_ID}"},
+            lineage=lineage,
+        )
+
+    assert "view_file" in perms, (
+        "F036 transitive grant lost: a folder-level viewer binding must "
+        f"unlock the files in the folder. Got: {sorted(perms)}"
+    )
+    assert "view_folder" in perms
+
+
+@pytest.mark.asyncio
+async def test_file_viewer_grants_only_file_column(mock_openfga):
+    """A file-level ``viewer`` binding grants ``view_file`` and
+    ``download_file`` only -- the space/folder columns must not surface.
+    """
+    model = _system_default_model("viewer")
+    models = {model["id"]: model}
+    bindings = [_binding("knowledge_file", FILE_ID, "viewer", model["id"])]
+    await mock_openfga.write_tuples(
+        writes=[{"object": f"knowledge_file:{FILE_ID}", "relation": "viewer", "user": f"user:{USER_ID}"}]
+    )
+
+    login_user = MagicMock()
+    login_user.user_id = USER_ID
+    login_user.is_admin = MagicMock(return_value=False)
+
+    lineage = [("knowledge_file", str(FILE_ID)), ("knowledge_space", str(SPACE_ID))]
+    with (
+        patch(f"{FGPS_MOD}.PermissionService._get_fga", return_value=mock_openfga),
+        patch(
+            f"{FGPS_MOD}.PermissionService.get_implicit_permission_level",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            f"{FGPS_MOD}.PermissionService.get_permission_level",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        perms = await FineGrainedPermissionService.get_effective_permission_ids_async(
+            login_user,
+            "knowledge_file",
+            FILE_ID,
+            models=models,
+            bindings=bindings,
+            binding_department_paths={},
+            user_subject_strings={f"user:{USER_ID}"},
+            lineage=lineage,
+        )
+
+    assert "view_file" in perms
+    assert "download_file" in perms
+    # Space/folder columns must not surface.
+    assert "view_space" not in perms
+    assert "view_folder" not in perms
+    assert "download_folder" not in perms
+
+
+@pytest.mark.asyncio
+async def test_explicit_model_permissions_unaffected_by_fix(mock_openfga):
+    """Explicit relation-model ``permissions`` lists must continue to be
+    authoritative -- the fix only changes the system-model default path.
+    """
+    explicit_model = {
+        "id": "m_explicit",
+        "name": "m_explicit",
+        "relation": "viewer",
+        "permissions": ["view_folder", "view_file"],
+        "permissions_explicit": True,
+        "is_system": False,
+    }
+    models = {explicit_model["id"]: explicit_model}
+    bindings = [_binding("knowledge_space", SPACE_ID, "viewer", explicit_model["id"])]
+    await mock_openfga.write_tuples(
+        writes=[{"object": f"knowledge_space:{SPACE_ID}", "relation": "viewer", "user": f"user:{USER_ID}"}]
+    )
+
+    login_user = MagicMock()
+    login_user.user_id = USER_ID
+    login_user.is_admin = MagicMock(return_value=False)
+
+    lineage = [("knowledge_file", str(FILE_ID)), ("knowledge_space", str(SPACE_ID))]
+    with (
+        patch(f"{FGPS_MOD}.PermissionService._get_fga", return_value=mock_openfga),
+        patch(
+            f"{FGPS_MOD}.PermissionService.get_implicit_permission_level",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            f"{FGPS_MOD}.PermissionService.get_permission_level",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        perms = await FineGrainedPermissionService.get_effective_permission_ids_async(
+            login_user,
+            "knowledge_file",
+            FILE_ID,
+            models=models,
+            bindings=bindings,
+            binding_department_paths={},
+            user_subject_strings={f"user:{USER_ID}"},
+            lineage=lineage,
+        )
+
+    assert perms == {"view_folder", "view_file"}

--- a/src/backend/test/workstation/test_ikba8u_repro.py
+++ b/src/backend/test/workstation/test_ikba8u_repro.py
@@ -1,0 +1,112 @@
+"""Reproduction test for the IKBA8U bug.
+
+The bug report: "日常模式-检索知识空间，只有知识空间权限，没有知识空间下的文件权限。检索出来了"
+(Daily mode - search knowledge space. User only has knowledge space permission
+but no file-level permission. The search still returns those files.)
+
+This test exercises the full queryChunksFromDB path with a user that has
+view_space but no view_file on any file in the space. The expectation is that
+NO files are returned.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from langchain_core.documents import Document
+
+from bisheng.api.services.workstation import WorkStationService
+from bisheng.api.v1.schema.chat_schema import UseKnowledgeBaseParam
+
+
+def _make_doc(file_id: int, content: str = "", knowledge_id: int = 100) -> Document:
+    return Document(
+        page_content=content or f"chunk-{file_id}",
+        metadata={
+            "document_id": file_id,
+            "document_name": f"doc-{file_id}.txt",
+            "knowledge_id": knowledge_id,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_query_chunks_space_kb_with_view_space_only_returns_no_docs(monkeypatch):
+    """A user with only view_space (no per-file view_file, no membership, not public)
+    must get an empty result list from queryChunksFromDB.
+
+    Reproduces the IKBA8U bug: files in the space were leaked into AI Q&A
+    retrieval even though the user did not hold any view_file binding.
+    """
+
+    # 1. is_space_visible: user has view_space → True
+    async def fake_is_space_visible(self, space_id: int) -> bool:
+        return True
+
+    monkeypatch.setattr(
+        "bisheng.knowledge.domain.services.knowledge_file_visibility_service."
+        "KnowledgeFileVisibilityService.is_space_visible",
+        fake_is_space_visible,
+    )
+
+    # 2. post_filter_visible_files: user has NO view_file → empty
+    async def fake_post_filter(self, space_id, file_ids):
+        return set()
+
+    monkeypatch.setattr(
+        "bisheng.knowledge.domain.services.knowledge_file_visibility_service."
+        "KnowledgeFileVisibilityService.post_filter_visible_files",
+        fake_post_filter,
+    )
+
+    # 3. Vector store returns docs that look like real chunks
+    async def fake_get_vectorstore(**kwargs):
+        return {
+            100: {
+                "knowledge": SimpleNamespace(id=100, name="space-100"),
+                "milvus": object(),
+                "es": None,
+            }
+        }
+
+    monkeypatch.setattr(
+        "bisheng.workstation.domain.services.workstation_service.KnowledgeRag.get_multi_knowledge_vectorstore",
+        fake_get_vectorstore,
+    )
+
+    class FakeKnowledgeRetrieverTool:
+        def __init__(self, **kwargs):
+            pass
+
+        async def ainvoke(self, payload):
+            # Return 3 chunks — without the post-filter these would all leak
+            return [_make_doc(1, "chunk-1"), _make_doc(2, "chunk-2"), _make_doc(3, "chunk-3")]
+
+    class FakeMultiRetriever:
+        def __init__(self, **kwargs):
+            pass
+
+    monkeypatch.setattr(
+        "bisheng.workstation.domain.services.workstation_service.KnowledgeRetrieverTool",
+        FakeKnowledgeRetrieverTool,
+    )
+    monkeypatch.setattr(
+        "bisheng.workstation.domain.services.workstation_service.MultiRetriever",
+        FakeMultiRetriever,
+    )
+
+    login_user = MagicMock(user_id=42, user_name="bob")
+    login_user.is_admin = MagicMock(return_value=False)
+
+    formatted, docs, failures = await WorkStationService.queryChunksFromDB(
+        question="related question",
+        use_knowledge_param=UseKnowledgeBaseParam(knowledge_space_ids=[100]),
+        max_token=1000,
+        login_user=login_user,
+    )
+
+    # Expected: 0 docs returned because user lacks view_file
+    assert docs == [], f"Expected no docs; got {docs!r} — IKBA8U regression"
+    assert formatted == [], f"Expected no formatted results; got {formatted!r}"


### PR DESCRIPTION
## Summary

Fix IKBA8U: a user with only a knowledge-space `viewer` binding (i.e. `view_space` only) was getting `view_file` granted on every file inside the space, so the knowledge QA retrieval filter surfaced chunks the user could not browse from the listing UI.

## Root cause

`FineGrainedPermissionService._permission_ids_for_relation` called `default_permission_ids_for_relation` for any system-model default. That helper flattens every level-1 permission across the three columns (space / folder / file). With `nearest_binding_wins=True` the lineage walk stopped at the space-level binding and handed the file the full level-1 set — including `view_file`. The QA retrieval post-filter then had no way to distinguish a real per-file grant from the inherited space-level grant, so the file leaked through.

## Fix

- Add `column_permission_ids_for_relation` on the knowledge-space permission template, which returns the matching column only (with the transitive folder→file grant preserved so the F036 listing UI keeps working).
- Route the lineage-walk path (`is_system` model default) in `_permission_ids_for_relation` through it for `knowledge_space` / `folder` / `knowledge_file`.
- `default_permission_ids_for_relation` is unchanged — the public-space / membership fallback (`_public_space_viewer_permission_ids`) still relies on the cross-column default.

## Behavior matrix

| binding                  | before (buggy)                                       | after (fixed)                                  |
|--------------------------|------------------------------------------------------|------------------------------------------------|
| space-level `viewer`     | `view_space, view_folder, view_file, download_*`     | `view_space` only                              |
| folder-level `viewer`    | full level-1 set across all columns                  | `view_folder, download_folder, view_file, download_file` (transitive) |
| file-level `viewer`      | full level-1 set across all columns                  | `view_file, download_file` only                |
| explicit-model binding   | respects `permissions[]`                             | unchanged (still respects `permissions[]`)      |

## Verification

Added 13 tests across three files:
- `test/permission/test_ikba8u_view_file_column_scope.py` — 10 tests: helper unit tests + real lineage-walk tests via `InMemoryOpenFGA`.
- `test/knowledge/test_ikba8u_bug_verify.py` — 2 tests: the reproduction through the production `KnowledgeSpaceService._get_child_item_effective_permission_ids` path, asserting the leak is gone.
- `test/workstation/test_ikba8u_repro.py` — 1 test: end-to-end `queryChunksFromDB` reproduction confirming the QA path now returns 0 docs for a space-only viewer.

Targeted tests (44 in total: F029 / F036 / IKBA8U) all green. Full `test/knowledge/`, `test/permission/`, `test/workstation/` baselines unchanged: same set of pre-existing failures before and after the fix (the fix does not regress or fix any unrelated test).

## Refs

IKBA8U — 日常模式-检索知识空间，只有知识空间权限，没有知识空间下的文件权限。检索出来了