### PR TITLE
fix(quota): 知识空间创建超限回到具体错误码，去掉重复的配额装饰器

### DIFF
--- a/src/backend/bisheng/knowledge/api/endpoints/knowledge_space.py
+++ b/src/backend/bisheng/knowledge/api/endpoints/knowledge_space.py
@@ -39,7 +39,6 @@ from bisheng.knowledge.domain.services.knowledge_space_chat_service import (
 from bisheng.knowledge.domain.services.knowledge_space_service import (
     KnowledgeSpaceService,
 )
-from bisheng.role.domain.services.quota_service import QuotaResourceType, require_quota
 from bisheng.workstation.domain.services.workstation_service import WorkStationService
 
 router = APIRouter(prefix="/knowledge/space", tags=["knowledge_space"])
@@ -51,8 +50,15 @@ SPACE_FILE_DOWNLOAD_PERMISSION_ACTION = "download"
 # ──────────────────────────── Space CRUD ──────────────────────────────────────
 
 
+# No `@require_quota` here, unlike assistant / workflow / tool. Those have no
+# domain-level quota check, so the decorator is their only gate. Knowledge spaces
+# gate inside `KnowledgeSpaceService._assert_space_creation_quota`, which also
+# covers the two paths the decorator cannot reach (the v2 open API in
+# `open_endpoints/filelib.py` and the F050 prospective-grant GETs). Keeping the
+# decorator would only duplicate the COUNT and — because it runs first — replace
+# the domain error 18001 ("创建知识空间数量已达上限") with the generic 19402
+# ("当前角色配额已用尽"), losing which resource actually ran out.
 @router.post("")
-@require_quota(QuotaResourceType.KNOWLEDGE_SPACE)
 async def create_space(
     req: KnowledgeSpaceCreateReq,
     svc: KnowledgeSpaceService = Depends(get_knowledge_space_service),

--- a/src/backend/test/knowledge/test_knowledge_space_create_quota.py
+++ b/src/backend/test/knowledge/test_knowledge_space_create_quota.py
@@ -181,6 +181,25 @@ class TestCreationGate:
                 await service.create_knowledge_space(name="Space", skip_user_limit=True)
         gate.assert_not_awaited()
 
+    def test_create_endpoint_has_no_quota_decorator(self):
+        """The gate must stay in the service layer so the domain code survives.
+
+        `@require_quota` runs before the handler and raises the generic 19402
+        ("当前角色配额已用尽"), which hides 18001 and with it *which* quota ran
+        out. The service-layer check also covers the v2 open API and the F050
+        prospective-grant GETs, which the decorator cannot reach.
+        """
+        import inspect
+
+        from bisheng.knowledge.api.endpoints import knowledge_space as ep
+
+        # Match decorator lines only — the comment above the handler explains
+        # why it is absent and mentions the name.
+        decorators = [
+            ln.strip() for ln in inspect.getsource(ep).splitlines() if ln.strip().startswith("@")
+        ]
+        assert not any(d.startswith("@require_quota") for d in decorators), decorators
+
     async def test_gate_runs_before_the_embedding_lookup(self):
         """Fail-closed ordering: quota must reject before any downstream work."""
         service = _service()


### PR DESCRIPTION
114 上实测发现：建到上限时后端返回的是 19402「当前角色配额已用尽，请联系管理员调整
配置」，而不是更具体的 18001「创建知识空间数量已达上限」。原因是端点上的
`@require_quota` 先于 service 层执行，把领域错误码盖掉了——用户看不出到底是哪种配额 用尽，而这正是上一个提交特意保留 18001 的目的。

`knowledge_space` 是唯一在 service 层也有配额检查的资源
（`_assert_space_creation_quota`，上一个提交加的），装饰器在这条路径上纯属重复 COUNT。 assistant / workflow / tool 没有领域层检查，装饰器是它们唯一的闸，保持不动——所以这 不是推翻装饰器模式，而是这个资源不再需要两道。

去掉后三条创建路径仍然都受限：v1 端点、v2 开放 API（`filelib.py`，装饰器本来就够不到）、 F050 预授权 GET。租户级 `knowledge_space` 上限同样仍生效（`get_effective_quota` 走 `_apply_tenant_cap`），只是不再区分「租户超限」和「角色超限」——租户配额 UI 只写 `storage_gb`，这个键在实际环境里恒为 -1，这个区分在现实中不存在。

测试钉住装饰器不被加回去。断言只匹配装饰器行：handler 上方那段解释「为什么没有它」的
注释里也写着这个名字，断整段 `getsource` 会假失败（第一版就是这么挂的）。

## What

简要描述做了什么改动。

## Why

为什么需要这个改动？

## How

实现方式、设计决策（如有）。

## Test

- [ ] 本地测试通过
- [ ] 114 测试服务器验证通过

## Related

- Issue/ticket:
