### PR TITLE
fix(points): 补上展示名 helper 的 import，避免入库发分 NameError

### DIFF
--- a/src/backend/bisheng/points/domain/services/points_award_facade.py
+++ b/src/backend/bisheng/points/domain/services/points_award_facade.py
@@ -7,6 +7,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Any
 
+from bisheng.points.domain.constants.rule_display_name import resolve_point_rule_display_name
 from bisheng.points.domain.constants.space_level_rules import earn_rule_for_space_level
 from bisheng.points.domain.services.points_ledger_service import LedgerResult, PointsLedgerService
 

--- a/src/backend/bisheng/points/domain/services/points_monthly_reward_service.py
+++ b/src/backend/bisheng/points/domain/services/points_monthly_reward_service.py
@@ -23,6 +23,7 @@ from bisheng.points.domain.constants.monthly_reward_rules import (
     pick_highest_reward,
 )
 from bisheng.points.domain.constants.notify_templates import resolve_earn_notify
+from bisheng.points.domain.constants.rule_display_name import resolve_point_rule_display_name
 from bisheng.points.domain.repositories.points_repository import PointsRepository
 from bisheng.points.domain.services.points_ledger_service import PointsLedgerService
 from bisheng.points.domain.services.points_notify_service import (

--- a/src/backend/bisheng/points/domain/services/points_pending_deduct_service.py
+++ b/src/backend/bisheng/points/domain/services/points_pending_deduct_service.py
@@ -13,6 +13,7 @@ from datetime import datetime, timedelta
 from bisheng.common.errcode.points import PointsInvalidAdjustError, PointsRuleNotFoundError
 from bisheng.core.database import get_async_db_session
 from bisheng.points.domain.constants.notify_templates import format_deduct_notify_reason
+from bisheng.points.domain.constants.rule_display_name import resolve_point_rule_display_name
 from bisheng.points.domain.models import PointPendingDeduct
 from bisheng.points.domain.repositories.points_repository import PointsRepository
 from bisheng.points.domain.services.points_ledger_service import PointsLedgerService

--- a/src/backend/bisheng/points/domain/services/points_query_service.py
+++ b/src/backend/bisheng/points/domain/services/points_query_service.py
@@ -11,6 +11,7 @@ from bisheng.common.dependencies.user_deps import UserPayload
 from bisheng.common.errcode.points import PointsInvalidAdjustError, PointsRuleNotFoundError
 from bisheng.common.schemas.api import PageData
 from bisheng.points.domain.constants.notify_templates import format_deduct_notify_reason
+from bisheng.points.domain.constants.rule_display_name import resolve_point_rule_display_name
 from bisheng.points.domain.schemas.points_schema import (
     PointAdjustRequest,
     PointAdminDepartmentOption,

--- a/src/backend/test/points/test_points_award_facade.py
+++ b/src/backend/test/points/test_points_award_facade.py
@@ -64,11 +64,21 @@ class FakeAwardRepository:
         pass
 
 
-def _rule(code="G1", *, status="enabled", beneficiary="uploader", score=3, daily_cap=15, score_expr=None):
+def _rule(
+    code="G1",
+    *,
+    status="enabled",
+    beneficiary="uploader",
+    score=3,
+    daily_cap=15,
+    score_expr=None,
+    display_name=None,
+):
     return SimpleNamespace(
         rule_code=code,
         rule_type="earn",
         name=f"rule-{code}",
+        display_name=display_name,
         status=status,
         beneficiary=beneficiary,
         daily_cap=daily_cap,
@@ -224,6 +234,36 @@ async def test_same_session_serial_awards_respect_daily_cap():
     assert third.reason == "daily_cap"
     assert repo.account.balance == 60
     assert len(repo.logs) == 2
+
+
+@pytest.mark.asyncio
+async def test_space_file_award_uses_rule_display_name_as_title():
+    """入库发分必须解析展示名；漏 import 会被 _safe 吞成 reason=error，流水为空。"""
+    repo = FakeAwardRepository(
+        {"G1": _rule(score=3, display_name="公共库上传展示名")},
+    )
+    outcome = await _facade(repo).on_space_file_ready(_file_event())
+    assert not outcome.skipped, outcome.reason
+    assert outcome.rule_name == "公共库上传展示名"
+    log = next(iter(repo.logs.values()))
+    assert log.title == "公共库上传展示名"
+    assert log.delta == 3
+
+
+@pytest.mark.asyncio
+async def test_team_ks_space_awards_g6_with_publisher_beneficiary():
+    """科室库 team_ks 走 G6；受益人 publisher 且直传人=发布人时应入账。"""
+    repo = FakeAwardRepository(
+        {"G6": _rule("G6", beneficiary="publisher", score=20, daily_cap=1000, display_name="科室库上传")},
+    )
+    outcome = await _facade(repo).on_space_file_ready(_file_event(space_level="team_ks", uploader_id=4, publisher_id=4))
+    assert not outcome.skipped, outcome.reason
+    assert outcome.rule_code == "G6"
+    assert outcome.rule_name == "科室库上传"
+    assert repo.account.balance == 20
+    log = next(iter(repo.logs.values()))
+    assert log.title == "科室库上传"
+    assert "earn:G6:100:10" in repo.logs
 
 
 @pytest.mark.asyncio

--- a/src/backend/test/points/test_points_rule_display_name.py
+++ b/src/backend/test/points/test_points_rule_display_name.py
@@ -1,5 +1,6 @@
 """积分规则 display_name 与默认 name 分离。"""
 
+import importlib
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -8,6 +9,14 @@ import pytest
 from bisheng.points.domain.constants.rule_display_name import resolve_point_rule_display_name
 from bisheng.points.domain.schemas.points_schema import PointRuleRequest
 from bisheng.points.domain.services.points_rule_service import PointsRuleService
+
+# 8/21 把流水标题改成 helper 后漏 import，发分被 _safe 吞成 error。这些模块必须绑定该名字。
+_DISPLAY_NAME_CONSUMER_MODULES = (
+    "bisheng.points.domain.services.points_award_facade",
+    "bisheng.points.domain.services.points_monthly_reward_service",
+    "bisheng.points.domain.services.points_query_service",
+    "bisheng.points.domain.services.points_pending_deduct_service",
+)
 
 
 def test_resolve_point_rule_display_name_prefers_display_name():
@@ -18,6 +27,14 @@ def test_resolve_point_rule_display_name_prefers_display_name():
 def test_resolve_point_rule_display_name_falls_back_to_default_name():
     rule = SimpleNamespace(rule_code="G1", name="发布/上传文档到公共库", display_name=None)
     assert resolve_point_rule_display_name(rule) == "发布/上传文档到公共库"
+
+
+@pytest.mark.parametrize("modname", _DISPLAY_NAME_CONSUMER_MODULES)
+def test_award_related_services_bind_display_name_helper(modname):
+    """消费展示名的服务必须 import helper，避免运行时 NameError。"""
+    mod = importlib.import_module(modname)
+    helper = getattr(mod, "resolve_point_rule_display_name", None)
+    assert helper is resolve_point_rule_display_name, f"{modname} 未绑定 resolve_point_rule_display_name"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- 入库/月奖/调分/补扣路径在改用 `resolve_point_rule_display_name` 后漏了 import，Worker 入账时 `NameError`，被 Facade 吞掉，表现为上传成功但积分不到账。
- 给 4 个消费展示名的服务补上 import。
- 补回归测试：展示名作流水标题、科室库 G6 发分、相关模块必须绑定该 helper。

## Test plan
- [x] `uv run pytest test/points/test_points_award_facade.py test/points/test_points_rule_display_name.py -v`
- [x] `uv run pytest test/points/test_points_monthly_reward.py test/points/test_points_pending_deduct.py test/points/test_points_admin_lists.py test/points/test_points_award_hooks.py -q`
- [ ] 部署后用非库管用户再上传科室/团队库文档，确认产生对应 G5/G6 流水（本次不补发历史积分）


Made with [Cursor](https://cursor.com)