### PR TITLE
fix(knowledge): 对话选库个人知识库不展示「我的收藏」

### DIFF
--- a/src/frontend/client/src/pages/appChat/UserSelectedKnowledgePicker.test.tsx
+++ b/src/frontend/client/src/pages/appChat/UserSelectedKnowledgePicker.test.tsx
@@ -39,7 +39,20 @@ describe("UserSelectedKnowledgePicker", () => {
                     spaceLevel: "team",
                 },
             ],
-            personalSpaces: [],
+            personalSpaces: [
+                {
+                    id: "40",
+                    name: "个人资料库",
+                    spaceLevel: "personal",
+                    isFavorite: false,
+                },
+                {
+                    id: "41",
+                    name: "我的收藏",
+                    spaceLevel: "personal",
+                    isFavorite: true,
+                },
+            ],
         });
         mockGetSpaceChildrenApi.mockImplementation(({ space_id }) => {
             if (String(space_id) === "13") {
@@ -140,6 +153,13 @@ describe("UserSelectedKnowledgePicker", () => {
                 effective_file_count: 1,
             });
         });
+    });
+
+    it("hides 我的收藏 from the personal knowledge list", async () => {
+        render(<UserSelectedKnowledgePicker value={null} onChange={jest.fn()} />);
+
+        expect(await screen.findByText("个人资料库")).toBeTruthy();
+        expect(screen.queryByText("我的收藏")).not.toBeInTheDocument();
     });
 
     it("reports over-limit folder scope before workflow execution", async () => {

--- a/src/frontend/client/src/pages/appChat/UserSelectedKnowledgePicker.tsx
+++ b/src/frontend/client/src/pages/appChat/UserSelectedKnowledgePicker.tsx
@@ -128,7 +128,8 @@ export default function UserSelectedKnowledgePicker({
                     ...groups.publicSpaces,
                     ...groups.departmentSpaces,
                     ...groups.teamSpaces,
-                    ...groups.personalSpaces,
+                    // 问答/对话选库不展示『我的收藏』系统个人库
+                    ...groups.personalSpaces.filter((space) => !space.isFavorite),
                 ].map(mapSpace).filter((item) => !keyword || item.source_name.toLowerCase().includes(keyword.toLowerCase()));
                 setSpaceList(spaces);
             })


### PR DESCRIPTION
## Summary
- 智能应用对话里选择知识范围时，个人知识库不再展示系统库「我的收藏」。
- 知识工作台侧栏的「我的收藏」不受影响。

## Test plan
- [x] `npx jest src/pages/appChat/UserSelectedKnowledgePicker.test.tsx --coverage=false --watchAll=false`
- [ ] 浏览器打开智能应用对话选库，个人知识库 tab 确认没有「我的收藏」


Made with [Cursor](https://cursor.com)