### PR TITLE
feat: add OrcaRouter as a first-class model provider

### DIFF
--- a/src/backend/bisheng/llm/domain/const.py
+++ b/src/backend/bisheng/llm/domain/const.py
@@ -18,6 +18,7 @@ class LLMServerType(Enum):
     MINIMAX = 'minimax'
     ANTHROPIC = 'anthropic'
     DEEPSEEK = 'deepseek'
+    ORCAROUTER = 'orcarouter'  # OrcaRouter OpenAI-compatible AI gateway
     SPARK = 'spark'  # Xunfei Starfire Large Model
     BISHENG_RT = 'bisheng_rt'
     TENCENT = 'tencent'  # Tencent Cloud

--- a/src/backend/bisheng/llm/domain/llm/llm.py
+++ b/src/backend/bisheng/llm/domain/llm/llm.py
@@ -181,6 +181,7 @@ _llm_node_type: Dict = {
     LLMServerType.MINIMAX.value: {'client': ChatMinimax, 'params_handler': _get_minimax_params},
     LLMServerType.ANTHROPIC.value: {'client': ChatAnthropic, 'params_handler': _get_anthropic_params},
     LLMServerType.DEEPSEEK.value: {'client': CustomChatDeepSeek, 'params_handler': _get_deepseek_params},
+    LLMServerType.ORCAROUTER.value: {'client': ChatOpenAICompatible, 'params_handler': _get_openai_params},
     LLMServerType.SPARK.value: {'client': ChatOpenAICompatible, 'params_handler': _get_spark_params},
     LLMServerType.TENCENT.value: {'client': ChatOpenAICompatible, 'params_handler': _get_openai_params},
     LLMServerType.MOONSHOT.value: {'client': ChatMoonshot, 'params_handler': _get_moonshot_params},

--- a/src/backend/test/llm/test_orcarouter_provider.py
+++ b/src/backend/test/llm/test_orcarouter_provider.py
@@ -1,0 +1,37 @@
+"""Dispatch tests for the OrcaRouter provider registration.
+
+OrcaRouter is an OpenAI-compatible AI gateway that exposes a
+provider/model namespace (e.g. ``orcarouter/auto``) behind the same
+``/v1/chat/completions`` contract. It is wired through the same
+OpenAI-compatible client and params handler as the existing QIAN_FAN /
+TENCENT / SILICON providers, so the tests lock the dispatch mapping
+rather than duplicating payload tests already covered by
+``test_provider_chatmodels.py``.
+"""
+
+from bisheng.core.ai.llm.chat_openai_compatible import ChatOpenAICompatible
+from bisheng.llm.domain.const import LLMServerType
+from bisheng.llm.domain.llm.llm import _get_openai_params, _llm_node_type
+
+
+def test_orcarouter_server_type_registered():
+    assert LLMServerType.ORCAROUTER.value == "orcarouter"
+
+
+def test_orcarouter_uses_openai_compatible_client():
+    assert _llm_node_type[LLMServerType.ORCAROUTER.value]["client"] is ChatOpenAICompatible
+
+
+def test_orcarouter_uses_openai_params_handler():
+    assert _llm_node_type[LLMServerType.ORCAROUTER.value]["params_handler"] is _get_openai_params
+
+
+def test_orcarouter_params_resolve_endpoint():
+    params = _get_openai_params(
+        {"model": "orcarouter/auto", "streaming": False},
+        {"openai_api_base": "https://api.orcarouter.ai/v1", "openai_api_key": "sk-orca-test"},
+        {},
+    )
+    assert params["base_url"] == "https://api.orcarouter.ai/v1"
+    assert params["api_key"] == "sk-orca-test"
+    assert params["model"] == "orcarouter/auto"

--- a/src/frontend/platform/src/pages/ModelPage/manage/CustomForm.tsx
+++ b/src/frontend/platform/src/pages/ModelPage/manage/CustomForm.tsx
@@ -79,6 +79,24 @@ const modelProviders = {
             key: "openai_api_key",
         },
     ],
+    orcarouter: [
+        {
+            label: "Base URL",
+            type: "text",
+            placeholder: "https://api.orcarouter.ai/v1",
+            default: "https://api.orcarouter.ai/v1",
+            required: true,
+            key: "openai_api_base",
+        },
+        {
+            label: "API Key",
+            type: "password",
+            placeholder: "",
+            default: "",
+            required: true,
+            key: "openai_api_key",
+        },
+    ],
     azure_openai: [
         {
             label: "Azure Endpoint",

--- a/src/frontend/platform/src/pages/ModelPage/manage/ModelConfig.tsx
+++ b/src/frontend/platform/src/pages/ModelPage/manage/ModelConfig.tsx
@@ -378,6 +378,7 @@ export const modelProvider = [
     { "name": "vllm", "value": "vllm" },
     { "name": "阿里云百炼", "value": "qwen" },
     { "name": "DeepSeek", "value": "deepseek" },
+    { "name": "OrcaRouter", "value": "orcarouter" },
     { "name": "硅基流动", "value": "silicon" },
     { "name": "火山引擎", "value": "volcengine" },
     { "name": "智谱 AI", "value": "zhipu" },

--- a/src/frontend/platform/src/pages/ModelPage/manage/useLink.ts
+++ b/src/frontend/platform/src/pages/ModelPage/manage/useLink.ts
@@ -47,6 +47,10 @@ const modelProviderInfo: Record<string, ProviderInfo> = {
         apiKeyUrl: 'https://platform.deepseek.com/api_keys',
         modelUrl: 'https://platform.deepseek.com/docs',
     },
+    orcarouter: {
+        apiKeyUrl: 'https://www.orcarouter.ai/console',
+        modelUrl: 'https://www.orcarouter.ai/models',
+    },
 };
 
 // 获取API信息

--- a/src/frontend/platform/src/util/advancedParamsTemplates.ts
+++ b/src/frontend/platform/src/util/advancedParamsTemplates.ts
@@ -244,6 +244,7 @@ export interface AdvancedParams {
     'minimax': 'minimax-llm',
     'anthropic': 'anthropic-llm',
     'deepseek': 'deepseek-llm',
+    'orcarouter': 'openai-llm', // OrcaRouter OpenAI-compatible AI gateway
     'moonshot': 'moonshot-llm' // 月之暗面
   };
   


### PR DESCRIPTION
## What

Adds **OrcaRouter** as a first-class model provider in BISHENG's unified model management. OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents — like OpenRouter, it exposes a provider/model namespace across many models, but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding it as a named provider means BISHENG users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Why

BISHENG already ships named entries for OpenAI / Anthropic / DeepSeek / Qwen / SiliconFlow and friends in `modelProvider` (`src/frontend/platform/src/pages/ModelPage/manage/ModelConfig.tsx`). OrcaRouter fits the same slot: it speaks the OpenAI `chat/completions` contract that `ChatOpenAICompatible` already targets, so it needs no new client — just registration.

## How

Mirrors the existing `silicon` / `qianfan` / `tencent` wiring:

- Backend: `LLMServerType.ORCAROUTER` in `llm/domain/const.py`, dispatched to `ChatOpenAICompatible` with the shared `_get_openai_params` handler in `llm/domain/llm/llm.py`.
- Frontend (platform): provider dropdown entry, per-provider config form (Base URL defaults to `https://api.orcarouter.ai/v1`, API key), key/catalog links in `useLink.ts`, and the `openai-llm` advanced-params template mapping.

## Test

- [x] Platform `pnpm lint` + `pnpm typecheck` + `pnpm check-i18n` pass locally
- [x] New backend dispatch test (`test/llm/test_orcarouter_provider.py`) passes; existing `test/llm/test_provider_chatmodels.py` stays green
- [x] Live check against `https://api.orcarouter.ai/v1/chat/completions` with `orcarouter/auto` returned `200`

## Related

- Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
