### PR TITLE
fix(workbench): allow image uploads for vision models

### DIFF
--- a/src/frontend/client/src/common/chatAccept.test.ts
+++ b/src/frontend/client/src/common/chatAccept.test.ts
@@ -34,6 +34,23 @@ describe("buildChatAccept", () => {
         });
         expect(accept.split(",")).toEqual(expect.arrayContaining([".png", ".mp3", ".mp4", ".py"]));
     });
+
+    it("allows backend-supported image formats for a vision model", () => {
+        const accept = buildChatAccept({ ...DAILY, enableVision: true });
+        expect(accept.split(",")).toEqual(expect.arrayContaining([".png", ".jpg", ".jpeg", ".webp", ".gif"]));
+    });
+
+    it("does not add image formats for a non-vision model", () => {
+        const accept = buildChatAccept({ ...DAILY, enableVision: false });
+        expect(accept.split(",")).not.toContain(".png");
+        expect(accept.split(",")).toContain(".ofd");
+    });
+
+    it("does not duplicate parser-supported images for a vision model", () => {
+        const accept = buildChatAccept({ ...DAILY, enableEtl4lm: true, enableVision: true });
+        expect(accept.split(",").filter((ext) => ext === ".png")).toHaveLength(1);
+        expect(accept.split(",")).toEqual(expect.arrayContaining([".bmp", ".webp", ".gif"]));
+    });
 });
 
 describe("isFileNameAccepted", () => {
@@ -58,6 +75,13 @@ describe("isFileNameAccepted", () => {
         expect(isFileNameAccepted("analyze.py", daily)).toBe(false);
         expect(isFileNameAccepted("data.csv", daily)).toBe(false);
         expect(isFileNameAccepted("report.pdf", daily)).toBe(true);
+    });
+
+    it("rejects an attached image after switching to a non-vision model", () => {
+        const vision = buildChatAccept({ ...DAILY, enableVision: true });
+        const textOnly = buildChatAccept({ ...DAILY, enableVision: false });
+        expect(isFileNameAccepted("diagram.webp", vision)).toBe(true);
+        expect(isFileNameAccepted("diagram.webp", textOnly)).toBe(false);
     });
 
     it("treats an empty or wildcard accept as no restriction", () => {

--- a/src/frontend/client/src/common/chatAccept.test.ts
+++ b/src/frontend/client/src/common/chatAccept.test.ts
@@ -51,6 +51,15 @@ describe("buildChatAccept", () => {
         expect(accept.split(",").filter((ext) => ext === ".png")).toHaveLength(1);
         expect(accept.split(",")).toEqual(expect.arrayContaining([".bmp", ".webp", ".gif"]));
     });
+
+    it("keeps vision images accepted when leaving task mode", () => {
+        const taskAccept = buildChatAccept({ ...DAILY, enableVision: true, taskMode: true });
+        const dailyAccept = buildChatAccept({ ...DAILY, enableVision: true });
+        for (const ext of [".png", ".jpg", ".jpeg", ".webp", ".gif"]) {
+            expect(taskAccept.split(",")).toContain(ext);
+            expect(dailyAccept.split(",")).toContain(ext);
+        }
+    });
 });
 
 describe("isFileNameAccepted", () => {

--- a/src/frontend/client/src/common/chatAccept.ts
+++ b/src/frontend/client/src/common/chatAccept.ts
@@ -8,6 +8,8 @@ const BASE_WITH_IMAGES =
 
 const OFD_SUFFIX = '.ofd';
 
+const VISION_IMAGE_ACCEPT = '.png,.jpg,.jpeg,.webp,.gif';
+
 const MEDIA_ACCEPT = MEDIA_SUFFIXES.join(',').toLowerCase();
 
 /**
@@ -51,6 +53,8 @@ export interface BuildChatAcceptOptions {
     enableMedia: boolean;
     enableEtl4lm: boolean;
     includeOfd: boolean;
+    /** Allow image attachments that a selected vision model can consume directly. */
+    enableVision?: boolean;
     /** Task mode additionally accepts data/config/source files. */
     taskMode?: boolean;
 }
@@ -60,6 +64,11 @@ export function buildChatAccept(opts: BuildChatAcceptOptions): string {
     let base = opts.enableEtl4lm ? BASE_WITH_IMAGES : BASE_ACCEPT;
     if (opts.includeOfd) {
         base = `${base},${OFD_SUFFIX}`;
+    }
+    if (opts.enableVision) {
+        const accepted = new Set(base.split(','));
+        for (const ext of VISION_IMAGE_ACCEPT.split(',')) accepted.add(ext);
+        base = [...accepted].join(',');
     }
     if (opts.enableMedia) {
         base = `${base},${MEDIA_ACCEPT}`;

--- a/src/frontend/client/src/components/Chat/AiChatInput.tsx
+++ b/src/frontend/client/src/components/Chat/AiChatInput.tsx
@@ -258,6 +258,9 @@ const AiChatInput = memo(
             mediaDurationSec?: number;
         }>>([]);
         const inputFilesRef = useRef<any>(null);
+        const supportsVision = modelOptions?.some(
+            (model) => String(model.id) === String(modelValue) && model.visual
+        );
 
         // Leaving task mode drops what only task mode could carry: the skill
         // selection (so the panel's checkboxes reset in sync with the now-hidden
@@ -272,6 +275,7 @@ const AiChatInput = memo(
                 const dailyAccept = buildChatAccept({
                     enableMedia: !!envConfig?.enable_media_upload,
                     enableEtl4lm: !!bsConfig?.enable_etl4lm,
+                    enableVision: !isLingsi && !!supportsVision,
                     includeOfd: !isLingsi,
                 });
                 const isKept = (name: string) => isFileNameAccepted(name || "", dailyAccept);
@@ -298,7 +302,7 @@ const AiChatInput = memo(
             // envConfig/bsConfig are read only when the transition fires; leaving them
             // out keeps a config refetch from re-running the cleanup.
             // eslint-disable-next-line react-hooks/exhaustive-deps
-        }, [taskMode, setDailySkills]);
+        }, [taskMode, setDailySkills, supportsVision]);
 
         // Voice input: check if ASR model is available
         const { data: modelData } = useGetWorkbenchModelsQuery();
@@ -318,9 +322,6 @@ const AiChatInput = memo(
         const kbDisabled = !!disabled;
         const toolsDisabled = !!disabled;
         const filesDisabled = !!disabled;
-        const supportsVision = modelOptions?.some(
-            (model) => String(model.id) === String(modelValue) && model.visual
-        );
         const fileAccept = buildChatAccept({
             enableMedia: !!envConfig?.enable_media_upload,
             enableEtl4lm: !!bsConfig?.enable_etl4lm,

--- a/src/frontend/client/src/components/Chat/AiChatInput.tsx
+++ b/src/frontend/client/src/components/Chat/AiChatInput.tsx
@@ -318,6 +318,16 @@ const AiChatInput = memo(
         const kbDisabled = !!disabled;
         const toolsDisabled = !!disabled;
         const filesDisabled = !!disabled;
+        const supportsVision = modelOptions?.some(
+            (model) => String(model.id) === String(modelValue) && model.visual
+        );
+        const fileAccept = buildChatAccept({
+            enableMedia: !!envConfig?.enable_media_upload,
+            enableEtl4lm: !!bsConfig?.enable_etl4lm,
+            enableVision: !isLingsi && !!supportsVision,
+            includeOfd: !isLingsi,
+            taskMode,
+        });
 
         const navigate = useNavigate();
 
@@ -349,6 +359,11 @@ const AiChatInput = memo(
             const trimmed = text.trim();
             // Workbench: uploaded files require accompanying text before send.
             if (!trimmed || disabled || sendDisabled || isStreaming || isParsingMedia || fileUploading || filesParsing) return;
+            // The selected model may have changed since these files were attached.
+            if (chatFiles?.some((file) => !isFileNameAccepted(file.name || file.filename || '', fileAccept))) {
+                showToast({ message: localize('com_ui_upload_file_type_error'), status: 'error' });
+                return;
+            }
             // Pass files through to parent. The local first-frame poster is a blob
             // that this component revokes on the very next line, and it outranks
             // the server cover in the message bubble — so it stops here, and the
@@ -372,7 +387,7 @@ const AiChatInput = memo(
                 window.clearTimeout(textareaScrollHideTimerRef.current);
                 textareaScrollHideTimerRef.current = null;
             }
-        }, [text, disabled, sendDisabled, isStreaming, isParsingMedia, fileUploading, filesParsing, onSend, chatFiles, setText]);
+        }, [text, disabled, sendDisabled, isStreaming, isParsingMedia, fileUploading, filesParsing, fileAccept, onSend, chatFiles, setText, showToast, localize]);
 
         const handleKeyDown = useCallback(
             (e: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -465,20 +480,11 @@ const AiChatInput = memo(
                         "+" menu; keep the picker trigger hidden here. */}
                     {showUpload && (() => {
                         const InputFilesAny = InputFiles as any;
-                        const accept = buildChatAccept({
-                            enableMedia: !!envConfig?.enable_media_upload,
-                            enableEtl4lm: !!bsConfig?.enable_etl4lm,
-                            includeOfd: !isLingsi,
-                            // Task mode also takes data/config/source files: it has a
-                            // workspace and a code interpreter to use them with. Daily
-                            // chat has neither, and would fail the turn on parse.
-                            taskMode,
-                        });
                         return <InputFilesAny
                             ref={inputFilesRef}
                             v={""}
                             showVoice={showVoice}
-                            accepts={accept}
+                            accepts={fileAccept}
                             disabled={filesDisabled}
                             hideTrigger
                             hideList

--- a/src/frontend/client/src/types/chat/config.ts
+++ b/src/frontend/client/src/types/chat/config.ts
@@ -530,6 +530,7 @@ export type BsConfig = {
     displayName: string;
     /** Optional admin-configured intro shown under the name in model pickers. */
     description?: string;
+    visual?: boolean;
   }>;
   voiceInput: {
     enabled: boolean;


### PR DESCRIPTION
The Workbench upload selector currently filters out images unless an OCR parser is configured, even when the selected model itself supports vision.

This change allows PNG, JPG, JPEG, WebP, and GIF uploads when the selected Workbench model is configured with vision. Existing document and OCR behavior stays unchanged.

If an image is already attached and the user switches models, the file is checked again before sending. An unsupported attachment remains visible, but the message is not sent until the user removes it or switches to a compatible model.

The backend already reads these images as data URLs and sends them to the selected model as multimodal image content, so no backend change is needed.