### PR TITLE
fix(knowledge): 科室绑定下拉仅科室显示已绑定，非科室去掉勾选框

### DIFF
--- a/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
+++ b/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
@@ -2076,16 +2076,22 @@ class KnowledgeSpaceService(KnowledgeUtils):
     ) -> dict[str, Any]:
         """科室库绑定下拉: 部门管理员授权子树并集, 展示最多到 office.
 
-        超管看租户全部活跃组织后再裁剪. 已绑定 ID 只返回仍出现在树上的节点.
+        超管看租户全部活跃组织后再裁剪. 已绑定 ID 只返回树上的 office,
+        公司/部门即使已绑知识库也不标已绑定.
         """
         departments = filter_clinic_bind_tree_departments(await self._clinic_visible_departments())
         tree = await self._build_department_tree(departments)
 
-        filtered_ids = {int(dept.id) for dept in departments if getattr(dept, "id", None) is not None}
+        office_ids = {
+            int(dept.id)
+            for dept in departments
+            if getattr(dept, "id", None) is not None and is_clinic_bindable_department(dept)
+        }
         bound_ids = await self._bound_department_ids(
-            filtered_ids,
+            office_ids,
             exclude_space_id=exclude_space_id,
         )
+        bound_ids &= office_ids
 
         return {"data": tree, "bound_department_ids": sorted(bound_ids)}
 

--- a/src/backend/test/knowledge/test_knowledge_space_my_department_tree.py
+++ b/src/backend/test/knowledge/test_knowledge_space_my_department_tree.py
@@ -287,6 +287,44 @@ async def test_marks_bound_offices(mock_session) -> None:
 
 
 @pytest.mark.asyncio
+async def test_does_not_mark_bound_non_office_nodes(mock_session) -> None:
+    login_user = _login_user()
+    svc = KnowledgeSpaceService(request=None, login_user=login_user)
+    bindings_mock = AsyncMock(return_value=[_binding(1, 200)])
+
+    departments = [
+        _department(1, name="炼铁部", path="/1/", org_level="dept"),
+        _department(2, name="炼铁作业区", parent_id=1, path="/1/2/", org_level="office"),
+    ]
+
+    with (
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service."
+            "DepartmentAdminGrantDao.aget_department_ids_by_user_id",
+            new=AsyncMock(return_value=[1]),
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.DepartmentDao.aget_active_by_tenant",
+            new=AsyncMock(return_value=departments),
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.DepartmentKnowledgeSpaceDao.aget_by_department_ids",
+            bindings_mock,
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.get_async_db_session",
+            return_value=mock_session,
+        ),
+    ):
+        result = await svc.get_my_department_tree_for_create()
+
+    assert result["bound_department_ids"] == []
+    bindings_mock.assert_awaited_once()
+    queried_ids = set(bindings_mock.await_args.args[0])
+    assert queried_ids == {2}
+
+
+@pytest.mark.asyncio
 async def test_exclude_space_id_omits_current_binding(mock_session) -> None:
     login_user = _login_user()
     svc = KnowledgeSpaceService(request=None, login_user=login_user)

--- a/src/frontend/client/src/components/permission/SubjectSearchDepartment.test.tsx
+++ b/src/frontend/client/src/components/permission/SubjectSearchDepartment.test.tsx
@@ -343,6 +343,49 @@ describe("SubjectSearchDepartment", () => {
     expect(screen.queryByText("com_permission.already_granted")).not.toBeInTheDocument();
   });
 
+  it("does not show already bound label on non-office nodes", async () => {
+    const loadDepartments = jest.fn().mockResolvedValue([
+      {
+        id: 1,
+        dept_id: "dept-1",
+        name: "炼铁部",
+        org_level: "dept",
+        parent_id: null,
+        children: [
+          {
+            id: 2,
+            dept_id: "dept-2",
+            name: "炼铁作业区",
+            org_level: "office",
+            parent_id: 1,
+            children: [],
+          },
+        ],
+      },
+    ]);
+
+    render(
+      <SubjectSearchDepartment
+        value={[]}
+        onChange={jest.fn()}
+        includeChildren
+        onIncludeChildrenChange={jest.fn()}
+        selectionMode="single"
+        loadDepartments={loadDepartments}
+        disabledIds={[1, 2]}
+        canSelectNode={(node) => node.org_level === "office"}
+        boundDisabledLabelKey="com_permission.already_bound"
+      />,
+    );
+
+    const deptLabel = await screen.findByText("炼铁部");
+    expect(within(deptLabel.parentElement as HTMLElement).queryByRole("checkbox")).not.toBeInTheDocument();
+    expect(within(deptLabel.parentElement as HTMLElement).queryByText("com_permission.already_bound")).not.toBeInTheDocument();
+    fireEvent.click(within(deptLabel.parentElement as HTMLElement).getByRole("button"));
+    const officeLabel = await screen.findByText("炼铁作业区");
+    expect(within(officeLabel.parentElement as HTMLElement).getByText("com_permission.already_bound")).toBeInTheDocument();
+  });
+
   it("uses resource-scoped department candidates when a resource is provided", async () => {
     mockedGetResourceGrantDepartments.mockResolvedValue([
       {
@@ -579,12 +622,14 @@ describe("SubjectSearchDepartment", () => {
 
     const deptLabel = await screen.findByText("炼铁部");
     expect(within(deptLabel.parentElement as HTMLElement).getByText("com_permission.org_level_dept")).toBeInTheDocument();
+    expect(within(deptLabel.parentElement as HTMLElement).queryByRole("checkbox")).not.toBeInTheDocument();
     // 非 office 不可选，点行只展开；不要再点 chevron，否则会收起。
     fireEvent.click(deptLabel);
     expect(onChange).not.toHaveBeenCalled();
 
     const officeLabel = await screen.findByText("炼铁作业区");
     expect(within(officeLabel.parentElement as HTMLElement).getByText("com_permission.org_level_office")).toBeInTheDocument();
+    expect(within(officeLabel.parentElement as HTMLElement).getByRole("checkbox")).toBeInTheDocument();
     fireEvent.click(officeLabel);
     expect(onChange).toHaveBeenCalledWith([
       expect.objectContaining({ type: "department", id: 2, name: "炼铁作业区" }),

--- a/src/frontend/client/src/components/permission/SubjectSearchDepartment.tsx
+++ b/src/frontend/client/src/components/permission/SubjectSearchDepartment.tsx
@@ -369,6 +369,10 @@ function TreeNode({
   const isBoundDisabled = disabledIds.has(node.id);
   const isLevelBlocked = Boolean(canSelectNode && !canSelectNode(node));
   const isDisabled = isBoundDisabled || isLevelBlocked;
+  const showBoundDisabledLabel =
+    isBoundDisabled &&
+    showAlreadyGrantedLabel &&
+    (!canSelectNode || canSelectNode(node));
   const isChecked = isExplicitlySelected || isImplicitlySelected;
   const isIndeterminate = !isChecked && indeterminateIds.has(node.id);
   const nextAncestorIncluded = ancestorIncluded || Boolean(explicitSelection?.include_children);
@@ -404,19 +408,23 @@ function TreeNode({
         ) : (
           <span className="w-5" />
         )}
-        <Checkbox
-          checked={isIndeterminate ? "indeterminate" : isChecked}
-          disabled={isDisabled}
-          onClick={(e) => e.stopPropagation()}
-          onCheckedChange={() => {
-            if (isDisabled) return;
-            if (isImplicitlySelected) {
-              onMaterializeInheritedSelection();
-              return;
-            }
-            onToggle(node);
-          }}
-        />
+        {isLevelBlocked ? (
+          <span className="h-4 w-4 shrink-0" aria-hidden />
+        ) : (
+          <Checkbox
+            checked={isIndeterminate ? "indeterminate" : isChecked}
+            disabled={isDisabled}
+            onClick={(e) => e.stopPropagation()}
+            onCheckedChange={() => {
+              if (isDisabled) return;
+              if (isImplicitlySelected) {
+                onMaterializeInheritedSelection();
+                return;
+              }
+              onToggle(node);
+            }}
+          />
+        )}
         <Building2 className="h-4 w-4 shrink-0 text-gray-400" />
         <span className="min-w-0 truncate text-sm" title={displayName}>
           {displayName}
@@ -439,7 +447,7 @@ function TreeNode({
             {localize("com_permission.covered_by_parent_department")}
           </span>
         )}
-        {isBoundDisabled && showAlreadyGrantedLabel && (
+        {showBoundDisabledLabel && (
           <span className="ml-auto shrink-0 rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500">
             {localize(boundDisabledLabelKey)}
           </span>

--- a/src/frontend/client/src/pages/knowledge/CreateKnowledgeSpaceDrawer.test.tsx
+++ b/src/frontend/client/src/pages/knowledge/CreateKnowledgeSpaceDrawer.test.tsx
@@ -201,7 +201,7 @@ jest.mock("~/components/permission/SubjectSearchDepartment", () => ({
                             data-disabled={disabled ? "true" : "false"}
                             onClick={() => onChange([{ type: "department", id: department.id, name: department.name }])}
                         >
-                            选择{department.name}{bound ? "(已绑定)" : ""}
+                            选择{department.name}{bound && (!canSelectNode || canSelectNode(department)) ? "(已绑定)" : ""}
                         </button>
                     );
                 })}


### PR DESCRIPTION
## Summary
- 绑定科室下拉只给 **科室（office）** 标「已绑定」；公司/部门即使已绑知识库也不展示该文案。
- 非科室节点去掉勾选框，点行仍可展开；只有科室保留勾选框。
- 权限管理下拉的「已授权」与勾选框不受影响。

接续已合入的 #2388。

## Test plan
- [ ] `pytest test/knowledge/test_knowledge_space_my_department_tree.py`
- [ ] `npx jest src/components/permission/SubjectSearchDepartment.test.tsx --coverage=false --watchAll=false`
- [ ] 手工：部门已绑部门库时，科室下拉里该部门无「已绑定」、无勾选框；已绑科室置灰并显示「已绑定」


Made with [Cursor](https://cursor.com)