### PR TITLE
feat(portal): 首页问答次数叠加专家问答与智能问答

### DIFF
--- a/src/backend/bisheng/common/constants/telemetry.py
+++ b/src/backend/bisheng/common/constants/telemetry.py
@@ -1,4 +1,7 @@
 KNOWLEDGE_SPACE_CONTENT_STAT_INDEX = "mid_knowledge_space_content_stat"
+REALTIME_QA_QUESTION_FACT_INDEX = "mid_realtime_qa_question_fact"
+# 首页问答在文档问答事件之外叠加的看板 qa_type。
+HOME_STATS_EXTRA_QA_TYPES = ("expert", "smart")
 
 KNOWLEDGE_SPACE_DASHBOARD_FILE_LEVELS = (
     "public",

--- a/src/backend/bisheng/common/telemetry/portal_event_service.py
+++ b/src/backend/bisheng/common/telemetry/portal_event_service.py
@@ -3,8 +3,10 @@ from typing import Any
 
 from bisheng.common.constants.enums.telemetry import BaseTelemetryTypeEnum
 from bisheng.common.constants.telemetry import (
+    HOME_STATS_EXTRA_QA_TYPES,
     KNOWLEDGE_SPACE_CONTENT_STAT_INDEX,
     KNOWLEDGE_SPACE_DASHBOARD_FILE_LEVELS,
+    REALTIME_QA_QUESTION_FACT_INDEX,
 )
 from bisheng.common.schemas.telemetry.event_data_schema import (
     PortalDocumentDownloadEventData,
@@ -98,9 +100,7 @@ class PortalTelemetryEventService:
                         {"term": {"event_type": BaseTelemetryTypeEnum.PORTAL_DOCUMENT_READ.value}},
                         {"term": {"event_data.portal_document_read_file_id": file_id}},
                     ],
-                    "must_not": [
-                        {"exists": {"field": "event_data.portal_document_read_content_stat_schema_version"}}
-                    ],
+                    "must_not": [{"exists": {"field": "event_data.portal_document_read_content_stat_schema_version"}}],
                 }
             },
         }
@@ -140,9 +140,7 @@ class PortalTelemetryEventService:
             "query": {
                 "bool": {
                     "filter": filters,
-                    "must_not": [
-                        {"exists": {"field": "event_data.portal_document_read_content_stat_schema_version"}}
-                    ],
+                    "must_not": [{"exists": {"field": "event_data.portal_document_read_content_stat_schema_version"}}],
                 }
             },
             "aggs": {
@@ -209,6 +207,11 @@ class PortalTelemetryEventService:
 
     @staticmethod
     async def count_home_events() -> dict[str, int]:
+        """首页阅读/收藏/问答计数.
+
+        问答 = 现有 portal_qa 事件(剔除已投影为智能问答的 smart_qa) + 看板事实表 expert/smart.
+        智能问答已写入 portal_qa, 剔除后再按事实表加回, 避免双计.
+        """
         event_values = [event_type.value for event_type in PORTAL_HOME_EVENT_TYPES]
         body = {
             "size": 0,
@@ -226,10 +229,7 @@ class PortalTelemetryEventService:
                                     },
                                     {
                                         "exists": {
-                                            "field": (
-                                                "event_data.portal_document_read_"
-                                                "content_stat_schema_version"
-                                            )
+                                            "field": ("event_data.portal_document_read_content_stat_schema_version")
                                         }
                                     },
                                 ]
@@ -243,12 +243,21 @@ class PortalTelemetryEventService:
                                             "event_type": BaseTelemetryTypeEnum.PORTAL_FAVORITE.value,
                                         }
                                     },
+                                    {"exists": {"field": ("event_data.portal_favorite_content_stat_schema_version")}},
+                                ]
+                            }
+                        },
+                        {
+                            "bool": {
+                                "filter": [
                                     {
-                                        "exists": {
-                                            "field": (
-                                                "event_data.portal_favorite_"
-                                                "content_stat_schema_version"
-                                            )
+                                        "term": {
+                                            "event_type": BaseTelemetryTypeEnum.PORTAL_QA.value,
+                                        }
+                                    },
+                                    {
+                                        "term": {
+                                            "event_data.portal_qa_scene": "smart_qa",
                                         }
                                     },
                                 ]
@@ -274,11 +283,42 @@ class PortalTelemetryEventService:
             key = str(bucket.get("key") or "")
             if key in counts:
                 counts[key] = int(bucket.get("doc_count") or 0)
+        extra_qa_count = await PortalTelemetryEventService.count_dashboard_qa_by_types(HOME_STATS_EXTRA_QA_TYPES)
         return {
             "read_count": counts[BaseTelemetryTypeEnum.PORTAL_DOCUMENT_READ.value],
             "favorite_count": counts[BaseTelemetryTypeEnum.PORTAL_FAVORITE.value],
-            "qa_count": counts[BaseTelemetryTypeEnum.PORTAL_QA.value],
+            "qa_count": counts[BaseTelemetryTypeEnum.PORTAL_QA.value] + extra_qa_count,
         }
+
+    @staticmethod
+    async def count_dashboard_qa_by_types(qa_types: tuple[str, ...]) -> int:
+        """按看板事实表统计指定 qa_type 的提问数, 口径与问答总数相同 (question_id value_count)."""
+        if not qa_types:
+            return 0
+        es_client = await get_statistics_es_connection()
+        response = await es_client.search(
+            index=REALTIME_QA_QUESTION_FACT_INDEX,
+            body={
+                "size": 0,
+                "query": {
+                    "bool": {
+                        "filter": [
+                            {"terms": {"qa_type": list(qa_types)}},
+                        ]
+                    }
+                },
+                "aggs": {
+                    "qa_count": {
+                        "value_count": {
+                            "field": "question_id",
+                        }
+                    }
+                },
+            },
+            filter_path="aggregations.qa_count.value",
+        )
+        value = ((response.get("aggregations") or {}).get("qa_count") or {}).get("value")
+        return int(value or 0)
 
     @staticmethod
     async def count_dashboard_files() -> int:

--- a/src/backend/test/knowledge/test_portal_home_qa_count.py
+++ b/src/backend/test/knowledge/test_portal_home_qa_count.py
@@ -1,0 +1,64 @@
+"""门户首页问答计数: 文档问答事件 + 看板专家/智能问答事实."""
+
+import pytest
+
+from bisheng.common.constants.telemetry import (
+    HOME_STATS_EXTRA_QA_TYPES,
+    REALTIME_QA_QUESTION_FACT_INDEX,
+)
+from bisheng.common.telemetry.portal_event_service import PortalTelemetryEventService
+
+
+class _FakeSearchClient:
+    def __init__(self, *, qa_value: int = 0) -> None:
+        self.qa_value = qa_value
+        self.search_calls: list[dict] = []
+
+    async def search(self, **kwargs):
+        self.search_calls.append(kwargs)
+        return {"aggregations": {"qa_count": {"value": self.qa_value}}}
+
+
+@pytest.mark.asyncio
+async def test_count_dashboard_qa_by_types_uses_fact_index(monkeypatch: pytest.MonkeyPatch):
+    fake_client = _FakeSearchClient(qa_value=9)
+
+    async def fake_get_es_connection():
+        return fake_client
+
+    monkeypatch.setattr(
+        "bisheng.common.telemetry.portal_event_service.get_statistics_es_connection",
+        fake_get_es_connection,
+    )
+
+    result = await PortalTelemetryEventService.count_dashboard_qa_by_types(HOME_STATS_EXTRA_QA_TYPES)
+
+    assert result == 9
+    assert fake_client.search_calls == [
+        {
+            "index": REALTIME_QA_QUESTION_FACT_INDEX,
+            "body": {
+                "size": 0,
+                "query": {
+                    "bool": {
+                        "filter": [
+                            {"terms": {"qa_type": ["expert", "smart"]}},
+                        ]
+                    }
+                },
+                "aggs": {
+                    "qa_count": {
+                        "value_count": {
+                            "field": "question_id",
+                        }
+                    }
+                },
+            },
+            "filter_path": "aggregations.qa_count.value",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_count_dashboard_qa_by_types_empty() -> None:
+    assert await PortalTelemetryEventService.count_dashboard_qa_by_types(()) == 0

--- a/src/backend/test/knowledge/test_shougang_portal_telemetry.py
+++ b/src/backend/test/knowledge/test_shougang_portal_telemetry.py
@@ -135,7 +135,12 @@ def test_portal_telemetry_recorder_is_best_effort(monkeypatch):
 async def test_portal_home_event_counts(monkeypatch):
     class FakeEsClient:
         async def search(self, **kwargs):
-            assert kwargs["index"] == "base_telemetry_events"
+            if kwargs["index"] == "mid_realtime_qa_question_fact":
+                assert kwargs["body"]["query"]["bool"]["filter"] == [
+                    {"terms": {"qa_type": ["expert", "smart"]}},
+                ]
+                return {"aggregations": {"qa_count": {"value": 8}}}
+
             query = kwargs["body"]["query"]["bool"]
             assert query["filter"] == [
                 {
@@ -148,14 +153,24 @@ async def test_portal_home_event_counts(monkeypatch):
                     }
                 }
             ]
+            must_not = query["must_not"]
             excluded_fields = {
                 item["bool"]["filter"][1]["exists"]["field"]
-                for item in query["must_not"]
+                for item in must_not
+                if "exists" in item["bool"]["filter"][1]
             }
             assert excluded_fields == {
                 "event_data.portal_document_read_content_stat_schema_version",
                 "event_data.portal_favorite_content_stat_schema_version",
             }
+            assert {
+                "bool": {
+                    "filter": [
+                        {"term": {"event_type": "portal_qa"}},
+                        {"term": {"event_data.portal_qa_scene": "smart_qa"}},
+                    ]
+                }
+            } in must_not
             return {
                 "aggregations": {
                     "by_event_type": {
@@ -175,15 +190,11 @@ async def test_portal_home_event_counts(monkeypatch):
         "bisheng.common.telemetry.portal_event_service.get_statistics_es_connection",
         fake_get_statistics_es_connection,
     )
-    monkeypatch.setattr(
-        "bisheng.common.telemetry.portal_event_service.telemetry_service.index_name",
-        "base_telemetry_events",
-    )
 
     assert await PortalTelemetryEventService.count_home_events() == {
         "read_count": 11,
         "favorite_count": 3,
-        "qa_count": 5,
+        "qa_count": 13,
     }
 
 
@@ -198,11 +209,7 @@ async def test_portal_document_read_counts_by_space_ids(monkeypatch):
             assert not any("event_data.portal_document_read_source_app" in item.get("term", {}) for item in filters)
             assert {"terms": {"event_data.portal_document_read_space_id": [12, 13]}} in filters
             assert body["query"]["bool"]["must_not"] == [
-                {
-                    "exists": {
-                        "field": "event_data.portal_document_read_content_stat_schema_version"
-                    }
-                }
+                {"exists": {"field": "event_data.portal_document_read_content_stat_schema_version"}}
             ]
             terms = body["aggs"]["by_file"]["terms"]
             assert terms["field"] == "event_data.portal_document_read_file_id"


### PR DESCRIPTION
## Summary
- 门户首页「次问答」= 现有文档问答 `portal_qa` 事件 + 看板事实表中的专家问答、智能问答。
- 智能问答本来就写在 `portal_qa` 里，先剔除 `scene=smart_qa` 再按事实表加回，避免双计。
- 专家问答删除后事实表会减，首页跟着减。不含单独再加「我的知识·文档问答」。

## Test plan
- [ ] `pytest test/knowledge/test_portal_home_qa_count.py test/knowledge/test_shougang_portal_telemetry.py::test_portal_home_event_counts test/knowledge/test_portal_home_file_count.py`
- [ ] 对照后台看板：首页数字 ≈ 文档问答事件 + 专家问答数 + 智能问答数
- [ ] 门户 BFF 首页 Redis TTL 过期或刷新后数字更新


Made with [Cursor](https://cursor.com)