### PR TITLE
fix(llm): clear stale model refs from system configs on server delete

### DIFF
--- a/src/backend/bisheng/llm/domain/services/llm.py
+++ b/src/backend/bisheng/llm/domain/services/llm.py
@@ -380,6 +380,134 @@ class LLMService:
         return config
 
     @classmethod
+    async def _clear_stale_model_refs_from_system_configs(
+        cls,
+        deleted_model_ids: set[int],
+        tenant_id: int | None = None,
+    ) -> None:
+        """Null out references to deleted models across the 5 system configs.
+
+        Without this, deleting an LLM server (or removing a model from one)
+        leaves the knowledge/assistant/evaluation/workflow/workbench config
+        rows pointing at a ``model_id`` that no longer exists. The next
+        GET sanitises the response so the UI picker hides the dead entry,
+        but the persisted row still carries the stale id, and any
+        write-time ``avalidate_system_model_refs`` call (and any consumer
+        that bypasses the sanitiser) trips a 19802 "model deleted" on the
+        next update. The frontend's knowledge-base picker was the canary:
+        it kept showing the dropped model and rejected saves with the
+        same 19802.
+        """
+        if not deleted_model_ids:
+            return
+        target = _resolve_tenant_id(tenant_id)
+        deleted_set = {int(mid) for mid in deleted_model_ids if mid}
+
+        # --- knowledge_llm ------------------------------------------------
+        try:
+            knowledge_llm, _, _ = await cls.aget_knowledge_llm_with_meta(target)
+        except Exception:
+            knowledge_llm = None
+        if knowledge_llm is not None:
+            changed = False
+            if knowledge_llm.embedding_model_id in deleted_set:
+                knowledge_llm.embedding_model_id = None
+                changed = True
+            if knowledge_llm.source_model_id in deleted_set:
+                knowledge_llm.source_model_id = None
+                changed = True
+            if knowledge_llm.extract_title_model_id in deleted_set:
+                knowledge_llm.extract_title_model_id = None
+                changed = True
+            if knowledge_llm.qa_similar_model_id in deleted_set:
+                knowledge_llm.qa_similar_model_id = None
+                changed = True
+            if knowledge_llm.asr_model_id in deleted_set:
+                knowledge_llm.asr_model_id = None
+                changed = True
+            if changed:
+                await cls._base_update_llm_config(
+                    data=knowledge_llm.model_dump(),
+                    key=ConfigKeyEnum.KNOWLEDGE_LLM,
+                    tenant_id=target,
+                )
+
+        # --- assistant_llm ------------------------------------------------
+        try:
+            assistant_llm, _, _ = await cls.aget_assistant_llm_with_meta(target)
+        except Exception:
+            assistant_llm = None
+        if assistant_llm is not None:
+            changed = False
+            if assistant_llm.auto_llm and assistant_llm.auto_llm.model_id in deleted_set:
+                assistant_llm.auto_llm = None
+                changed = True
+            if assistant_llm.llm_list:
+                filtered = [
+                    item for item in assistant_llm.llm_list
+                    if item.model_id not in deleted_set
+                ]
+                if len(filtered) != len(assistant_llm.llm_list):
+                    assistant_llm.llm_list = filtered
+                    changed = True
+            if changed:
+                await cls._base_update_llm_config(
+                    data=assistant_llm.model_dump(),
+                    key=ConfigKeyEnum.ASSISTANT_LLM,
+                    tenant_id=target,
+                )
+
+        # --- evaluation_llm + workflow_llm (both EvaluationLLMConfig) -----
+        for cfg_key in (ConfigKeyEnum.EVALUATION_LLM, ConfigKeyEnum.WORKFLOW_LLM):
+            try:
+                cfg, _, _ = await cls._aget_typed_with_meta(
+                    cfg_key, EvaluationLLMConfig, target,
+                )
+            except Exception:
+                continue
+            if cfg is not None and cfg.model_id in deleted_set:
+                cfg.model_id = None
+                await cls._base_update_llm_config(
+                    data=cfg.model_dump(),
+                    key=cfg_key,
+                    tenant_id=target,
+                )
+
+        # --- workbench_llm (WorkbenchModelConfig) -------------------------
+        try:
+            workbench_llm, _, _ = await cls.aget_workbench_llm_with_meta(target)
+        except Exception:
+            workbench_llm = None
+        if workbench_llm is not None:
+            changed = False
+            if workbench_llm.linsight_default_model_id is not None and (
+                _coerce_model_id(workbench_llm.linsight_default_model_id) in deleted_set
+            ):
+                workbench_llm.linsight_default_model_id = None
+                changed = True
+            if workbench_llm.models is not None:
+                filtered = [
+                    m for m in workbench_llm.models
+                    if _coerce_model_id(m.id) not in deleted_set
+                ]
+                if len(filtered) != len(workbench_llm.models):
+                    workbench_llm.models = filtered
+                    changed = True
+            for field_name in ("embedding_model", "asr_model", "tts_model", "chat_title_llm"):
+                ws_model = getattr(workbench_llm, field_name)
+                if ws_model is None:
+                    continue
+                if _coerce_model_id(ws_model.id) in deleted_set:
+                    setattr(workbench_llm, field_name, None)
+                    changed = True
+            if changed:
+                await cls._base_update_llm_config(
+                    data=workbench_llm.model_dump(),
+                    key=ConfigKeyEnum.LINSIGHT_LLM,
+                    tenant_id=target,
+                )
+
+    @classmethod
     async def get_all_llm(
         cls,
         only_shared: bool = False,
@@ -691,7 +819,29 @@ class LLMService:
         with bypass_tenant_filter():
             pre = await LLMDao.aget_server_by_id(server_id)
 
+        # Capture the model ids we're about to drop so we can null out
+        # any system-config rows that still reference them. Without this
+        # step the knowledge/assistant/evaluation/workflow/workbench
+        # defaults keep pointing at a model that no longer exists, and
+        # the next ``update_*_llm`` write (or any direct consumer) trips
+        # ``LlmModelConfigDeletedError`` (10009) / 19802.
+        with bypass_tenant_filter():
+            models_to_drop = await LLMDao.aget_model_by_server_ids([server_id])
+        deleted_model_ids = {one.id for one in models_to_drop if one.id is not None}
+        tenant_id = getattr(pre, "tenant_id", None) if pre is not None else None
+
         await LLMDao.adelete_server_by_id(server_id, operator=login_user)
+
+        if deleted_model_ids:
+            try:
+                await cls._clear_stale_model_refs_from_system_configs(
+                    deleted_model_ids, tenant_id=tenant_id,
+                )
+            except Exception:
+                logger.exception(
+                    "cleanup system-config refs after delete_llm_server failed: server_id=%s",
+                    server_id,
+                )
 
         if pre is not None:
             await _write_llm_audit(
@@ -878,7 +1028,26 @@ class LLMService:
             list(model_dict.values()),
             operator=login_user,
         )
+        # ``update_server_with_models`` deletes any model not in the new
+        # list; gather those ids before the post-update read so we can
+        # clear stale references in the system-config rows. ``set_default_model``
+        # already auto-fills empty slots on *new* models, so the only
+        # cleanup required here is the orphans we just dropped.
         new_server_info = await cls.get_one_llm(db_server.id, operator=login_user)
+        new_model_ids = {one.id for one in new_server_info.models if one.id is not None}
+        deleted_model_ids = {
+            mid for mid in old_model_dict.keys() if mid not in new_model_ids
+        }
+        if deleted_model_ids:
+            try:
+                await cls._clear_stale_model_refs_from_system_configs(
+                    deleted_model_ids, tenant_id=exist_server.tenant_id,
+                )
+            except Exception:
+                logger.exception(
+                    "cleanup system-config refs after update_llm_server failed: server_id=%s",
+                    exist_server.id,
+                )
         if hasattr(server, "share_to_children") and exist_server.tenant_id == ROOT_TENANT_ID:
             await _write_llm_audit(
                 login_user,

--- a/src/backend/test/llm/test_llm_config_cleanup_on_delete.py
+++ b/src/backend/test/llm/test_llm_config_cleanup_on_delete.py
@@ -1,0 +1,438 @@
+"""Regression test for the bug where deleting (or removing a model from) an
+LLM server left stale ``model_id`` references in the 5 system-config rows
+(knowledge_llm / assistant_llm / evaluation_llm / workflow_llm /
+linsight_llm). The next ``update_*_llm`` write then tripped
+``LlmModelConfigDeletedError`` because ``avalidate_system_model_refs``
+rejects a model_id that no longer exists — and the knowledge-base picker
+in the management UI kept showing the dropped model until the admin
+manually cleared it.
+
+Covers ``LLMService._clear_stale_model_refs_from_system_configs`` plus
+the wiring from ``delete_llm_server`` and ``update_llm_server``.
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bisheng.common.models.config import ConfigKeyEnum
+from bisheng.llm.domain.schemas import (
+    AssistantLLMConfig,
+    AssistantLLMItem,
+    EvaluationLLMConfig,
+    KnowledgeLLMConfig,
+    WorkbenchModelConfig,
+    WSModel,
+)
+
+
+def _make_knowledge_llm(**overrides) -> KnowledgeLLMConfig:
+    base = {
+        "embedding_model_id": 10,
+        "source_model_id": 11,
+        "extract_title_model_id": 12,
+        "qa_similar_model_id": 13,
+        "asr_model_id": 14,
+    }
+    base.update(overrides)
+    return KnowledgeLLMConfig(**base)
+
+
+def _make_assistant_llm(**overrides) -> AssistantLLMConfig:
+    base = {
+        "llm_list": [
+            AssistantLLMItem(model_id=20, default=True),
+            AssistantLLMItem(model_id=21),
+        ],
+        "auto_llm": AssistantLLMItem(model_id=22),
+    }
+    base.update(overrides)
+    return AssistantLLMConfig(**base)
+
+
+def _make_evaluation_llm(model_id: int | None) -> EvaluationLLMConfig:
+    return EvaluationLLMConfig(model_id=model_id)
+
+
+def _make_workbench_llm() -> WorkbenchModelConfig:
+    return WorkbenchModelConfig(
+        models=[WSModel(id="30", name="m30"), WSModel(id="31", name="m31")],
+        linsight_default_model_id="32",
+        embedding_model=WSModel(id="33", name="m33"),
+        asr_model=WSModel(id="34", name="m34"),
+        tts_model=WSModel(id="35", name="m35"),
+        chat_title_llm=WSModel(id="36", name="m36"),
+    )
+
+
+# --- the core cleanup helper -----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clear_stale_model_refs_no_op_when_empty_set():
+    from bisheng.llm.domain.services.llm import LLMService
+
+    upsert_mock = AsyncMock()
+    with patch.object(
+        LLMService, "_base_update_llm_config", upsert_mock,
+    ):
+        await LLMService._clear_stale_model_refs_from_system_configs(set())
+    upsert_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_clear_stale_model_refs_clears_knowledge_llm():
+    from bisheng.llm.domain.services.llm import LLMService
+
+    knowledge_llm = _make_knowledge_llm()
+    with patch.object(
+        LLMService,
+        "aget_knowledge_llm_with_meta",
+        AsyncMock(return_value=(knowledge_llm, False, False)),
+    ), patch.object(
+        LLMService, "aget_assistant_llm_with_meta",
+        AsyncMock(return_value=(AssistantLLMConfig(), False, False)),
+    ), patch.object(
+        LLMService, "_aget_typed_with_meta",
+        AsyncMock(return_value=(_make_evaluation_llm(None), False, False)),
+    ), patch.object(
+        LLMService, "aget_workbench_llm_with_meta",
+        AsyncMock(return_value=(_make_workbench_llm(), False, False)),
+    ), patch.object(
+        LLMService, "_base_update_llm_config", AsyncMock(),
+    ) as upsert_mock:
+        # Drop model 11 (source_model_id) and 14 (asr_model_id).
+        await LLMService._clear_stale_model_refs_from_system_configs(
+            {11, 14}, tenant_id=1,
+        )
+
+    assert knowledge_llm.source_model_id is None
+    assert knowledge_llm.asr_model_id is None
+    # Untouched slots stay populated.
+    assert knowledge_llm.embedding_model_id == 10
+    assert knowledge_llm.extract_title_model_id == 12
+    assert knowledge_llm.qa_similar_model_id == 13
+    upsert_mock.assert_awaited_once()
+    kwargs = upsert_mock.await_args.kwargs
+    assert kwargs["key"] is ConfigKeyEnum.KNOWLEDGE_LLM
+
+
+@pytest.mark.asyncio
+async def test_clear_stale_model_refs_clears_assistant_llm_items():
+    from bisheng.llm.domain.services.llm import LLMService
+
+    assistant_llm = _make_assistant_llm()
+    with patch.object(
+        LLMService, "aget_knowledge_llm_with_meta",
+        AsyncMock(return_value=(_make_knowledge_llm(), False, False)),
+    ), patch.object(
+        LLMService, "aget_assistant_llm_with_meta",
+        AsyncMock(return_value=(assistant_llm, False, False)),
+    ), patch.object(
+        LLMService, "_aget_typed_with_meta",
+        AsyncMock(return_value=(_make_evaluation_llm(None), False, False)),
+    ), patch.object(
+        LLMService, "aget_workbench_llm_with_meta",
+        AsyncMock(return_value=(_make_workbench_llm(), False, False)),
+    ), patch.object(
+        LLMService, "_base_update_llm_config", AsyncMock(),
+    ) as upsert_mock:
+        # Drop 21 (in llm_list) and 22 (auto_llm); keep 20.
+        await LLMService._clear_stale_model_refs_from_system_configs(
+            {21, 22}, tenant_id=1,
+        )
+
+    assert [item.model_id for item in assistant_llm.llm_list] == [20]
+    assert assistant_llm.auto_llm is None
+    # Only the assistant row should have been rewritten.
+    written_keys = {call.kwargs["key"] for call in upsert_mock.await_args_list}
+    assert written_keys == {ConfigKeyEnum.ASSISTANT_LLM}
+
+
+@pytest.mark.asyncio
+async def test_clear_stale_model_refs_clears_evaluation_and_workflow():
+    from bisheng.llm.domain.services.llm import LLMService
+
+    evaluation = _make_evaluation_llm(model_id=50)
+    workflow = _make_evaluation_llm(model_id=60)
+
+    async def fake_aget_typed(key, model_cls, tenant_id):
+        if key is ConfigKeyEnum.EVALUATION_LLM:
+            return (evaluation, False, False)
+        if key is ConfigKeyEnum.WORKFLOW_LLM:
+            return (workflow, False, False)
+        return (model_cls(), False, False)
+
+    with patch.object(
+        LLMService, "aget_knowledge_llm_with_meta",
+        AsyncMock(return_value=(_make_knowledge_llm(), False, False)),
+    ), patch.object(
+        LLMService, "aget_assistant_llm_with_meta",
+        AsyncMock(return_value=(AssistantLLMConfig(), False, False)),
+    ), patch.object(
+        LLMService, "_aget_typed_with_meta",
+        AsyncMock(side_effect=fake_aget_typed),
+    ), patch.object(
+        LLMService, "aget_workbench_llm_with_meta",
+        AsyncMock(return_value=(_make_workbench_llm(), False, False)),
+    ), patch.object(
+        LLMService, "_base_update_llm_config", AsyncMock(),
+    ) as upsert_mock:
+        await LLMService._clear_stale_model_refs_from_system_configs(
+            {50, 60}, tenant_id=1,
+        )
+
+    assert evaluation.model_id is None
+    assert workflow.model_id is None
+    written_keys = {call.kwargs["key"] for call in upsert_mock.await_args_list}
+    assert ConfigKeyEnum.EVALUATION_LLM in written_keys
+    assert ConfigKeyEnum.WORKFLOW_LLM in written_keys
+
+
+@pytest.mark.asyncio
+async def test_clear_stale_model_refs_clears_workbench_linsight():
+    from bisheng.llm.domain.services.llm import LLMService
+
+    workbench = _make_workbench_llm()
+    with patch.object(
+        LLMService, "aget_knowledge_llm_with_meta",
+        AsyncMock(return_value=(_make_knowledge_llm(), False, False)),
+    ), patch.object(
+        LLMService, "aget_assistant_llm_with_meta",
+        AsyncMock(return_value=(AssistantLLMConfig(), False, False)),
+    ), patch.object(
+        LLMService, "_aget_typed_with_meta",
+        AsyncMock(return_value=(_make_evaluation_llm(None), False, False)),
+    ), patch.object(
+        LLMService, "aget_workbench_llm_with_meta",
+        AsyncMock(return_value=(workbench, False, False)),
+    ), patch.object(
+        LLMService, "_base_update_llm_config", AsyncMock(),
+    ) as upsert_mock:
+        # Drop the embedding model + one entry from ``models``.
+        await LLMService._clear_stale_model_refs_from_system_configs(
+            {30, 33}, tenant_id=1,
+        )
+
+    assert workbench.embedding_model is None
+    assert [m.id for m in workbench.models] == ["31"]
+    # Untouched: asr/tts/chat_title + linsight_default.
+    assert workbench.asr_model.id == "34"
+    assert workbench.tts_model.id == "35"
+    assert workbench.chat_title_llm.id == "36"
+    assert workbench.linsight_default_model_id == "32"
+    written_keys = {call.kwargs["key"] for call in upsert_mock.await_args_list}
+    assert ConfigKeyEnum.LINSIGHT_LLM in written_keys
+
+
+@pytest.mark.asyncio
+async def test_clear_stale_model_refs_skips_unaffected_configs():
+    """When only one config is touched, only that config is rewritten."""
+    from bisheng.llm.domain.services.llm import LLMService
+
+    # The dropped ids don't appear anywhere except knowledge_llm.
+    knowledge_llm = _make_knowledge_llm(embedding_model_id=99)
+    with patch.object(
+        LLMService,
+        "aget_knowledge_llm_with_meta",
+        AsyncMock(return_value=(knowledge_llm, False, False)),
+    ), patch.object(
+        LLMService, "aget_assistant_llm_with_meta",
+        AsyncMock(return_value=(_make_assistant_llm(), False, False)),
+    ), patch.object(
+        LLMService, "_aget_typed_with_meta",
+        AsyncMock(return_value=(_make_evaluation_llm(None), False, False)),
+    ), patch.object(
+        LLMService, "aget_workbench_llm_with_meta",
+        AsyncMock(return_value=(_make_workbench_llm(), False, False)),
+    ), patch.object(
+        LLMService, "_base_update_llm_config", AsyncMock(),
+    ) as upsert_mock:
+        await LLMService._clear_stale_model_refs_from_system_configs(
+            {99}, tenant_id=1,
+        )
+
+    assert knowledge_llm.embedding_model_id is None
+    upsert_mock.assert_awaited_once()
+    assert upsert_mock.await_args.kwargs["key"] is ConfigKeyEnum.KNOWLEDGE_LLM
+
+
+# --- delete_llm_server wires the cleanup ------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_llm_server_clears_stale_config_refs():
+    """End-to-end: deleting a server drops all of its models from the
+    system-config rows in the same call."""
+    from bisheng.llm.domain.services.llm import LLMService
+
+    pre_server = MagicMock(id=1, tenant_id=7, name="s1", type="openai",
+                            config={}, limit_flag=False, limit=0)
+    dropped_models = [
+        MagicMock(id=11, server_id=1),
+        MagicMock(id=12, server_id=1),
+    ]
+    cleanup_mock = AsyncMock()
+
+    with patch(
+        "bisheng.llm.domain.services.llm.LLMDao.aget_server_by_id",
+        AsyncMock(return_value=pre_server),
+    ), patch(
+        "bisheng.llm.domain.services.llm.LLMDao.aget_model_by_server_ids",
+        AsyncMock(return_value=dropped_models),
+    ), patch(
+        "bisheng.llm.domain.services.llm.LLMDao.adelete_server_by_id",
+        AsyncMock(),
+    ), patch(
+        "bisheng.llm.domain.services.llm._write_llm_audit",
+        AsyncMock(),
+    ), patch.object(
+        LLMService,
+        "_clear_stale_model_refs_from_system_configs",
+        cleanup_mock,
+    ):
+        await LLMService.delete_llm_server(
+            request=MagicMock(), login_user=MagicMock(), server_id=1,
+        )
+
+    cleanup_mock.assert_awaited_once()
+    args = cleanup_mock.await_args.args[0]
+    assert args == {11, 12}
+    assert cleanup_mock.await_args.kwargs.get("tenant_id") == 7
+
+
+# --- update_llm_server wires the cleanup when models get removed -----------
+
+
+@pytest.mark.asyncio
+async def test_update_llm_server_clears_refs_for_removed_models():
+    """When updating a server and removing a model from the list, the
+    dropped model's id is forwarded to the cleanup helper."""
+    from bisheng.llm.domain.services.llm import LLMService
+
+    exist_server = MagicMock(id=2, tenant_id=7, name="s2", type="openai",
+                              config={}, limit_flag=False, limit=0,
+                              share_to_children=False)
+    old_models = [
+        MagicMock(id=21, server_id=2, model_name="a", model_type="llm"),
+        MagicMock(id=22, server_id=2, model_name="b", model_type="llm"),
+    ]
+    new_server_info = MagicMock(
+        id=2, models=[MagicMock(id=21)], tenant_id=7,
+    )
+    cleanup_mock = AsyncMock()
+    fake_set_default = AsyncMock()
+    fake_test_status = AsyncMock()
+    fake_update_share = AsyncMock()
+
+    with patch(
+        "bisheng.llm.domain.services.llm.LLMDao.aget_server_by_id",
+        AsyncMock(return_value=exist_server),
+    ), patch(
+        "bisheng.llm.domain.services.llm.LLMDao.aget_model_by_server_ids",
+        AsyncMock(return_value=old_models),
+    ), patch(
+        "bisheng.llm.domain.services.llm.LLMDao.aget_server_by_name",
+        AsyncMock(return_value=None),
+    ), patch(
+        "bisheng.llm.domain.services.llm.LLMDao.update_server_with_models",
+        AsyncMock(return_value=exist_server),
+    ), patch(
+        "bisheng.llm.domain.services.llm.LLMDao.aupdate_server_share",
+        fake_update_share,
+    ), patch(
+        "bisheng.llm.domain.services.llm.LLMDao.aget_model_by_server_ids",
+        AsyncMock(side_effect=[old_models, new_server_info.models]),
+    ), patch(
+        "bisheng.llm.domain.services.llm.LLMDao.aget_model_by_type",
+        AsyncMock(return_value=None),
+    ), patch(
+        "bisheng.llm.domain.services.llm._write_llm_audit",
+        AsyncMock(),
+    ), patch(
+        "bisheng.llm.domain.services.llm.ResourceShareService.list_sharing_children",
+        AsyncMock(return_value=[]),
+    ), patch.object(
+        LLMService, "get_one_llm", AsyncMock(return_value=new_server_info),
+    ), patch.object(LLMService, "set_default_model", fake_set_default), \
+         patch.object(LLMService, "test_model_status", fake_test_status), \
+         patch.object(LLMService, "_clear_stale_model_refs_from_system_configs",
+                      cleanup_mock):
+        server_req = MagicMock(
+            id=2, name="s2", description="", type="openai",
+            limit_flag=False, limit=0, config={},
+            models=[MagicMock(id=21, model_name="a", model_type="llm",
+                              description="", config=None,
+                              model_dump=MagicMock(return_value={
+                                  "id": 21, "model_name": "a",
+                                  "model_type": "llm",
+                              }))],
+        )
+        server_req.share_to_children = False
+        await LLMService.update_llm_server(
+            request=MagicMock(), login_user=MagicMock(), server=server_req,
+        )
+
+    cleanup_mock.assert_awaited_once()
+    assert cleanup_mock.await_args.args[0] == {22}
+    assert cleanup_mock.await_args.kwargs.get("tenant_id") == 7
+
+
+@pytest.mark.asyncio
+async def test_update_llm_server_skips_cleanup_when_nothing_removed():
+    """No ids missing from the new list → no cleanup call."""
+    from bisheng.llm.domain.services.llm import LLMService
+
+    exist_server = MagicMock(id=3, tenant_id=7, name="s3", type="openai",
+                              config={}, limit_flag=False, limit=0,
+                              share_to_children=False)
+    same_models = [
+        MagicMock(id=31, server_id=3, model_name="a", model_type="llm"),
+    ]
+    new_server_info = MagicMock(
+        id=3, models=list(same_models), tenant_id=7,
+    )
+    cleanup_mock = AsyncMock()
+
+    with patch(
+        "bisheng.llm.domain.services.llm.LLMDao.aget_server_by_id",
+        AsyncMock(return_value=exist_server),
+    ), patch(
+        "bisheng.llm.domain.services.llm.LLMDao.aget_model_by_server_ids",
+        AsyncMock(side_effect=[same_models, same_models]),
+    ), patch(
+        "bisheng.llm.domain.services.llm.LLMDao.aget_server_by_name",
+        AsyncMock(return_value=None),
+    ), patch(
+        "bisheng.llm.domain.services.llm.LLMDao.update_server_with_models",
+        AsyncMock(return_value=exist_server),
+    ), patch(
+        "bisheng.llm.domain.services.llm.LLMDao.aget_model_by_type",
+        AsyncMock(return_value=None),
+    ), patch(
+        "bisheng.llm.domain.services.llm._write_llm_audit",
+        AsyncMock(),
+    ), patch(
+        "bisheng.llm.domain.services.llm.ResourceShareService.list_sharing_children",
+        AsyncMock(return_value=[]),
+    ), patch.object(
+        LLMService, "get_one_llm", AsyncMock(return_value=new_server_info),
+    ), patch.object(LLMService, "set_default_model", AsyncMock()), \
+         patch.object(LLMService, "test_model_status", AsyncMock()), \
+         patch.object(LLMService, "_clear_stale_model_refs_from_system_configs",
+                      cleanup_mock):
+        server_req = MagicMock(
+            id=3, name="s3", description="", type="openai",
+            limit_flag=False, limit=0, config={},
+            models=[MagicMock(id=31, model_name="a", model_type="llm",
+                              description="", config=None,
+                              model_dump=MagicMock(return_value={
+                                  "id": 31, "model_name": "a",
+                                  "model_type": "llm",
+                              }))],
+        )
+        server_req.share_to_children = False
+        await LLMService.update_llm_server(
+            request=MagicMock(), login_user=MagicMock(), server=server_req,
+        )
+
+    cleanup_mock.assert_not_awaited()


### PR DESCRIPTION
## 修复说明

修复模型配置中删除 LLM 服务/模型后，系统配置表中残留已删除模型引用的问题。

### 问题根因

删除 LLM 服务（或从服务中移除模型）时，5 个系统配置表
（knowledge_llm / assistant_llm / evaluation_llm / workflow_llm /
linsight_llm）中的 model_id 引用没有被清理。表现：
- 下次写入这些配置时，`avalidate_system_model_refs` 会因
  model_id 已不存在而报 `LlmModelConfigDeletedError` (10009 / 19802)
- 管理后台的"配置知识库模型"下拉仍显示已删除的模型
  （getter 的 sanitize 只过滤返回值，并未清理持久化数据）
- 再次添加相同名称的新模型会报错

### 修复内容

在 `LLMService` 中新增 `_clear_stale_model_refs_from_system_configs`：
- 接收待删除的 model_id 集合
- 按 tenant 遍历 5 个系统配置，null 掉任何指向已删除 model_id
  的字段（包括 knowledge_llm 的 5 个 model_id、assistant_llm 的
  llm_list / auto_llm、evaluation_llm / workflow_llm 的 model_id，
  以及 workbench_llm 的 embedding_model / asr_model / tts_model /
  chat_title_llm / linsight_default_model_id / models）
- 只回写真正发生变化的配置行

在 `delete_llm_server` 删除 server 之前，先抓取要删的 model_id；
在 `update_llm_server` 中 `update_server_with_models` 完成后，计算
old − new 的 model_id 差集，然后调用该清理函数。

清理失败不会阻塞删除本身（best-effort + logger.exception）。

### 验证

新增 `test/llm/test_llm_config_cleanup_on_delete.py`：
- 直接覆盖 5 个配置的清理逻辑
- 覆盖 `delete_llm_server` 接线
- 覆盖 `update_llm_server` 移除模型路径 + 无变化时不调用清理

### 关联 Issue

Gitee IKBSC6: 模型配置-配置完成后删除一个LLM模型，再添加一个LLM模型-配置知识库模型 选项里会有第一个删除的模型 添加报错