### PR TITLE
feat(auth): 平台管理员运营岗与门户 iframe 白名单

### DIFF
--- a/specs/056-platform-operator-role/acceptance-test-cases.md
+++ b/specs/056-platform-operator-role/acceptance-test-cases.md
@@ -1,0 +1,151 @@
+# 验收测试用例：平台管理员（运营岗）
+
+输入：已确认需求（11 项管理端权限、非超管、入口+接口 403）+ `design.md`。  
+状态：**实现前矩阵，尚未执行，不得勾「已通过」。**  
+规格仅在毕昇 worktree 本地 `specs/056-platform-operator-role/`（`features/` 若 ignore 则不进远程）。
+
+## 夹具约定
+
+| 代号 | 身份 | 做法 |
+|---|---|---|
+| U-anon | 未登录 | 无 Cookie |
+| U-user | 普通用户 | 仅 `DefaultRole`（普通用户），无「平台管理员」、非 `AdminRole` |
+| U-ops | 平台管理员 | `role.role_name` 精确为 `平台管理员`；**无** `AdminRole`；`is_admin()` 必须为 false |
+| U-portal | 门户整页「管理员」 | `role_name=管理员`，非超管 |
+| U-super | 真超管 | `AdminRole=1` 或 `is_global_super` |
+
+U-ops 同时保留普通用户角色，以便前台可登录。验收库：毕昇 `config.yaml` **171 MySQL**。门户 BFF 写配置最终落毕昇 `config`（`key=shougang_portal_config`）。
+
+失败期望一律：**拒绝（401/403 或业务码）且目标表无脏行；响应不回无权正文（配置全文、密钥、他人流水）。**
+
+---
+
+## 需求追踪
+
+| 方案 AC | 覆盖用例 |
+|---|---|
+| 角色名「平台管理员」，租户内不重复 | AT-01, AT-02, AT-03 |
+| 保留名不可改名/删除 | AT-04 |
+| 不是超管 | AT-10, AT-11, AT-32 |
+| 能进 11 项且写穿 | AT-20～AT-30 |
+| 不能进禁止模块 | AT-40～AT-48 |
+| 入口隐藏 + 接口 403 | AT-50～AT-54 |
+| 三 iframe 能开；approval/sys 进不去 | AT-60～AT-63 |
+| 积分/迁移认运营身份而非 `is_admin()` | AT-21, AT-22, AT-10 |
+| 超管不变 | AT-70, AT-71 |
+| 解绑后失效 | AT-80 |
+
+无通知/待办面。无 DDL。DM8：本需求无新 SQL 方言，P2 回归即可。
+
+---
+
+## 跨模块影响（测试必须覆盖的波及，不单测改过的文件）
+
+| 改动点 | 受影响 | 风险 | 测什么 |
+|---|---|---|---|
+| `/user/info` 的 `role` 标签 | 门户会话、`isPortalAdmin` | 自定义角色下发成 `"[id]"` 则整页进不去；误并入 `ADMIN_ROLES` 则全开 | AT-12, AT-50, AT-40 |
+| `require_platform_admin` 扩资格 | 积分管理 + **专家问答违规删除若误扩** | 垂直越权 | AT-21, AT-48 |
+| `require_system_admin` 扩资格 | 迁移全库 | 现网单测会拒绝展示角色名，实现后必须改测 | AT-22, AT-23 |
+| `get_admin_user` **不**扩 | `PUT /shougang-portal/config` | 用户 Cookie 直打可改首页 | AT-11 |
+| BFF `admin_config` 拆 ACL | 问答可写 vs 导航/数据源不可写 | 漏 path 则改禁止配置或泄露密钥 | AT-24, AT-40, AT-45 |
+| `userContext` standalone | 三 iframe vs 审批/系统壳 | 只改路由不够 | AT-60, AT-62 |
+| 角色 WEB_MENU 剥离 | Platform 侧栏 | 误勾 `board`/`sys` 从后台直进 | AT-32 |
+
+---
+
+## 用例矩阵
+
+| ID | P | 层级 | 身份 | 追溯 | 步骤 / 输入 | 期望 HTTP | 期望落库 / 副作用 | 再打一枪 | 现状 |
+|---|---|---|---|---|---|---|---|---|---|
+| AT-01 | P0 | 接口+落库 | U-super | 创建保留名 | 创建 `role_name=平台管理员` | 200，返回该名 | `role` 一行，`role_name` 精确四字 | 再创建同名（任意 department）→ 24002，行数仍 1 | 缺口；`test_role_service.py` 仅有同 scope 重名 |
+| AT-02 | P0 | 接口+落库 | U-super | 与「管理员」不冲突 | 已有 `管理员`，再创建 `平台管理员` | 200 | 两行并存 | `GET` 角色列表两名都在 | 缺口 |
+| AT-03 | P0 | 单元 | — | 精确匹配 | `has_platform_operator_role`：`平台管理员` true；`管理员` / `系统管理员` / `xx平台管理员` / 空格变体 trim 后全等才 true | — | 不写库 | substring 不得 true | 缺口（新 helper） |
+| AT-04 | P1 | 接口+落库 | U-super | 保留名保护 | 对 AT-01 角色改名或删除 | 24004（或方案等价码） | `role_name` 仍为 `平台管理员` | 绑定用户后资格仍在 | 缺口 |
+| AT-10 | P0 | 接口 | U-ops | 不是超管 | `GET /api/v1/user/info` | 200，`role=平台管理员`，`role_names` 含该名；**无** `role=admin` | 不写 `userrole.role_id=1` | 服务端 `is_admin()` false（测依赖或受保护接口） | 缺口；现网自定义角色 `role` 为 id 列表 |
+| AT-11 | P0 | 接口 | U-ops | 不扩 `get_admin_user` | 用户 Cookie `PUT /api/v1/shougang-portal/config` 改 `domains` | 403，无配置正文 | `config.value` 与调用前一致 | 再 GET internal/超管读，导航未变 | 缺口；现 `test_portal_config` 有超管依赖可对照 |
+| AT-12 | P0 | 接口 | U-ops | 门户吃得到身份 | 门户登录后会话 `user.role` 或 `role_names` | 门户 `/api/v1/auth/me`（或现网会话接口）含运营岗 | 门户无角色表 | 刷新会话仍为运营岗 | 缺口；BFF 现只抄 `role` 字符串 |
+| AT-20 | P0 | UI | U-ops | 11 项入口 | 打开 `/admin` | 200 页 | 侧栏仅 11 项中的 1–10；有迁移入口（第 11 项） | 禁止项菜单节点不存在 | 缺口；现 `NAV_GROUPS` 全渲染。`adminAccess.test.ts` 需扩展且 **不得** 把该名并入 `isPortalAdmin` |
+| AT-21 | P0 | 接口+落库 | U-ops | 2 积分管理 | `POST /api/v1/points/admin/adjust` 合法调账 | 200 | `user_point_log` 新增对应 `delta`；账户余额一致 | 再 GET `/admin/users/{id}/detail` 与表一致；普通用户打同一接口 18201 且 log 行数不变 | 缺口；现闸门只认超管。`test_department_org_level.py` 需改夹具 |
+| AT-22 | P0 | 接口+落库 | U-ops | 11 迁移全库 | `GET /knowledge/migrations/spaces` 能列出非本人库；`POST /batches` 建批 | 200 | `knowledge_migration_batch` 一行，操作者为 U-ops | 再 GET 该 `batch_no` 仍在；U-user 建批 403 且表无新行 | 缺口；`test_knowledge_migration_auth.py` **现拒绝展示角色**，实现后改为运营岗通过、账号名旁路仍拒 |
+| AT-23 | P0 | 接口 | U-ops | 迁移全库列表 | spaces 含无个人权限的库（与超管同一列表口径） | 200，可选库不按个人 ReBAC 收窄 | 不写 | U-user 403 | 缺口 |
+| AT-24 | P0 | 接口+落库 | U-ops | 3 问答配置 | 门户 `POST /api/v1/admin/config/qa` 改欢迎语 | 200 | 毕昇 `config` JSON 内 `qa` 已更新；`domains` 未变 | 再 GET `/qa` 与库一致；U-user 403 且 `qa` 回滚/未变 | 缺口；扩 `test_admin_config_api.py` |
+| AT-25 | P0 | 接口+落库 | U-ops | 4 写作模板 | `POST /qa` 改 `templates`（与问答同一文档） | 200 | `config` 模板数组变更 | 再读一致；禁止 path 仍 403 | 可与 AT-24 同文件两条 |
+| AT-26 | P0 | 接口+落库 | U-ops | 5 应用配置 | `POST /admin/config/agent-config` | 200 | `config` 内 agent 变更 | 再 GET 一致 | 缺口 |
+| AT-27 | P0 | 接口+落库 | U-ops | 6 知识分类 | `POST /admin/config/document-types` | 200 | `config` 内 document_types 变更 | 再 GET 一致 | 缺口 |
+| AT-28 | P0 | 接口+落库 | U-ops | 7 水印 | `POST /admin/config/watermark` | 200 | `config` 内 watermark 变更 | 再 GET 一致 | 缺口 |
+| AT-29 | P0 | 接口+落库 | U-ops | 8 字典 | 毕昇 `POST /api/v1/dictoption/create` | 200 | `system_dictionary` 新行 | 再 GET by type 见该行；U-user 19102 且无新行 | 缺口；`test_dictionary_router.py` 扩管理员夹具 |
+| AT-30 | P1 | 接口 | U-ops | 1/9/10 iframe API | 看板列表（等同超管可见范围）；敏感词 GET/PUT；tag-console 管理接口各一成功 | 200 | 看板/策略/标签按现超管语义落库或可读 | U-user 未授权 | 缺口。PUT 敏感词须查 `sensitive_word_policy` |
+| AT-40 | P0 | 接口+落库 | U-ops | 禁止：首页导航 | `POST /admin/config/domains` | 403，无 domains 正文 | `config` 内 domains 不变 | 再 POST 一次仍不变 | 缺口 |
+| AT-41 | P0 | 接口+落库 | U-ops | 禁止：推荐/搜索/轮播/展示 | `POST` recommendation、search、banners、display 各一 | 403 | 对应 JSON 块不变 | 再读 | 缺口（可 parametrize） |
+| AT-42 | P0 | 接口+落库 | U-ops | 禁止：课程 | 现网课程写接口 | 403 | 课程表行数不变 | 再写仍拒 | 缺口 |
+| AT-43 | P0 | 接口 | U-ops | 禁止：自动发布/科室绑定/业务域 | 对应 POST/DELETE | 403 | 绑定表/规则不变 | 再打 | 缺口 |
+| AT-44 | P0 | 接口 | U-ops | 禁止：回收站 | `/api/v1/...` 回收站写 | 403 | 回收记录不变 | — | 缺口 |
+| AT-45 | P0 | 接口 | U-ops | 禁止：数据源密钥 | `GET /admin/config/bisheng`、`GET /rest-auth`、`GET /admin/config` 全量 | 403，body 无密码/token | 不写 | 超管 GET 仍有配置（脱敏规则同现网） | 缺口 **P0 防泄露** |
+| AT-46 | P0 | 接口 | U-ops | 禁止：站点/集成/统一认证 | 对应 GET/POST | 403 | 配置不变 | — | 缺口 |
+| AT-47 | P0 | 接口 | U-ops | 禁止：审批/系统 standalone 后端 | 审批、系统配置现网超管 API | 403 | 不写 | 不扩 `can_platform_operate` 到这些模块 | 缺口 |
+| AT-48 | P0 | 接口+UI | U-ops | 禁止：专家问答违规删除 | 调现网超管扣分/删问接口；UI 无违规删按钮 | 403 或 18201（保持超管码） | 问答/积分表无违规删产生的行 | `is_platform_super_admin` 仍不含运营岗 | 缺口。现 `adminAccess.test.ts` 超管判定不得把 U-ops 算进去 |
+| AT-50 | P0 | 单元/UI | U-ops | `isPortalAdmin` 不含该名 | `isPortalAdmin({role:'平台管理员'})===false`；`canEnterAdminShell===true` | — | — | 「管理员」仍 true | 缺口；改 `adminAccess.test.ts` |
+| AT-51 | P0 | UI | U-ops | 直链禁止 section | `/admin?section=site`（或 domains） | 无权限模块页 | 不请求禁止 API（或请求被 403） | 侧栏仍无该项 | 缺口 |
+| AT-52 | P0 | UI | U-ops | Header | 有「知识管理后台」「迁移记录」；无回收站；无毕昇管理后台外链 | — | — | U-user 无后台/迁移 | 缺口；改 Header 源码断言 + `knowledgeMigrationAccess.test.ts` |
+| AT-53 | P0 | UI | U-user | 整页仍拒 | `/admin`、`/knowledge-migrations` | 无权限 | 不写 | 登录用户前台仍可用 | 现网已有，保持 |
+| AT-54 | P0 | UI | U-anon | 未登录 | `/admin` | 去登录 | 不写 | — | 现网已有 |
+| AT-60 | P0 | UI+接口 | U-ops | iframe 三页能开 | 打开三条 `/platform/standalone/{dashboard,knowledge-tag-library,content-security}` | 页能渲染；内接口 200 | 见 AT-30 | 无管理端 WEB_MENU 时也不得踢到 workspace | 缺口；Platform `userContext` |
+| AT-62 | P0 | UI | U-ops | approval/sys 进不去 | 打开 `/platform/standalone/approval`、`/sys`、有壳 `/dashboard` | 403 或踢走 workspace | 不加载审批/系统页 | 后端仍 403 | 缺口 |
+| AT-63 | P1 | UI | U-ops | 不从毕昇侧栏进 | 登录 Platform 非 standalone | 踢走 workspace / 无管理侧栏 | `roleaccess` 无 board/sys | 有 shell 的 `/dashboard` 进不去 | 缺口 |
+| AT-70 | P0 | 接口+落库 | U-super | 超管积分/迁移/配置仍开 | 调账、建迁移、POST domains、GET bisheng | 200 | 与现网一致落库 | 再读一致 | 现网覆盖，回归勿破 |
+| AT-71 | P0 | UI | U-super / U-portal | 整页管理员菜单全开 | `/admin` 全部 NAV_GROUPS | 开 | — | 回收站、外链仍开（U-portal 按现网） | 现网；加回归断言「未误删整页资格」 |
+| AT-80 | P0 | 接口+落库 | U-ops→解绑 | 解绑失效 | 超管从 `userrole` 去掉该角色后，原用户调积分 adjust、POST /qa | 18201 / 403 | 无新 log、`config.qa` 不变 | `/user/info.role` 不再是平台管理员 | 缺口 |
+| AT-81 | P1 | 接口 | U-ops+U-super 同一人 | 超管优先 | 同时绑 AdminRole 与平台管理员 | `/user/info.role=admin` | 禁止模块也可写（超管） | `is_admin()` true | 缺口 |
+| AT-90 | P2 | 单元 | — | WEB_MENU 剥离 | 保存该角色菜单含 `board`,`sys` | 200，返回菜单无管理端 key | `roleaccess` 无这些 third_id | 再读 WEB_MENU | 缺口 |
+| AT-91 | P2 | 单元 | — | 不把该名加入 ADMIN_ROLES | 源码/单测：`ADMIN_ROLES` 仍三元；BFF `is_portal_admin_role('平台管理员')` false | — | — | — | 缺口 |
+
+---
+
+## 11 项与用例对照（防漏模块）
+
+| # | 模块 | 成功用例 | 失败对照 |
+|---|---|---|---|
+| 1 | 数据看板 | AT-30, AT-60 | AT-62 有壳后台 |
+| 2 | 积分管理 | AT-21 | AT-48 专家问答违规删；U-user 18201 |
+| 3 | 问答配置 | AT-24 | AT-40 导航 |
+| 4 | 写作模板 | AT-25 | 同左 |
+| 5 | 应用配置 | AT-26 | AT-41 |
+| 6 | 知识分类 | AT-27 | AT-41 |
+| 7 | 水印设置 | AT-28 | AT-45 数据源 |
+| 8 | 字典配置 | AT-29 | U-user 19102 |
+| 9 | 内容与安全审查 | AT-30, AT-60 | AT-62 |
+| 10 | 标签管理 | AT-30, AT-60 | AT-62 |
+| 11 | 迁移记录/新建迁移 | AT-22, AT-23, AT-52 | U-user 403；解绑 AT-80 |
+
+---
+
+## 建议测试文件（实现阶段再写，本步不落测试代码）
+
+**毕昇（新文件，勿追加巨石）：**
+
+- `test/user/test_platform_operator_identity.py` — AT-03, AT-10, AT-11, AT-81
+- `test/role/test_platform_operator_reserved_name.py` — AT-01, AT-02, AT-04, AT-90
+- `test/points/test_platform_operator_points_admin.py` — AT-21, AT-80（调账+查表）
+- `test/knowledge/test_platform_operator_migration.py` — AT-22, AT-23；并改 `test_knowledge_migration_auth.py`
+- `test/dictionary/test_platform_operator_dictionary.py` — AT-29
+- `test/workstation/test_platform_operator_tag_and_sensitive.py` — AT-30 中标签/敏感词
+- Platform：`src/frontend/platform/src/test/` standalone 白名单 — AT-60, AT-62
+
+**门户：**
+
+- 扩 `frontend/tests/adminAccess.test.ts`、`knowledgeMigrationAccess.test.ts` — AT-50, AT-52
+- 扩 `backend/tests/test_admin_config_api.py`（及 qa/agent 分测）— AT-24～AT-28, AT-40～AT-46
+- 课程/回收站拒绝 — AT-42, AT-44
+
+**UI 手测（无稳定 iframe E2E 时书面降级，不把未跑的勾完成）：** AT-20, AT-51, AT-60, AT-62, AT-63, AT-71。
+
+---
+
+## 明确不测（非目标）
+
+- 种子插入「平台管理员」角色行。
+- 按库收窄迁移。
+- 公开发现开关、用户角色管理、OpenFGA 新 relation。
+- 性能压测（现 `perf_admin_write.py` 不改口径）。
+
+下一步：用例确认后拆 `tasks.md`，再写代码。P0 写库条必须 171 MySQL 流转，mock 仓储不算过门。

--- a/specs/056-platform-operator-role/design.md
+++ b/specs/056-platform-operator-role/design.md
@@ -1,0 +1,354 @@
+# 设计说明：可复用角色「平台管理员」（运营岗，非超管）
+
+跨仓（毕昇写模型 + 门户消费）。需求已确认后再实现；本文是实现权威。
+
+## 1. 目标、非目标、取舍
+
+### 目标
+
+新增可复用 RBAC 角色，显示名固定为 **`平台管理员`**。持有该角色的用户：
+
+- 前台当普通登录用户使用；
+- 拥有门户管理端下列 **11 项**模块的入口与写权限（见下表）；迁移为全库；
+- 不能进门户管理整组、课程、审批、系统管理，也不能从毕昇管理后台直进看板/标签/审查；
+- 积分规则/调账/字典等写接口放行，但 **`is_admin()` 仍为 false**（不是超管）。
+
+真超管（RBAC `AdminRole=1` / `is_global_super`）行为不变。
+
+### 平台管理员拥有的管理端模块（11 项）
+
+这 11 项是允许名单的完整集合：菜单要显示，对应接口要放行。不在此列的管理端模块一律不能进（入口隐藏 + 403）。
+
+1. **数据看板**（`platformDashboard`）— 门户 iframe `/platform/standalone/dashboard`
+2. **积分管理**（`points`）— 改规则、调账、扣分、运营查询；不含专家问答违规删除
+3. **问答配置**（`qa`）
+4. **写作模板**（`qaTemplates`）
+5. **应用配置**（`agentConfig`）
+6. **知识分类**（`documentTypes`）
+7. **水印设置**（`watermark`）
+8. **字典配置**（`dictConfig`）
+9. **内容与安全审查**（`platformContentSecurity`）— 门户 iframe `/platform/standalone/content-security`
+10. **标签管理**（`platformTagLibrary`）— 门户 iframe `/platform/standalone/knowledge-tag-library`
+11. **迁移记录 / 新建迁移** — Header 入口 + 路由 `/knowledge-migrations`；全库；不是 `NAV_GROUPS` 的 nav key，资格用 `canViewMigrations`
+
+不在这 11 项内、平台管理员不能进的管理端模块：首页导航/分区/轮播/展示/搜索/知识推荐策略、课程管理、业务域映射绑定、自动发布、科室知识库绑定、审批管理、系统管理（站点/数据源/集成/统一认证/审计/系统配置）、回收站、毕昇管理后台外链、公开发现开关、用户/角色、专家问答违规删除。
+
+### 非目标（本期不做）
+
+- 不新建门户角色表、不新增 `role` 列、不做 Alembic 插角色种子（超管在角色管理创建一条即可）。
+- 不把「平台管理员」加入现有整页白名单 `{管理员, 系统管理员, admin}`。
+- 不给该角色毕昇管理端 WEB_MENU；不开放 `LoginUser.get_admin_user()` / `get_tenant_admin_user()` 给该角色。
+- 不改公开发现开关、回收站、专家问答违规删除、用户/角色管理、全库知识空间管理。
+- 不做按知识库收窄的迁移范围（已拍板：与超管一样全库）。
+- 不引入 OpenFGA 新 relation；不改多租户注入。
+
+### 关键决策
+
+| 决策 | 选定 | 否决 | 原因 | 何时可推翻 |
+|---|---|---|---|---|
+| 身份载体 | 毕昇 `role.role_name` 精确等于 `平台管理员` | 账号白名单；把人设成 `AdminRole`；门户独立角色表 | 需求是可复用角色；`is_admin()` 会打开全部超管能力 | 要稳定 ID 不随改名失效时，再加 `role_type`/`code` 列（需 DDL） |
+| 鉴权形状 | 入口隐藏 + 对应接口 403 | 只藏菜单 | 用户已选 B | 无 |
+| 门户 `/admin` | 模块级允许名单，与整页 `isPortalAdmin` 拆开 | 把该名塞进 `ADMIN_ROLES` | 塞进去会打开门户管理/课程/审批/系统管理 | 无 |
+| 内嵌三页 | 只放行 `/standalone/{dashboard,knowledge-tag-library,content-security}` | 给管理端 WEB_MENU；放行全部 `/standalone/*` | 只要门户 iframe；`/standalone/approval` 与 `/standalone/sys` 必须进不去 | 产品允许从毕昇后台进这三页时 |
+| 配置写路径 | 门户文档（问答/模板/应用/分类/水印）在 **BFF 按 path 鉴权**，下游仍用服务账号调毕昇 `get_admin_user` | 把 `get_admin_user` 扩成运营身份 | 扩了之后用户可直打毕昇 `PUT /shougang-portal/config` 改首页导航等 | BFF 不再用服务账号写配置时必须重做 |
+| 积分/迁移/字典/看板/标签/敏感词 | 毕昇服务认「超管 ∪ 平台管理员」 | 继续只认 `is_admin()` | 这些接口走用户 Cookie（`/workspace/api`），不经过 BFF 整页闸门 | 无 |
+| 角色名唯一 | 同一租户内该保留名全局唯一（跨 `role_type`/`department_id`）；禁止改名/删除该名角色 | 只靠现有 scope 唯一约束 | 现网唯一键是 `(tenant_id, role_type, role_name, department_scope_key)`，部门范围下可再插同名 | 产品允许同名部门角色时 |
+
+---
+
+## 2. 术语对照（中文名 ≠ 超管）
+
+| 产品称呼 | 代码身份 | 判定 |
+|---|---|---|
+| 系统超管 / 真超管 | RBAC `AdminRole`（`role.id=1`）或 FGA `is_global_super` | `LoginUser.is_admin()` 或 `is_global_super`。`/user/info.role` 为 `admin` |
+| 门户整页管理员 | 角色名 `管理员` / `系统管理员`，或账号 `admin` | 门户 `isPortalAdmin` / BFF `require_admin_session`。**不包含**「平台管理员」 |
+| 系统管理员（迁移 Header 旧逻辑） | `role ∈ {系统管理员, admin}` | 现 `isSystemAdministrator`。本期改为：超管 ∪ 平台管理员 可进迁移 |
+| **平台管理员（运营岗）** | `role.role_name == "平台管理员"` | 下文 `has_platform_operator_role`。`is_admin()` 必须仍为 false |
+| 运营写资格 | 超管 ∪ 平台管理员 | `can_platform_operate`。只用于允许名单内的模块，不用于审批/系统管理 |
+
+常量（唯一事实源，两仓拷贝同一字面量）：
+
+```text
+PLATFORM_OPERATOR_ROLE_NAME = "平台管理员"
+```
+
+匹配：去首尾空白后 **全等**。大小写敏感（中文无 case）。不得用 `includes("管理员")`。
+
+---
+
+## 3. 持久化
+
+无 DDL、无字段增删改、不做迁移。不涉及对象存储新桶。
+
+### 3.1 身份（毕昇）
+
+| 表 | 角色 | 关键已有字段 | 结构 |
+|---|---|---|---|
+| `role` | 读；超管创建/绑菜单时写 | `id`, `role_name`, `role_type`, `department_id`, `tenant_id`, `remark` | 无变更 |
+| `userrole` | 读；超管给人绑角色时写 | `user_id`, `role_id`, `tenant_id` | 无变更 |
+| `roleaccess` | 旁路：保存该角色 WEB_MENU 时读/写并 **剥离管理端 key** | `role_id`, `third_id`, `type`（WEB_MENU=99） | 无变更 |
+| `user` | 旁路读（会话） | `user_id`, `user_name` | 无变更 |
+
+运营资格 **不** 写入 JWT。每次请求 `init_login_user` 已装 `role_names`（现网已有），用列表判定即可。改名/解绑下一请求生效。
+
+保留名规则（服务层，非新唯一索引）：
+
+- 创建或改名目标为 `平台管理员`：该 `tenant_id` 下已有任一行同名 → `RoleNameDuplicateError`（24002）。
+- 已有 `role_name=平台管理员` 的行：禁止改名、禁止删除（复用 `RoleBuiltinProtectedError` 24004 或同语义新码，见契约）。可改 remark、可改 WEB_MENU（保存时剥离管理端）、可继续绑人。
+
+超管操作：在角色管理 **创建一条** 该名角色，给账号绑定；账号同时保留「普通用户」(`DefaultRole=2`) 以便前台/工作台。本期不自动 insert。
+
+### 3.2 业务写（沿用现表，资格放宽）
+
+| 表 | 角色 | 关键字段 | 结构 |
+|---|---|---|---|
+| `user_point_account` / `user_point_log` / `point_rule` / `point_copy` / `point_rank_snapshot` / `point_favorite_tier_award` / `point_pending_deduct` / `point_sync_outbox` | 积分管理读写，与现超管相同 | 现有规则/调账/流水列 | 无变更 |
+| `knowledge_migration_batch` / `knowledge_migration_unit` / `knowledge_migration_file` / `knowledge_migration_attempt` | 迁移全库读写，与现超管相同 | 批次/单元/状态 | 无变更 |
+| `system_dictionary` | 字典配置写 | 现有字典列 | 无变更 |
+| `dashboard` / `dashboard_component` / `dashboard_default` | 数据看板 iframe 内与超管同等列表/写 | 现有看板列 | 无变更 |
+| `sensitive_word_policy` | 内容审查策略读写 | 现有策略列 | 无变更 |
+| 标签库相关现表（tag console 已用） | 标签管理 iframe 读写 | 现有标签列 | 无变更 |
+| `config`（`key=shougang_portal_config` 或 `shougang_portal_config:t:{tenant_id}`） | 问答/模板/应用配置/知识分类/水印：BFF 合并写；运营身份 **不能** 直打毕昇 PUT 全量 | JSON 聚合 | 无变更 |
+
+门户 BFF 无独立角色表。`RemotePortalAdminConfigStore` 仍代理到毕昇 `config`。
+
+### 3.3 零落库面
+
+菜单显隐、Header、iframe 白名单、`userContext` 对 standalone 的放行：纯鉴权/前端，不落库。
+
+---
+
+## 4. 对外契约
+
+### 4.1 身份下发（一份源：`GET /api/v1/user/info`）
+
+现网 `_user_info_role_label`：超管 → `admin`；否则若 `role_names` 命中 `{管理员, 系统管理员, admin}` 则下发该名；否则下发 `str(role_ids)`。自定义「平台管理员」今天会变成 `"[3]"`，门户认不到。
+
+改后优先级：
+
+1. `AdminRole` → `role="admin"`（不变）。
+2. 否则 `role_names` 含精确 `平台管理员` → `role="平台管理员"`。
+3. 否则原门户整页名逻辑。
+4. 否则保持现网。
+
+同时在 `UserRead` **增加** `role_names: list[str]`（已有列的回显，不是新表字段）。门户会话同时存 `role` 与 `role_names`。判定运营岗：`role === "平台管理员"` **或** `role_names` 含该名。
+
+持有超管 + 平台管理员：仍下发 `admin`，走超管全量。持有 `管理员` + `平台管理员`：走整页管理员（不降级）。
+
+### 4.2 毕昇：单一资格函数
+
+模块：`user`（`LoginUser` / 小 helper）。`common/` 不引用 domain。
+
+```text
+has_platform_operator_role(user) :=
+  PLATFORM_OPERATOR_ROLE_NAME in user.role_names   # 精确
+
+can_platform_operate(user) :=
+  user.is_admin() OR user.is_global_super OR has_platform_operator_role(user)
+```
+
+禁止把 `has_platform_operator_role` 写进 `is_admin()`。
+
+**扩资格（`can_platform_operate`）的现网闸门：**
+
+| 现网闸门 | 模块 | 失败码 |
+|---|---|---|
+| `points_auth.require_platform_admin`（今日 = 超管） | 全部 `/api/v1/points/admin/*` 读/写 | 18201 `无积分管理权限` |
+| `require_system_admin` | `/api/v1/knowledge/migrations/*` | 继续 HTTP 403，detail 不泄露无权正文 |
+| `DictionaryService._ensure_admin` | `/api/v1/dictoption` 写 | 19102 |
+| `DashboardService` 中 `is_admin()` 列表/实时数据集写 | `/api/v1/dashboard*` | 现网未授权错误 |
+| `TagConsoleService._ensure_can_manage_tags` | `/api/v1/.../tag-console*` | 10712 |
+| `UserPayload.get_tenant_admin_user` 用在敏感词策略 | `GET/PUT /api/v1/sensitive-word-policies/{business_type}` | 改为 `get_login_user` + `can_platform_operate`，失败用现网未授权，**不**扩大 `get_tenant_admin_user` |
+
+**明确不扩：**
+
+- `LoginUser.get_admin_user` / `get_admin_user_from_ws`（含 `PUT /api/v1/shougang-portal/config`）。
+- `get_tenant_admin_user` 的通用语义（LLM 等）。
+- 专家问答违规删除：仍 `is_platform_super_admin`（超管）。积分管理页内的调账/扣分走扩后的 `require_platform_admin`。
+- Client 公开发现开关、知识空间超管 API、审批、系统配置、用户角色。
+
+积分函数建议拆名以免误导：`is_platform_super_admin` 保持超管；写积分管理改调 `can_platform_operate`。对外错误码 18201 不变。
+
+### 4.3 门户 BFF 模块 ACL
+
+现网 `require_admin_session` = `is_portal_admin_role(role) OR account==admin`。**不要**把「平台管理员」加入 `ADMIN_ROLES`。
+
+新增：
+
+```text
+is_platform_operator(session) := role 或 role_names 精确匹配「平台管理员」
+can_enter_admin_shell := is_portal_admin OR is_platform_operator
+```
+
+按 path 鉴权（router 级整组 `Depends(require_admin_session)` 拆掉）：
+
+| 资格 | 路径（均在 `/api/v1/admin/config` 下除非注明） |
+|---|---|
+| 仅整页管理员 | `GET/POST ""`（全量聚合）、`/domains`、`/sections`、`/category-cards`、`/banners`、`/display`、`/search*`、`/recommendation`、`/apps`（若仅门户管理用则仅超管；应用配置走 `/agent-config`）、`/auto-publish-rules`、`/dept-knowledge-binding*`、`/site`、`/bisheng`、`/integrations`、`/unified-auth`、`/rest-auth`、`/space-options`、`/spaces/*`（业务域绑库用） |
+| 整页管理员 ∪ 平台管理员 | `/qa`、`/qa/model-options`、`/agent-config`、`/agent-config/workflow-options`、`/document-types`、`/watermark` |
+| 仅整页管理员（其它路由） | `course.py` 写接口、`knowledge_recycle.py` 全部 |
+| 上传 | `admin_upload`：运营岗需要水印等素材，允许上传；真正改配置仍受上面 POST 限制 |
+
+`GET /api/v1/admin/config`（全量）：运营岗 **403**（现 `AdminPage.loadConfig` 会拉全量 + `/bisheng` + `/rest-auth`，后两者含密钥）。前端改为：运营岗只拉允许的分文档；整页管理员保持现网。BFF 即使被直打全量也 403。
+
+失败：HTTP 403，`detail` 固定「无权限访问知识管理后台」，不回配置正文。
+
+课程/回收站/站点：保持 `require_admin_session`。
+
+### 4.4 门户前端入口
+
+| 入口 | 超管 / 整页管理员 | 平台管理员 | 普通用户 |
+|---|---|---|---|
+| Header「知识管理后台」→ `/admin` | 开 | 开 | 关 |
+| `/admin` 壳 | 开 | 开（仅上表 11 项） | 登录去登录页；已登录无权限页 |
+| 上表第 1–10 项菜单 | 开 | 开 | — |
+| 门户管理 / 课程 / 业务域 / 自动发布 / 科室绑定 / 审批 / 系统管理 | 开 | **不渲染**；`?section=` 直链无权限页，不发对应 API | — |
+| 上表第 11 项：Header 迁移记录、`/knowledge-migrations`、页内新建迁移 | 开（现仅系统管理员） | **开（全库）** | 关 |
+| Header 回收站 | 开 | **关** | 关 |
+| 外链「毕昇管理后台」 | 开 | **关** | 关 |
+| 专家问答违规删除 | 仅超管 | 关 | 关 |
+
+第 1–10 项 nav key 与 `AdminPage.NAV_GROUPS` 一致。第 11 项迁移不是 nav key，走 `canViewMigrations := isSystemAdministrator OR isPlatformOperator`。完整列表以 §「平台管理员拥有的管理端模块（11 项）」为准。
+
+无权限文案：区分「仅管理员…」与「无权限访问该模块」，不要写「请用超管账号」。
+
+### 4.5 iframe / standalone
+
+嵌入 URL（不变）：
+
+- `/platform/standalone/dashboard`
+- `/platform/standalone/knowledge-tag-library`
+- `/platform/standalone/content-security`
+
+Platform `userContext` 现网：无管理端 WEB_MENU 则 **整站**（含 standalone）踢到 workspace。路由注释说 standalone 不按 `web_menu` 滤，但 context 未排除。
+
+改后：
+
+1. 路径属于 **运营白名单** 三条（含其子路径如 `/standalone/dashboard/:id` 仅当从看板进入的编辑态；**不包括** `/standalone/approval`、`/standalone/sys`、`/standalone/log`）：跳过 `canAccessPlatform` 踢走；仍要求已登录。
+2. 其它 `/platform/*`（含 `/admin`、`/dashboard` 有壳、`/sys`）：平台管理员仍踢到 workspace（或 403），满足「不许从管理后台直进」。
+3. 白名单外的 `/standalone/approval`、`/standalone/sys`、`/standalone/log`：前端进 403 页，不加载审批/系统页；后端审批/系统 API 保持超管闸门（不扩 `can_platform_operate`）。
+
+iframe 内接口走用户毕昇 Cookie（与现超管嵌页相同）。本地联调依赖现有 `/platform` 代理与 Cookie 域，不另开 SSO。
+
+### 4.6 角色管理契约
+
+创建/更新角色名：保留名冲突 → 24002。删除或改掉「平台管理员」这一行 → 24004（或等价）。保存 WEB_MENU：若 `role_name` 为保留名，服务端丢掉管理端 key（至少：`admin`,`backend`,`board`,`model`,`log`,`knowledge`,`build`,`evaluation`,`system_config`,`mark_task`,`sys` 及现网 `adminMenuKeys` 同类），只保留工作台类。超管误勾管理端菜单也不能从 Platform 进后台。
+
+---
+
+## 5. 流程与状态
+
+无新状态机。资格是请求时计算，不是资源状态。
+
+### 主路径
+
+1. 超管创建角色 `平台管理员`（可空菜单或仅工作台）→ 写 `role`。
+2. 超管把用户绑上该角色（保留普通用户）→ 写 `userrole`。
+3. 用户登录门户 → BFF 调 `/user/info` → 会话 `role=平台管理员`。
+4. Header 出现后台与迁移；`/admin` 只渲染允许名单。
+5. 点积分/问答等：门户或 `/workspace/api` 调对应写接口 → `can_platform_operate` 或 BFF 模块 ACL 通过 → 写第 3 节表。
+6. 点数据看板/标签/审查：iframe 白名单 standalone → 页内 API 同样 `can_platform_operate`。
+7. 登出 / 被解绑：下一请求无该 `role_name`，入口与接口同时失效。
+
+### 失败
+
+| 场景 | 系统停在 | 脏数据 |
+|---|---|---|
+| 未绑角色打 `/admin` | 无权限页；BFF 403 | 无 |
+| 运营岗直链 `?section=site` 或 POST `/admin/config/domains` | UI 无权限 + 403；`config` 行不变 | 无 |
+| 运营岗打 `PUT /api/v1/shougang-portal/config`（用户 Cookie） | `get_admin_user` 403 | 无 |
+| 运营岗改 iframe 为 `/standalone/approval` | 前端 403；审批 API 仍超管拒绝 | 无 |
+| 运营岗打积分/迁移（未扩资格的旧代码） | 18201 / HTTP 403 | 无（验收必须扩） |
+| 并发创建第二条「平台管理员」 | 24002 或 DB unique | 无第二行（同 scope）；跨 scope 由服务层拦截 |
+| 超管改名该角色 | 24004，名称仍在 | 资格不会静默消失 |
+| 只藏菜单未拦 BFF | 视为实现失败 | 配置可能被改 — 验收必须打禁止 path |
+
+积分/迁移写路径与现超管相同（账本行锁、批次状态机）。运营岗不引入新并发语义。内存 SQLite 测不到的 FOR UPDATE 仍在 171 MySQL 流转测。
+
+### 权限矩阵（AC 可测）
+
+| 身份 | `/admin` 允许名单 | 禁止模块 API | 积分写 | 迁移全库 | 三 iframe | `/standalone/sys` | 回收站 | 专家问答违规删 | `is_admin()` |
+|---|---|---|---|---|---|---|---|---|---|
+| 未登录 | 去登录 | 401 | 401 | 401 | 登录 | 登录 | 登录 | — | — |
+| 普通用户 | 无权限页 | 403 | 18201 | 403 | 踢走/403 | 403 | 403 | 关 | false |
+| 平台管理员 | 开 | 403 | 200 且落库 | 200 且落库 | 开且接口 200 | 403 | 403 | 关 | **false** |
+| 整页「管理员」 | 全开 | 200 | 视其是否超管 | 视 Header 旧规则；本期不收窄真超管 | 开 | 开 | 开 | 否（非超管） | false |
+| 超管 `admin` | 全开 | 200 | 200 | 200 | 开 | 开 | 开 | 开 | true |
+
+---
+
+## 6. 模块所有权
+
+| 规则 | 所有者 | 只调用方 |
+|---|---|---|
+| 角色名是否为运营岗 | 毕昇 `user`/`role` | 积分、迁移、字典、看板、tag console、敏感词、门户 BFF（经 `/user/info`） |
+| 门户模块 path ACL | 门户 `backend/app/api/dependencies.py` + `admin_config` 分路 | 前端只展示 |
+| WEB_MENU 剥离 | 毕昇 `RoleService` | Platform 侧栏 |
+| standalone 白名单 | Platform `userContext` + `routes/standalone` | 门户 iframe src |
+| 门户配置聚合写 | 毕昇 `ShougangPortalConfigService`（仍仅 `get_admin_user`） | 门户 BFF 服务账号 |
+
+调用链不跳层：毕昇 Router → Endpoint → Service → Repository；门户 routes → services → clients。
+
+禁止：前端用 `role` 字符串当唯一鉴权；禁止积分模块自己 parse 角色名（调统一 helper）。
+
+---
+
+## 7. 跨边界影响（blast radius）
+
+**不变量：** 仅当用户持有精确角色名「平台管理员」或超管时，才获得运营写资格；该资格 **不等于** `is_admin()`，也不能打开禁止模块。
+
+**波及面：**
+
+- 门户 `/admin` 菜单与 `loadConfig`（全量配置 + 数据源密钥）。
+- BFF `/api/v1/admin/config/*`、课程、回收站、上传。
+- Header 后台/迁移/回收站/外链。
+- 毕昇 `/user/info` 的 `role` 语义（自定义角色不再只有 id 列表）。
+- 积分管理全部 admin API；迁移全部 API（全库列表与写）。
+- 字典写；看板列表/写；tag console；敏感词策略。
+- Platform 登录后跳转（standalone 例外）。
+- 角色创建/改名/删除/WEB_MENU。
+
+**例外：** 真超管、现网「管理员/系统管理员」整页能力不收窄。前台知识/问答/积分查看不变。未登录首页不变。
+
+**可行性：** 能改干净。无 DDL。依赖现网 `role_names` 已在 `LoginUser` 上。工作量：跨两仓中等（鉴权点多，业务逻辑少）。
+
+**风险：高。** 漏改一处 `is_admin()` 则入口开、接口 403；误扩 `get_admin_user` 或 `ADMIN_ROLES` 则首页配置/审批可被改；`GET` 全量配置给运营岗会泄露数据源密码。回滚 = 回代码，库中角色行可留着（无资格函数即失效）。
+
+**建议验证：** 用非超管账号只绑「平台管理员」：允许名单写穿并查表；禁止 path 403 且 `config`/课程表不变；三 iframe 能开；改 URL 进 approval/sys 失败；`is_admin()` 为 false；超管回归全开。
+
+**建议延后：** 角色稳定 `code` 列；自动种子角色；把门户 ACL 做成可配置表。
+
+---
+
+## 8. 迁移、坑、后续
+
+- 存量：无角色则无人获得新资格。上线后超管创建并绑人。
+- 回滚代码后，已创建的「平台管理员」行仍在，只是门户又进不去、写接口又 403。
+- 坑 1：`AdminPage.loadConfig` 并行拉 `/admin/config`、`/bisheng`、`/rest-auth`。运营岗必须跳过后两路，且全量 GET 403。
+- 坑 2：积分、迁移走 `/workspace/api`，**不**走门户 `require_admin_session`。只改门户菜单不够。
+- 坑 3：`require_platform_admin` 今日名字像运营岗，实际是超管。必须拆，避免专家问答违规删除被一起放开。
+- 坑 4：`「平台管理员」` 以「管理员」结尾，但现网是 Set 全等，不会误判；禁止改成 substring。
+- 坑 5：standalone 路由不过 web_menu，但 `userContext` 会踢人；只改路由表不够。
+- 坑 6：BFF 写门户配置用服务账号，毕昇侧仍是超管写 `config`。BFF 漏 ACL = 运营岗可改禁止文档。
+- 短板：身份绑显示名，超管若绕过 API 直接改库 `role_name`，资格会漂。保留名只拦正规 API。
+- 这版不做种子行：避免多环境插出第二条。
+
+---
+
+## 9. AC 可追溯
+
+| AC | 存储 | 契约 | 流程 |
+|---|---|---|---|
+| 角色名叫「平台管理员」，租户内不重复、不与整页管理员名冲突 | `role.role_name` | 创建/改名 24002；精确匹配 | 超管创建一条 |
+| 不能改名/删除该保留名角色 | `role` | 24004 | 改名失败，资格仍在 |
+| 不是超管（无超管入口） | 不写 AdminRole | `is_admin()` false；`get_admin_user` 403 | 管理后台有壳页踢走 |
+| 能进 11 项 + 迁移全库 | 积分/迁移/字典/`config` 分文档 | 模块 ACL + `can_platform_operate` | 写穿查表 |
+| 不能进门户管理/课程/审批/系统管理 | `config` 禁止文档不变 | 403 | 直链+POST |
+| 入口隐藏 + 接口 403 | — | BFF/毕昇 | 菜单不渲染且 API 拒 |
+| 三 iframe 能开 | dashboard/tag/sensitive 表 | standalone 白名单 + 各 API | 嵌页可读写 |
+| approval/sys standalone 进不去 | — | 前端 403 + 后端不扩资格 | 改 URL |
+| 积分/迁移认运营身份 | 积分表、迁移表 | 扩 `require_*`，不扩 `is_admin()` | 调账/建批次落库 |
+| 超管不变 | 同现网 | `role=admin` | 全模块仍开 |
+| 解绑后失效 | `userrole` 删除 | 下一请求无 role_name | 403 |
+
+方案未确认前不拆 tasks、不写业务代码。确认后先出验收用例，再实现。

--- a/specs/056-platform-operator-role/hand-test.md
+++ b/specs/056-platform-operator-role/hand-test.md
@@ -1,0 +1,175 @@
+# 平台管理员 — 手测用例与数据
+
+入口脑图：Cursor Canvas（可开在聊天旁）。本文可复制到飞书/XMind。
+
+环境：门户 `http://127.0.0.1:5173`，Platform `http://127.0.0.1:3001`，毕昇 API `http://127.0.0.1:7860`。验收库 171 MySQL。本地栈需先「启动联调」。
+
+密码：下列账号与现网 `admin`（user_id=1）同一密码哈希；用你平时登 171 admin 的密码。不要用文档里的 `admin123`，除非你已确认该明文能登 171。
+
+---
+
+## 脑图（Mermaid）
+
+```mermaid
+mindmap
+  root((平台管理员手测))
+    0 准备
+      HT-00 超管创建角色「平台管理员」
+      HT-00b 绑定 ht056-ops + 普通用户
+      HT-00c /user/info 与门户会话
+    1 身份
+      HT-10 不是超管
+      HT-12 门户认得到运营岗
+    2 能进11项
+      HT-20 /admin 侧栏10项+迁移
+      HT-21 积分调账
+      HT-22 迁移全库+新建
+      HT-24 问答配置
+      HT-25 写作模板
+      HT-26 应用配置
+      HT-27 知识分类
+      HT-28 水印
+      HT-29 字典
+      HT-60 三 iframe
+    3 不能进
+      HT-51 直链禁止 section
+      HT-40 首页导航 domains
+      HT-45 密钥/全量 config
+      HT-48 专家问答违规删
+      HT-52 Header 无回收站外链
+      HT-62 approval/sys/有壳后台
+      HT-63 Platform 非 standalone 踢走
+    4 对照
+      HT-53 普通用户拒后台
+      HT-54 未登录去登录
+      HT-70 超管积分迁移配置仍开
+      HT-71 整页管理员菜单全开但不能迁移
+      HT-80 解绑后失效
+```
+
+---
+
+## 账号（171 已插入，2026-08-28）
+
+| 代号 | 账号 | user_id | 当前角色 | 用途 | 备注 |
+|---|---|---|---|---|---|
+| U-super | `admin` | 1 | System Admin (id=1) | 创建保留名、绑人、回归 | 已有 |
+| U-super2 | `gzx04` | 7 | System Admin + 普通用户 | 备用超管 | 已有，同密码 |
+| U-portal | `ht056-portal` | 840 | 普通用户 + 管理员(id=5) | AT-71 整页管理员 | 新建 |
+| U-ops | `ht056-ops` | 838 | **仅普通用户** | 主测运营岗 | 新建；**HT-00b 后才有「平台管理员」** |
+| U-user | `ht056-user` | 839 | 普通用户 | 无权限对照 | 新建 |
+| U-both | `ht056-both` | 841 | 仅普通用户 | AT-81 超管优先（可选） | 新建；后绑 AdminRole+平台管理员 |
+| U-anon | — | — | 无 Cookie | 未登录 | |
+| 调账对象 | `gzx02` | 5 | 普通用户 | 积分余额 360 | 已有账户 |
+| 迁移对照库主人 | `gzx0002` | 13 | 普通用户 | 知识库 9990006 | 不要用 U-ops 登录此号 |
+
+禁止：把「平台管理员」加进门户 `ADMIN_ROLES`；U-ops 不得出现 `role=admin`。
+
+---
+
+## 准备步骤（必须先做）
+
+1. U-super 登录毕昇 Platform 角色管理，创建角色名精确四字 **`平台管理员`**（不要空格、不要「xx平台管理员」）。
+2. 期望：创建成功；再创建同名 → 24002；可与「管理员」并存；改名/删除失败。
+3. 给 `ht056-ops` 同时保留 **普通用户** + **平台管理员**（前台才能登录）。
+4. 不要给该角色勾管理端 WEB_MENU（`board`/`sys`）；即使勾了保存后应被剥掉。
+5. `ht056-ops` 重新登录门户，确认 Header 有「知识管理后台」「迁移记录」。
+
+角色不要用 SQL 插，必须走 RoleService（保留名 + 菜单剥离）。
+
+---
+
+## 业务数据（171 现网，只读引用）
+
+| 用途 | 表 | 关键行 |
+|---|---|---|
+| 调账对象 | `user_point_account` | user_id=5 `gzx02` balance=360 |
+| 迁移「非本人库」 | `knowledge` | id=9990006 名称 `gzx0002的知识库` user_id=13 |
+| 超管库对照 | `knowledge` | id=9990007 `一会删` user_id=1 |
+| 门户配置 | 毕昇 `config` key=`shougang_portal_config` | 问答/水印可改；domains 对 U-ops 禁止 |
+| 角色 | `role` | 尚无「平台管理员」行，HT-00 创建 |
+| 绑定 | `userrole` | ht056-* 已绑 role_id=2；portal 另绑 5 |
+
+无 DDL。手测写库后应用 U-ops 账号再读一遍核对。
+
+---
+
+## 用例清单（逐步）
+
+入口：`http://127.0.0.1:5173`。每条失败期望：页面拒绝或接口 403，且禁止项表/配置块不变。
+
+### 0 准备
+
+- **HT-00** U-super 创建「平台管理员」。期望：角色列表出现精确四字；同租户再创建失败。
+- **HT-00b** 绑定 `ht056-ops`。期望：`userrole` 有该角色 + 普通用户；无 role_id=1。
+- **HT-00c** `ht056-ops` 登录后 `GET /api/v1/user/info`：`role=平台管理员`，`role_names` 含该名，**不是** `admin`。门户 `/api/v1/auth/me` 同样。
+
+### 1 身份
+
+- **HT-10** 运营岗前台当普通用户可用；不能进毕昇有壳管理后台。
+- **HT-12** 门户用户菜单显示运营身份，刷新后仍在。
+
+### 2 能进（11 项）
+
+U-ops 打开 `/admin`。
+
+侧栏应有且仅有：数据看板、积分管理、问答配置、写作模板、应用配置、知识分类、水印设置、字典配置、内容与安全审查、标签管理。Header「迁移记录」算第 11 项。
+
+| ID | 操作 | 期望 |
+|---|---|---|
+| HT-20 | 扫侧栏与分组 | 无「门户管理」整组、课程、业务域映射、自动发布、科室绑定、审批、系统管理；无「BiSheng 管理后台」外链 |
+| HT-21 | 积分管理：给 `gzx02` 调账小额正数 | 成功；余额=原 360+delta；再打开详情一致 |
+| HT-22 | Header 迁移记录 → 新建迁移；源库选 9990006 | 能列出非本人库；建批成功；操作者是 ht056-ops |
+| HT-24 | 问答配置改欢迎语后保存 | 成功；刷新仍在；首页导航 domains 未变 |
+| HT-25 | 写作模板改一条 | 成功再读一致 |
+| HT-26 | 应用配置保存 | 成功再读一致 |
+| HT-27 | 知识分类保存 | 成功再读一致 |
+| HT-28 | 水印保存（可加可辨认后缀 `-ht056`） | 成功再读一致 |
+| HT-29 | 字典配置新建一条 type 带 `ht056` | 列表能见到；不要用生产字典名 |
+| HT-60 | 点数据看板 / 标签管理 / 内容与安全审查 | 三 iframe 能渲染，内接口可用，不被踢到 workspace |
+
+### 3 不能进
+
+| ID | 操作 | 期望 |
+|---|---|---|
+| HT-51 | 地址栏 `/admin?section=site`（再试 domains / banners / search） | 主区「无权限访问该模块」；Network 无全量 `/admin/config` 200 |
+| HT-40 | 若仍发出 `POST /api/v1/admin/config/domains` | 403，无 domains 正文；配置不变 |
+| HT-45 | Network 搜 `/bisheng` `/rest-auth` 全量 `/admin/config` | 403 或未发；body 无密码/token |
+| HT-48 | 专家问答已锁定问题 | 无违规删除按钮；不要用超管码误放行 |
+| HT-52 | Header 用户菜单 | 有知识管理后台、迁移记录；无回收站 |
+| HT-62 | 改 iframe URL 为 `/platform/standalone/approval`；另开 `/platform/standalone/sys`；有壳 `/dashboard` | 403 或踢 workspace；不加载审批/系统页 |
+| HT-63 | 用 U-ops 直接打开 Platform `:3001` 非 standalone | 踢走 workspace / 无管理侧栏 |
+
+### 4 对照账号
+
+| ID | 身份 | 操作 | 期望 |
+|---|---|---|---|
+| HT-53 | ht056-user | `/admin`、`/knowledge-migrations` | 无权限；前台首页仍可用 |
+| HT-54 | 退出登录 | `/admin` | 去登录 |
+| HT-70 | admin | 积分调账、建迁移、`/admin` 改首页导航、打开数据源 | 全开且能保存 |
+| HT-71 | ht056-portal | `/admin` | NAV 全开；有回收站/外链；**无**迁移记录；直开 `/knowledge-migrations` 无权限 |
+| HT-80 | 超管解绑 ht056-ops 的平台管理员后重登 | 调账、保存问答、开 `/admin` | 18201/403；无新积分流水；qa 不再被他改掉 |
+
+---
+
+## 涉及数据表
+
+无 DDL / 无字段增删改 / 不做迁移。
+
+| 表 | 角色 | 关键已有字段 |
+|---|---|---|
+| `role` | 写（HT-00 一行） | `id`,`role_name`,`tenant_id` |
+| `user` | 读；手测账号已插入 | `user_id`,`user_name`,`password`,`remark` |
+| `userrole` | 写绑定/解绑 | `user_id`,`role_id`,`tenant_id` |
+| `roleaccess` | 旁路（WEB_MENU 剥离） | `role_id`,`third_id` |
+| `user_point_account` / `user_point_log` | 调账读写 | `user_id`,`balance`,`delta` |
+| `knowledge` / `knowledge_migration_batch` | 迁移读写 | `id`,`user_id`,`batch_no` |
+| `system_dictionary` | 字典写 | type/value |
+| `sensitive_word_policy` | iframe 审查 | 现网策略 |
+| `config` (`key=shougang_portal_config`) | 门户配置读写 | JSON 内 qa/watermark/domains 等 |
+
+---
+
+## 不要测
+
+种子脚本插「平台管理员」角色、按库收窄迁移、公开发现开关、用户角色管理页本身、性能。

--- a/specs/056-platform-operator-role/tasks.md
+++ b/specs/056-platform-operator-role/tasks.md
@@ -1,0 +1,255 @@
+# 任务清单：平台管理员（运营岗）
+
+| 文档 | 状态 |
+|---|---|
+| `design.md` | 已确认 |
+| `acceptance-test-cases.md` | 已确认 |
+| `tasks.md` | 已拆解 |
+
+- Feature: `056-platform-operator-role`
+- 关联：`specs/056-platform-operator-role/design.md`、`acceptance-test-cases.md`
+- 无 `spec.md`：验收标准以 AT-xx 为准（等同 AC）
+- 仓：毕昇 `feat-2.5.0-sg-issue-3` + 门户 `dev-issue-3`
+- 无 DDL；无 Client 改动；无 Worker/Celery 新任务
+- 后端 Test-First：测试任务不得混入实现。写库 P0 必须 171 MySQL 流转（接口 + SELECT + 再打一枪）
+- 禁止把「平台管理员」并入门户 `ADMIN_ROLES` / `isPortalAdmin`；禁止把 `can_platform_operate` 写进 `is_admin()` / `get_admin_user`
+
+常量（两仓同一字面量）：`PLATFORM_OPERATOR_ROLE_NAME = "平台管理员"`
+
+---
+
+## Phase 0 — 基础设施 / 身份 helper（毕昇）
+
+- [x] T001 毕昇：写运营身份 helper 单测
+  - Done when: 新测试文件在 helper 尚不存在或未实现时失败；覆盖精确匹配与反例。
+  - 覆盖 AC: AT-03
+  - 验证: `cd src/backend && uv run pytest test/user/test_platform_operator_identity.py -k helper --coverage=false`（或项目既有 pytest 命令）
+  - 边界: 仅 `src/backend/test/user/test_platform_operator_identity.py`
+  - 逻辑: `has_platform_operator_role`：`平台管理员` true；trim 后全等 true；`管理员` / `系统管理员` / `admin` / `xx平台管理员` false。`can_platform_operate`：超管 true、运营岗 true、普通用户 false。`is_admin()` 不因运营岗变 true。
+
+- [x] T002 毕昇：实现运营身份 helper
+  - Done when: T001 绿；`is_admin()` 未改语义。
+  - 覆盖 AC: AT-03
+  - Depends: T001
+  - 边界: 仅新建 `src/backend/bisheng/user/domain/services/platform_operator.py`（中文 docstring）。`common/` 不引用 domain。
+  - 产出: `PLATFORM_OPERATOR_ROLE_NAME`、`has_platform_operator_role(user)`（读 `role_names`）、`can_platform_operate(user)` = `is_admin()` 或 `is_global_super` 或前者。
+
+---
+
+## Phase 1 — 身份下发与保留名（毕昇）
+
+- [x] T003 毕昇：写 `/user/info` 与 `get_admin_user` 测试
+  - Done when: 夹具 U-ops 在实现前失败（`role` 仍是 id 列表或 `get_admin_user` 误放行）。
+  - 覆盖 AC: AT-10, AT-11, AT-81
+  - Depends: T002
+  - 边界: 扩 `test/user/test_platform_operator_identity.py`（或同目录新测，不超过该文件）。171 若需真实登录则走现网 user fixture。
+  - 逻辑: U-ops：`role=平台管理员`，`role_names` 含该名，非 `admin`。U-ops Cookie `PUT /api/v1/shougang-portal/config` 改 domains → 403，`config` 行不变，再读导航不变。同时绑 AdminRole+运营岗 → `role=admin` 且 `is_admin()` true。
+
+- [x] T004 毕昇：下发 `role` / `role_names`
+  - Done when: T003 绿。
+  - 覆盖 AC: AT-10, AT-11, AT-81
+  - Depends: T003
+  - 边界: `src/backend/bisheng/user/api/user.py`（`_user_info_role_label`）、`src/backend/bisheng/user/domain/models/user.py`（`UserRead.role_names`）。不改 `get_admin_user`。
+  - 逻辑: 优先级 AdminRole→`admin`；否则 `role_names` 含保留名→`平台管理员`；否则原门户整页名。响应增加 `role_names`。
+
+- [x] T005 毕昇：写保留名与 WEB_MENU 剥离测试
+  - Done when: 实现前失败。
+  - 覆盖 AC: AT-01, AT-02, AT-04, AT-90
+  - Depends: T002
+  - 边界: 仅新文件 `src/backend/test/role/test_platform_operator_reserved_name.py`。171 MySQL。
+  - 逻辑: 超管创建「平台管理员」落 `role`；同租户任意 department 再创建 → 24002，行数仍 1；可与「管理员」并存；改名/删除 → 24004，`role_name` 不变；保存 WEB_MENU 含 `board`/`sys` 后 `roleaccess` 无这些 `third_id`。
+
+- [x] T006 毕昇：RoleService 保留名 + 剥离管理端菜单
+  - Done when: T005 绿。
+  - 覆盖 AC: AT-01, AT-02, AT-04, AT-90
+  - Depends: T005
+  - 边界: `src/backend/bisheng/role/domain/services/role_service.py`（创建/更新/删除/存菜单）。不改 `role` 表结构。
+  - 逻辑: 租户内保留名跨 scope 唯一；该名角色禁止改名/删除；保存 WEB_MENU 丢掉 design 所列管理端 key，只留工作台。
+
+---
+
+## Phase 2 — 毕昇写闸门（Test-First，171 流转）
+
+- [x] T007 毕昇：写积分运营流转测试
+  - Done when: U-ops 调账在实现前 18201。
+  - 覆盖 AC: AT-21, AT-48, AT-80
+  - Depends: T002
+  - 边界: 仅新文件 `src/backend/test/points/test_platform_operator_points_admin.py`。禁止追加巨石。171 MySQL。
+  - 逻辑: U-ops `POST /api/v1/points/admin/adjust` → 200，`user_point_log.delta` 与余额一致；再 GET detail 与表一致。U-user 同一接口 18201，log 行数不变。解绑 `userrole` 后再 adjust → 18201，无新 log。断言 `is_platform_super_admin(U-ops)` 仍 false。若存在专家问答超管删除/扣分接口，U-ops 调用须 403 或 18201 且问答/积分表无脏行（AT-48）。
+
+- [x] T008 毕昇：积分管理改认 `can_platform_operate`
+  - Done when: T007 绿；专家问答超管判定仍用 `is_platform_super_admin`。
+  - 覆盖 AC: AT-21, AT-48, AT-80
+  - Depends: T007
+  - 边界: `src/backend/bisheng/points/domain/services/points_auth.py`。`require_platform_admin` 改为 `can_platform_operate`；**不要**把运营岗并入 `is_platform_super_admin`。
+  - 影响: 所有调用 `require_platform_admin` 的积分 admin 写/读；`test_department_org_level.py` 夹具若只 mock `is_admin` 需能过（可在本任务补 import/夹具，不改产品语义）。
+
+- [x] T009 毕昇：写迁移全库流转测试
+  - Done when: U-ops 建批在实现前 403。
+  - 覆盖 AC: AT-22, AT-23
+  - Depends: T002
+  - 边界: 新文件 `src/backend/test/knowledge/test_platform_operator_migration.py`。不把新逻辑追加进巨石 knowledge 测试。171 MySQL。
+  - 逻辑: U-ops `GET /api/v1/knowledge/migrations/spaces` 含非本人库（与超管同一口径）；`POST /batches` 落 `knowledge_migration_batch`，操作者 U-ops；再 GET batch_no 仍在。U-user 建批 403，表无新行。
+
+- [x] T010 毕昇：迁移闸门扩运营岗
+  - Done when: T009 绿；账号名/`管理员` 旁路仍 403。
+  - 覆盖 AC: AT-22, AT-23
+  - Depends: T009
+  - 边界: `src/backend/bisheng/knowledge/domain/services/knowledge_migration_service.py` 的 `require_system_admin`。同步改 `src/backend/test/knowledge/test_knowledge_migration_auth.py`：运营岗（`role_names`）通过；`account=admin` 且 `is_admin` false 仍拒。
+
+- [x] T011 毕昇：写字典流转测试
+  - Done when: U-ops 创建字典在实现前 19102。
+  - 覆盖 AC: AT-29
+  - Depends: T002
+  - 边界: 新文件 `src/backend/test/dictionary/test_platform_operator_dictionary.py`。171 MySQL。
+  - 逻辑: U-ops `POST /api/v1/dictoption/create` → `system_dictionary` 新行；再按 type GET 见该行。U-user 19102，无新行。
+
+- [x] T012 毕昇：字典 `_ensure_admin` 改认运营岗
+  - Done when: T011 绿。
+  - 覆盖 AC: AT-29
+  - Depends: T011
+  - 边界: `src/backend/bisheng/dictionary/domain/services/dictionary_service.py`
+
+- [x] T013 毕昇：写看板 / 标签 / 敏感词 / 审批未扩测试
+  - Done when: 实现前 U-ops 看板列表窄于超管或敏感词 19801。
+  - 覆盖 AC: AT-30, AT-47
+  - Depends: T002
+  - 边界: 新文件 `src/backend/test/workstation/test_platform_operator_tag_and_sensitive.py`（敏感词+tag）；看板断言可同文件或 `test/telemetry_search/` 下新小文件（合计本任务 ≤2 文件）。171 能连则查 `sensitive_word_policy`。
+  - 逻辑: U-ops 看板列表范围等同超管；敏感词 GET/PUT 200，PUT 后表一致再 GET。tag-console 管理接口一成功。U-user 未授权。抽一条现网审批/系统超管 API，U-ops 仍 403。
+
+- [x] T014 毕昇：看板列表/写按 `can_platform_operate`
+  - Done when: T013 中看板断言绿。
+  - 覆盖 AC: AT-30
+  - Depends: T013
+  - 边界: `src/backend/bisheng/telemetry_search/domain/services/dashboard.py`（现 `is_admin()` 列表与实时写）。只扩运营资格，不改分享/部门管理员其它分支语义。
+
+- [x] T015 毕昇：tag console + 敏感词策略认运营岗
+  - Done when: T013 中标签/敏感词绿；`get_tenant_admin_user` 全局语义不变。
+  - 覆盖 AC: AT-30, AT-47
+  - Depends: T013
+  - 边界: `src/backend/bisheng/workstation/domain/services/tag_console_service.py` 的 `_ensure_can_manage_tags`；`src/backend/bisheng/sensitive_word/api/endpoints/policies.py` 改为 `get_login_user` + `can_platform_operate`（**不要**扩大 `get_tenant_admin_user`）。
+
+---
+
+## Phase 3 — 门户 BFF ACL（门户仓）
+
+- [x] T016 门户：写身份会话 + 模块 ACL 流转测试
+  - Done when: U-ops 在实现前进不了 `/admin` 配置或误拿到全量密钥。
+  - 覆盖 AC: AT-12, AT-24, AT-25, AT-26, AT-27, AT-28, AT-40, AT-41, AT-42, AT-43, AT-44, AT-45, AT-46, AT-91
+  - Depends: T004
+  - 边界: 新文件 `backend/tests/test_platform_operator_admin_acl.py`（门户仓）。不要把断言塞进巨石后整文件跑。落库查毕昇 `config` / 课程表 / 回收。171。
+  - 逻辑:
+    - 会话 `role` 或 `role_names` 为运营岗；`is_portal_admin_role('平台管理员')` false。
+    - 允许：POST `/api/v1/admin/config/qa`（含 templates）、`/agent-config`、`/document-types`、`/watermark` → 200，对应 JSON 块变、`domains` 不变；再 GET 一致。
+    - 禁止：POST domains / recommendation / search / banners / display、课程写、自动发布、科室绑定、回收站写、GET/POST site / bisheng / integrations / unified-auth / rest-auth、**GET 全量 `/admin/config`** → 403，body 无密码/token，目标块/表不变，再打一枪仍不变。
+
+- [x] T017 门户：会话透传 `role_names` + 运营岗判定
+  - Done when: AT-12 会话断言绿；`ADMIN_ROLES` 仍为三元。
+  - 覆盖 AC: AT-12, AT-91
+  - Depends: T016
+  - 边界: `backend/app/schemas/auth.py`、`backend/app/services/portal_auth_service.py`、`backend/app/api/dependencies.py`。不把保留名加入 `ADMIN_ROLES`。
+  - 产出: `is_platform_operator`；`can_enter_admin_shell`；`require_ops_module_session` / 按 path 的依赖（地图可放 `dependencies.py`）。
+
+- [x] T018 门户：`admin_config` 与课程/回收站/上传分路
+  - Done when: T016 绿。
+  - 覆盖 AC: AT-24, AT-25, AT-26, AT-27, AT-28, AT-40, AT-41, AT-42, AT-43, AT-44, AT-45, AT-46
+  - Depends: T017
+  - 边界: `backend/app/api/routes/admin_config.py`（去掉 router 整组 `require_admin_session`，按 path 挂依赖）；课程/回收站文件保持仅整页管理员；`admin_upload.py` 允许 `can_enter_admin_shell`。
+  - 逻辑: 全量 GET/POST `""` 仅整页管理员。允许名单 path 见 design §4.3。BFF 仍用服务账号写毕昇 `config`，用户 Cookie 不能靠本任务放开 `get_admin_user`。
+
+---
+
+## Phase 4 — 门户前端
+
+- [x] T019 门户：写 adminAccess / Header / 迁移路由单测
+  - Done when: 实现前 `isPortalAdmin('平台管理员')` 仍 false 且 `/admin` 壳进不去或迁移入口仍关。
+  - 覆盖 AC: AT-50, AT-52, AT-53, AT-54, AT-48, AT-71
+  - 边界: 扩 `frontend/tests/adminAccess.test.ts`、`frontend/tests/knowledgeMigrationAccess.test.ts`（门户仓，2 文件）。
+  - 逻辑: `isPortalAdmin` 不含该名；`canEnterAdminShell` 含该名。`canViewMigrations` 含运营岗与系统管理员。`isPlatformSuperAdmin` / 专家问答违规删 **不含** 运营岗。「管理员」整页资格回归仍 true。U-user / U-anon 行为保持。
+
+- [x] T020 门户：adminAccess + Header + 迁移路由
+  - Done when: T019 绿。
+  - 覆盖 AC: AT-50, AT-52, AT-48
+  - Depends: T017, T019
+  - 边界: `frontend/src/utils/adminAccess.ts`、`frontend/src/components/Header.tsx`、`frontend/src/App.tsx`（KnowledgeMigrationsRoute / AdminRoute）。
+  - 逻辑: Header「知识管理后台」用壳资格；迁移用 `canViewMigrations`；回收站/毕昇外链仍 `isPortalAdmin`。`/admin` 壳允许运营岗。映射 `PortalUser.roleNames`。
+
+- [x] T021 门户：AdminPage 11 项菜单、直链、loadConfig
+  - Done when: 运营岗只渲染 11 项中 1–10；禁止 section 无权限；不请求 `/bisheng`、`/rest-auth`、全量 config。
+  - 覆盖 AC: AT-20, AT-51, AT-45
+  - Depends: T020
+  - 边界: `frontend/src/pages/AdminPage.tsx`（只动导航过滤、section 守卫、`loadConfig`；不重构整页）。
+  - 逻辑: 允许名单 key 见 design 11 项。`?section=site|domains|...` 无权限页且不发禁止 API。外链「毕昇管理后台」对运营岗不展示。
+
+---
+
+## Phase 5 — 毕昇 Platform standalone
+
+- [x] T022 Platform：写 standalone 白名单单测
+  - Done when: 实现前无管理端 WEB_MENU 的用户在 standalone 三页仍会被踢（用纯函数测路径判定，不测真浏览器亦可）。
+  - 覆盖 AC: AT-60, AT-62
+  - 边界: `src/frontend/platform/src/test/` 下新小文件（路径白名单函数）。若必须改 `userContext.tsx` 才能抽函数，本任务只写失败测试 + 约定导出名 `isPlatformOperatorStandalonePath`。
+  - 逻辑: `/standalone/dashboard`、`/knowledge-tag-library`、`/content-security`（含子路径 dashboard/:id）为白名单；`/standalone/approval`、`/sys`、`/log`、有壳 `/dashboard` 否。
+
+- [x] T023 Platform：`userContext` 对白名单跳过踢走
+  - Done when: T022 绿；非白名单 standalone 与有壳管理页仍踢 workspace 或 403。
+  - 覆盖 AC: AT-60, AT-62, AT-63
+  - Depends: T004, T022
+  - 边界: `src/frontend/platform/src/contexts/userContext.tsx`；路径判断放 `src/frontend/platform/src/routes/standalone.ts`（已有 `isStandalonePath`，可加白名单集合）。
+  - 逻辑: 白名单且已登录 → 不因 `canAccessPlatform=false` 而 `location.replace(workspace)`。不给运营岗管理端 WEB_MENU。
+
+---
+
+## Phase 6 — 回归与手测
+
+- [x] T024 跑 P0 自动化（171）
+  - Done when: 上列新测 + 被改调用方测绿；超管积分/迁移/POST domains 回归仍绿（AT-70）。
+  - 覆盖 AC: AT-70
+  - Depends: T008, T010, T012, T014, T015, T018, T021, T023
+  - 边界: 只跑本特性相关 pytest/npm test，不跑全仓无关套件。记录命令与结果（可写本目录 `verification.md`）。
+  - 调用方: `test/points/test_department_org_level.py`、`test/knowledge/test_knowledge_migration_auth.py`、门户 `adminAccess.test.ts`。
+
+- [ ] T025 UI 手测清单（无稳定 iframe E2E，测试降级）
+  - Done when: 书面记录 U-ops 实点结果；未跑的不勾完成。
+  - 覆盖 AC: AT-20, AT-51, AT-60, AT-62, AT-63, AT-71
+  - Depends: T021, T023
+  - 降级理由: 三 iframe 依赖门户+Platform Cookie 同源与登录态，仓库无现成 Playwright 覆盖 standalone。
+  - 手测: `/admin` 仅 11 项菜单；直链 site 无权限；三条 standalone 能开且接口可用；改 URL 进 approval/sys 失败；超管/整页管理员菜单全开。
+
+---
+
+## AT 覆盖表（防漏）
+
+| AT | 测试任务 |
+|---|---|
+| AT-01, AT-02, AT-04, AT-90 | T005 |
+| AT-03 | T001 |
+| AT-10, AT-11, AT-81 | T003 |
+| AT-12, AT-24～AT-28, AT-40～AT-46, AT-91 | T016 |
+| AT-20, AT-51, AT-45（前端） | T021, T025 |
+| AT-21, AT-48, AT-80 | T007, T019 |
+| AT-22, AT-23 | T009 |
+| AT-29 | T011 |
+| AT-30, AT-47 | T013 |
+| AT-48, AT-50, AT-52, AT-53, AT-54, AT-71 | T019 |
+| AT-60, AT-62 | T022, T025 |
+| AT-63 | T023, T025 |
+| AT-70 | T024 |
+
+---
+
+## 实际偏差记录
+
+- T003：`UserRead` / `LoginUser.get_admin_user` 受 conftest premock 影响，不能在测试里直接实例化 `UserRead` 或原样 `raise UnAuthorizedError.http_exception()`；改为测 `collect_user_info_role_names` + 源码字段，以及 patch `http_exception` 后断言 403。`PUT /shougang-portal/config` 的 171 流转放到后续闸门任务，本任务覆盖身份下发与 `get_admin_user` 仍只认 `is_admin()`。
+- T008：`require_platform_admin` 扩运营岗后，专家问答 `moderate_delete` 若继续调用它会误放行。按 AT-48 / design，该接口改为 `is_platform_super_admin`（`qa_expert/domain/moderate_delete_service.py`），不把运营岗并入超管判定。
+- T009：pytest premock 了 `user.domain.models.user.User`，真实 `list_spaces` 的 User join 跑不起来。GET 全库口径用 mock 返回「本人库 + 非本人库」；POST 建批 mock `_normalize_create` 与 Celery dispatcher，真实 Repository 写 171 `knowledge_migration_batch`，再 SELECT / GET batch_no。
+- T011：生产挂载是 `/api/v1/dictionaries/dictoption/create`；AT 写的是 `/api/v1/dictoption/create`。流转测按 endpoint 自身 prefix（AT 路径）挂载，闸门与落库表相同。
+- T015：敏感词 endpoint 改为 `get_login_user` + `can_platform_operate`，错误码仍 19801（`LLMModelSharedReadonlyError`）。不改 `get_tenant_admin_user`。看板 `is_admin()` 全部改为 `_can_operate_dashboards()`，运营岗列表/实时写与超管同口径。
+- T016：门户配置 ACL 走 `PortalConfigService` 内存/文件 store（与 `test_admin_config_api` 同口径），不拿用户 Cookie PUT 毕昇全量 `config`。课程/回收站禁止路径断言 403，不打现网毕昇表。
+- T018：`require_admin_config_session` 与 `require_admin_session` 同一函数对象，按 path 分路（整页管理员全放行，运营岗仅 design §4.3 允许名单）。课程/回收站仍挂 `require_admin_session`（path 不在名单 → 运营岗 403）。`admin_upload` 改挂 `require_admin_shell_session`（`can_enter_admin_shell`）。未给 80 个路由逐个 Depends。
+- T020：Header「知识管理后台」改为 `navigate('/admin')`，不再 `window.open(bisheng_admin_entry_url)`；回收站仍 `isPortalAdmin`。`canViewMigrations` = 系统管理员 ∪ 运营岗，「管理员」角色仍不能进迁移（与改前一致）。
+- T021：运营岗 `loadConfig` 只 GET `/qa` `/agent-config` `/document-types` `/watermark`；不请求全量 config / `/bisheng` / `/rest-auth`。`?section=` 无权限时主区「无权限访问该模块」，左侧外链「BiSheng 管理后台」对运营岗隐藏。
+- T023：无管理端 WEB_MENU 时已登录走 `resolveNoAdminConsoleAction`（白名单 fall through，其它 standalone 进 `/403`，有壳管理页仍踢 workspace）；未登录（无 `user_id`）仍踢走，不把无 session 留在 iframe。
+- T024：命令与结果见同目录 `verification.md`。AT-70 用调用方测 + 门户 `test_post_admin_domains_updates_persisted_config` / `test_post_admin_bisheng_config_updates_runtime_without_echoing_secret`，未跑全仓。
+- T025：2026-08-28 本地栈未起（7860/8010/4001/3001/5173 down），手测未实点，不勾完成。清单写在 `verification.md`。
+

--- a/specs/056-platform-operator-role/verification.md
+++ b/specs/056-platform-operator-role/verification.md
@@ -1,0 +1,81 @@
+# 056 平台管理员 — T024 自动化记录
+
+日期: 2026-08-28。只跑本特性相关命令，未跑全仓套件。
+
+## T022 / T023 Platform standalone
+
+```bash
+cd src/frontend/platform
+npx vitest run src/test/platformOperatorStandalonePath.test.ts src/test/resolveRoutePermissions.test.ts --coverage=false
+```
+
+结果: **16 passed**（standalone 4 + resolveRoutePermissions 12）。
+
+白名单: `/standalone/dashboard`（含子路径）、`/standalone/knowledge-tag-library`、`/standalone/content-security`。
+非白名单 standalone → `standalone-403`；有壳 `/dashboard` `/sys` `/admin` → `kick`。
+`userContext` 已登录且无管理端 WEB_MENU 时用 `resolveNoAdminConsoleAction`；未登录仍踢走。
+
+## T024 毕昇后端（171 MySQL）
+
+```bash
+cd src/backend
+uv run pytest \
+  test/user/test_platform_operator_identity.py \
+  test/role/test_platform_operator_reserved_name.py \
+  test/points/test_platform_operator_points_admin.py \
+  test/knowledge/test_platform_operator_migration.py \
+  test/knowledge/test_knowledge_migration_auth.py \
+  test/dictionary/test_platform_operator_dictionary.py \
+  test/workstation/test_platform_operator_tag_and_sensitive.py \
+  test/points/test_department_org_level.py \
+  -q --tb=line
+```
+
+结果: **59 passed**。
+
+AT-70 闸门回归: `require_platform_admin` 仍放行 `is_global_super`；`require_system_admin` 仍放行 `is_admin()`。
+
+## T024 门户 BFF
+
+```bash
+cd backend
+./.venv/bin/python -m pytest \
+  tests/test_platform_operator_admin_acl.py \
+  tests/test_admin_upload_api.py \
+  tests/test_admin_config_api.py::test_admin_config_allows_bisheng_admin_role \
+  tests/test_admin_config_api.py::test_post_admin_domains_updates_persisted_config \
+  tests/test_admin_config_api.py::test_post_admin_bisheng_config_updates_runtime_without_echoing_secret \
+  -q --tb=line
+```
+
+结果: ACL+上传 **16 passed**；AT-70 管理员 POST domains / POST bisheng / GET 管理配置 **3 passed**。
+
+## T024 门户前端（隔离编译，避开全量 tsc 无关失败）
+
+```bash
+cd frontend
+npx tsc --ignoreConfig --ignoreDeprecations 6.0 --target es2023 --lib ES2023,DOM \
+  --module commonjs --moduleResolution node --esModuleInterop --skipLibCheck \
+  --jsx react-jsx --outDir /tmp/ops-tests --rootDir . --types node \
+  tests/adminAccess.test.ts tests/knowledgeMigrationAccess.test.ts
+node --test /tmp/ops-tests/tests/adminAccess.test.js /tmp/ops-tests/tests/knowledgeMigrationAccess.test.js
+```
+
+结果: **12 passed**。`npm test` 全量仍会被既有无关用例 tsc 挡住（如 `home_icon`），与本特性无关。
+
+## 跳过
+
+- 毕昇/门户全仓 pytest、Platform 全仓 vitest、门户 `npm test` 全量
+- Client / Worker
+- T025 浏览器手测（见下）
+
+## T025 UI 手测清单（未跑，不勾完成）
+
+本地 `7860/8010/4001/3001/5173` 均 down，未启动联调。需 U-ops Cookie 后实点:
+
+1. 门户 `/admin` 仅 11 项: 数据看板、积分管理、问答配置、写作模板、应用配置、知识分类、水印设置、字典配置、内容与安全审查、标签管理；Header「迁移记录」可见。
+2. 直链 `?section=site`（及 domains/recommendation/search/banners/display）主区「无权限」，不发全量 config。
+3. iframe 三条能开且接口可用: dashboard / knowledge-tag-library / content-security。
+4. 改 URL 进 `/platform/standalone/approval` 或有壳 `/sys` 失败（403 或踢 workspace）。
+5. 超管 / 「管理员」菜单仍全开；「管理员」仍不能进迁移。
+6. 运营岗无「BiSheng 管理后台」外链、无回收站、无课程。

--- a/src/backend/bisheng/database/models/role.py
+++ b/src/backend/bisheng/database/models/role.py
@@ -318,6 +318,24 @@ class RoleDao(RoleBase):
             return (await session.exec(stmt)).first()
 
     @classmethod
+    async def aget_role_by_exact_name_in_tenant(
+        cls,
+        tenant_id: int,
+        role_name: str,
+        exclude_id: Optional[int] = None,
+    ) -> Optional[Role]:
+        """租户内按显示名精确查找, 不限 role_type / department_id.
+
+        tenant_id 交给会话租户注入, 这里不再手写 WHERE tenant_id.
+        """
+        del tenant_id
+        stmt = select(Role).where(Role.role_name == role_name)
+        if exclude_id is not None:
+            stmt = stmt.where(Role.id != exclude_id)
+        async with get_async_db_session() as session:
+            return (await session.exec(stmt)).first()
+
+    @classmethod
     async def aget_user_count_by_role_ids(cls, role_ids: List[int]) -> dict:
         """Get user count for each role ID. Returns {role_id: count}."""
         if not role_ids:

--- a/src/backend/bisheng/dictionary/domain/services/dictionary_service.py
+++ b/src/backend/bisheng/dictionary/domain/services/dictionary_service.py
@@ -50,8 +50,10 @@ class DictionaryService:
 
     @staticmethod
     def _ensure_admin(user: UserPayload) -> None:
-        """校验当前用户是否为管理员,否则抛出权限错误"""
-        if not user.is_admin():
+        """校验当前用户是否具备运营写资格(超管或平台管理员)."""
+        from bisheng.user.domain.services.platform_operator import can_platform_operate
+
+        if not can_platform_operate(user):
             raise DictionaryPermissionDeniedError()
 
     def _validate_dict_key_format(self, dict_key: str) -> None:

--- a/src/backend/bisheng/knowledge/domain/services/knowledge_migration_service.py
+++ b/src/backend/bisheng/knowledge/domain/services/knowledge_migration_service.py
@@ -78,9 +78,13 @@ class CeleryKnowledgeMigrationTaskDispatcher:
 
 
 def require_system_admin(login_user: Any):
-    """只接受后端 AdminRole. 不接受账号名或展示角色旁路."""
-    is_admin = getattr(login_user, "is_admin", None)
-    if login_user is None or not callable(is_admin) or not bool(is_admin()):
+    """接受后端 AdminRole 或运营岗「平台管理员」.
+
+    不接受账号名 / 展示角色旁路; 不得把运营岗写进 is_admin().
+    """
+    from bisheng.user.domain.services.platform_operator import can_platform_operate
+
+    if not can_platform_operate(login_user):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="System administrator access required",

--- a/src/backend/bisheng/points/domain/services/points_auth.py
+++ b/src/backend/bisheng/points/domain/services/points_auth.py
@@ -1,10 +1,18 @@
-"""积分写操作的统一平台超级管理员校验。"""
+"""积分写操作的统一平台运营资格校验.
+
+require_platform_admin = 超管或平台管理员.
+is_platform_super_admin 仍只认超管, 专家问答违规删除不要走前者.
+"""
 
 from bisheng.common.errcode.points import PointsPermissionDeniedError
+from bisheng.user.domain.services.platform_operator import can_platform_operate
 
 
 def is_platform_super_admin(user) -> bool:
-    """平台超管：RBAC AdminRole 或 JWT 已解析的 is_global_super。"""
+    """平台超管: RBAC AdminRole 或 JWT 已解析的 is_global_super.
+
+    不得把「平台管理员」算进来.
+    """
     if not user:
         return False
     if getattr(user, "is_global_super", False):
@@ -14,6 +22,6 @@ def is_platform_super_admin(user) -> bool:
 
 
 def require_platform_admin(user) -> None:
-    """不具备平台管理员身份时抛出积分模块错误码。"""
-    if not is_platform_super_admin(user):
+    """不具备运营写资格(超管或平台管理员)时抛出积分模块错误码."""
+    if not can_platform_operate(user):
         raise PointsPermissionDeniedError()

--- a/src/backend/bisheng/qa_expert/domain/moderate_delete_service.py
+++ b/src/backend/bisheng/qa_expert/domain/moderate_delete_service.py
@@ -7,8 +7,9 @@ import logging
 from dataclasses import dataclass
 from typing import Literal
 
+from bisheng.common.errcode.points import PointsPermissionDeniedError
 from bisheng.core.context.tenant import DEFAULT_TENANT_ID, get_current_tenant_id
-from bisheng.points.domain.services.points_auth import require_platform_admin
+from bisheng.points.domain.services.points_auth import is_platform_super_admin
 from bisheng.points.domain.services.points_pending_deduct_service import PointsPendingDeductService
 from bisheng.qa_expert.domain.repositories import (
     AnswerRepository,
@@ -70,7 +71,8 @@ class ModerateDeleteService:
         扣分失败不回滚删除, 写入 point_pending_deduct 供 Beat 补扣.
         删回答时级联硬删其下评论，扣分仅针对回答作者。
         """
-        require_platform_admin(operator)
+        if not is_platform_super_admin(operator):
+            raise PointsPermissionDeniedError()
         if target_type not in ("question", "answer", "comment"):
             raise PermissionDeniedError(message="unsupported target_type")
         if int(target_id) <= 0:

--- a/src/backend/bisheng/role/domain/services/role_service.py
+++ b/src/backend/bisheng/role/domain/services/role_service.py
@@ -34,6 +34,11 @@ from bisheng.role.domain.schemas.role_schema import (
 from bisheng.role.domain.services.quota_service import QuotaService
 from bisheng.user.domain.models.user import UserDao
 from bisheng.user.domain.models.user_role import UserRole
+from bisheng.user.domain.services.platform_operator import (
+    PLATFORM_OPERATOR_ROLE_NAME,
+    is_platform_operator_role_name,
+    strip_platform_operator_admin_menus,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +48,39 @@ SYSTEM_PRESET_CREATOR_NAME = '系统预设'
 
 class RoleService:
     """Stateless service for role CRUD operations."""
+
+    @classmethod
+    def _canonical_role_name(cls, role_name: str) -> str:
+        """保留名统一成精确四字, 避免首尾空格绕过唯一性."""
+        if is_platform_operator_role_name(role_name):
+            return PLATFORM_OPERATOR_ROLE_NAME
+        return role_name
+
+    @classmethod
+    async def _ensure_platform_operator_name_available(
+        cls,
+        tenant_id: int,
+        role_name: str,
+        exclude_role_id: Optional[int] = None,
+    ) -> None:
+        """保留名在租户内跨 department / role_type 唯一, 冲突则 24002."""
+        if not is_platform_operator_role_name(role_name):
+            return
+        existing = await RoleDao.aget_role_by_exact_name_in_tenant(
+            tenant_id=tenant_id,
+            role_name=PLATFORM_OPERATOR_ROLE_NAME,
+            exclude_id=exclude_role_id,
+        )
+        if existing:
+            raise RoleNameDuplicateError()
+
+    @classmethod
+    def _reject_platform_operator_rename(cls, role, new_name: Optional[str]) -> None:
+        """已有「平台管理员」行禁止改名, 24004."""
+        if not is_platform_operator_role_name(getattr(role, "role_name", None)):
+            return
+        if new_name is not None and str(new_name).strip() != PLATFORM_OPERATOR_ROLE_NAME:
+            raise RoleBuiltinProtectedError()
 
     # ── Create ──
 
@@ -64,12 +102,14 @@ class RoleService:
 
         # Determine role_type
         role_type = 'global' if login_user.is_admin() else 'tenant'
+        role_name = cls._canonical_role_name(req.role_name)
+        await cls._ensure_platform_operator_name_available(login_user.tenant_id, role_name)
 
         # Check duplicate name (AC-09)
         existing = await RoleDao.aget_role_by_name(
             tenant_id=login_user.tenant_id,
             role_type=role_type,
-            role_name=req.role_name,
+            role_name=role_name,
             department_id=req.department_id,
         )
         if existing:
@@ -82,7 +122,7 @@ class RoleService:
         await cls._ensure_create_scope(login_user, req.department_id)
 
         role = Role(
-            role_name=req.role_name,
+            role_name=role_name,
             role_type=role_type,
             department_id=req.department_id,
             quota_config=req.quota_config,
@@ -114,10 +154,12 @@ class RoleService:
             QuotaService.validate_role_quota_config(req.quota_config)
 
         role_type = 'global' if login_user.is_admin() else 'tenant'
+        role_name = cls._canonical_role_name(req.role_name)
+        await cls._ensure_platform_operator_name_available(login_user.tenant_id, role_name)
         existing = await RoleDao.aget_role_by_name(
             tenant_id=login_user.tenant_id,
             role_type=role_type,
-            role_name=req.role_name,
+            role_name=role_name,
             department_id=req.department_id,
         )
         if existing:
@@ -128,9 +170,9 @@ class RoleService:
 
         await cls._ensure_create_scope(login_user, req.department_id)
 
-        menu_ids = cls._normalize_menu_ids(req.menu_ids or [])
+        menu_ids = cls._normalize_menu_ids(req.menu_ids or [], role_name=role_name)
         role = Role(
-            role_name=req.role_name,
+            role_name=role_name,
             role_type=role_type,
             department_id=req.department_id,
             quota_config=req.quota_config,
@@ -359,6 +401,7 @@ class RoleService:
 
         await cls._check_role_permission(login_user)
         await cls._ensure_role_mutation_access(role, login_user)
+        cls._reject_platform_operator_rename(role, req.role_name)
 
         # Validate quota_config (AC-10c)
         if req.quota_config is not None:
@@ -366,11 +409,15 @@ class RoleService:
 
         # Check duplicate name if changing name (AC-09)
         if req.role_name and req.role_name != role.role_name:
+            target_name = cls._canonical_role_name(req.role_name)
+            await cls._ensure_platform_operator_name_available(
+                login_user.tenant_id, target_name, exclude_role_id=role_id,
+            )
             target_department_id = req.department_id if 'department_id' in req.model_fields_set else role.department_id
             existing = await RoleDao.aget_role_by_name(
                 tenant_id=login_user.tenant_id,
                 role_type=role.role_type,
-                role_name=req.role_name,
+                role_name=target_name,
                 department_id=target_department_id,
             )
             if existing and existing.id != role_id:
@@ -382,7 +429,7 @@ class RoleService:
 
         # Apply updates
         if req.role_name is not None:
-            role.role_name = req.role_name
+            role.role_name = cls._canonical_role_name(req.role_name)
         if req.quota_config is not None:
             role.quota_config = req.quota_config
         if req.remark is not None:
@@ -409,16 +456,21 @@ class RoleService:
 
         await cls._check_role_permission(login_user)
         await cls._ensure_role_mutation_access(role, login_user)
+        cls._reject_platform_operator_rename(role, req.role_name)
 
         if req.quota_config is not None:
             QuotaService.validate_role_quota_config(req.quota_config)
 
         if req.role_name and req.role_name != role.role_name:
+            target_name = cls._canonical_role_name(req.role_name)
+            await cls._ensure_platform_operator_name_available(
+                login_user.tenant_id, target_name, exclude_role_id=role_id,
+            )
             target_department_id = req.department_id if 'department_id' in req.model_fields_set else role.department_id
             existing = await RoleDao.aget_role_by_name(
                 tenant_id=login_user.tenant_id,
                 role_type=role.role_type,
-                role_name=req.role_name,
+                role_name=target_name,
                 department_id=target_department_id,
             )
             if existing and existing.id != role_id:
@@ -427,7 +479,10 @@ class RoleService:
         if req.department_id is not None:
             await cls._validate_department(req.department_id)
 
-        menu_ids = cls._normalize_menu_ids(req.menu_ids or [])
+        menu_ids = cls._normalize_menu_ids(
+            req.menu_ids or [],
+            role_name=cls._canonical_role_name(req.role_name) if req.role_name else role.role_name,
+        )
 
         async with get_async_db_session() as session:
             result = await session.exec(select(Role).where(Role.id == role_id))
@@ -436,7 +491,7 @@ class RoleService:
                 raise RoleNotFoundError()
 
             if req.role_name is not None:
-                db_role.role_name = req.role_name
+                db_role.role_name = cls._canonical_role_name(req.role_name)
             if req.quota_config is not None:
                 db_role.quota_config = req.quota_config
             if req.remark is not None:
@@ -469,6 +524,9 @@ class RoleService:
         role = await RoleDao.aget_role_by_id(role_id)
         if not role:
             raise RoleNotFoundError()
+
+        if is_platform_operator_role_name(role.role_name):
+            raise RoleBuiltinProtectedError()
 
         # Permission check (AC-06 equivalent)
         if not login_user.is_admin() and role.role_type == 'global':
@@ -504,7 +562,7 @@ class RoleService:
         await cls._check_role_permission(login_user)
         await cls._ensure_role_mutation_access(role, login_user)
 
-        normalized = cls._normalize_menu_ids(menu_ids)
+        normalized = cls._normalize_menu_ids(menu_ids, role_name=role.role_name)
         async with get_async_db_session() as session:
             result = await session.exec(select(Role).where(Role.id == role_id))
             db_role = result.first()
@@ -762,8 +820,8 @@ class RoleService:
             logger.warning('Failed to validate department %d: %s', department_id, e)
 
     @classmethod
-    def _normalize_menu_ids(cls, menu_ids: List[str]) -> List[str]:
-        """Deduplicate menu keys; strip system_config (reserved for super-admin / dept-admin)."""
+    def _normalize_menu_ids(cls, menu_ids: List[str], role_name: Optional[str] = None) -> List[str]:
+        """Deduplicate menu keys; strip system_config; 运营岗再丢掉管理端 key."""
         out: list[str] = []
         for menu_id in menu_ids:
             s = str(menu_id)
@@ -771,7 +829,7 @@ class RoleService:
                 continue
             if s not in out:
                 out.append(s)
-        return out
+        return strip_platform_operator_admin_menus(role_name, out)
 
     @classmethod
     async def _replace_menu_access_in_session(

--- a/src/backend/bisheng/sensitive_word/api/endpoints/policies.py
+++ b/src/backend/bisheng/sensitive_word/api/endpoints/policies.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends
 
 from bisheng.common.dependencies.user_deps import UserPayload
+from bisheng.common.errcode.llm_tenant import LLMModelSharedReadonlyError
 from bisheng.common.schemas.api import resp_200
 from bisheng.sensitive_word.domain.schemas import (
     SensitiveWordBusinessType,
@@ -9,15 +10,24 @@ from bisheng.sensitive_word.domain.schemas import (
 from bisheng.sensitive_word.domain.services.sensitive_word_policy_service import (
     SensitiveWordPolicyService,
 )
+from bisheng.user.domain.services.platform_operator import can_platform_operate
 
 router = APIRouter(prefix='/sensitive-word-policies', tags=['sensitive-word-policies'])
+
+
+def _require_policy_operator(login_user: UserPayload) -> UserPayload:
+    """敏感词策略读写: 超管或运营岗. 不扩大 get_tenant_admin_user."""
+    if not can_platform_operate(login_user):
+        raise LLMModelSharedReadonlyError()
+    return login_user
 
 
 @router.get('/{business_type}')
 async def get_sensitive_word_policy(
     business_type: SensitiveWordBusinessType,
-    login_user: UserPayload = Depends(UserPayload.get_tenant_admin_user),
+    login_user: UserPayload = Depends(UserPayload.get_login_user),
 ):
+    _require_policy_operator(login_user)
     policy = await SensitiveWordPolicyService.aget_policy(login_user, business_type)
     return resp_200(policy.model_dump())
 
@@ -26,7 +36,8 @@ async def get_sensitive_word_policy(
 async def update_sensitive_word_policy(
     business_type: SensitiveWordBusinessType,
     payload: SensitiveWordPolicyPayload,
-    login_user: UserPayload = Depends(UserPayload.get_tenant_admin_user),
+    login_user: UserPayload = Depends(UserPayload.get_login_user),
 ):
+    _require_policy_operator(login_user)
     policy = await SensitiveWordPolicyService.aupsert_policy(login_user, business_type, payload)
     return resp_200(policy.model_dump())

--- a/src/backend/bisheng/telemetry_search/domain/services/dashboard.py
+++ b/src/backend/bisheng/telemetry_search/domain/services/dashboard.py
@@ -162,8 +162,14 @@ class DashboardService(BaseModel):
             for component in components
         )
 
+    def _can_operate_dashboards(self) -> bool:
+        """超管或运营岗: 看板列表/实时写与超管同一口径."""
+        from bisheng.user.domain.services.platform_operator import can_platform_operate
+
+        return can_platform_operate(self.login_user)
+
     async def _is_department_admin(self) -> bool:
-        if self.login_user.is_admin():
+        if self._can_operate_dashboards():
             return True
         from bisheng.database.models.department import DepartmentDao
 
@@ -178,7 +184,7 @@ class DashboardService(BaseModel):
         dashboard_id: int,
         incoming_components: Sequence[DashboardComponent] = (),
     ) -> None:
-        if self.login_user.is_admin():
+        if self._can_operate_dashboards():
             return
         existing_components = await DashboardDao.get_components(dashboard_id)
         if self._uses_realtime_dataset(
@@ -212,7 +218,7 @@ class DashboardService(BaseModel):
             filter_types = [DashboardType.PRESET_COMMERCIAL, DashboardType.CUSTOM]
         is_department_admin = False
         components_by_dashboard_id = {}
-        if self.login_user.is_admin():
+        if self._can_operate_dashboards():
             res = await DashboardDao.get_dashboards(keyword=keyword, dashboard_type=filter_types)
         else:
             # find extra dashboard ids
@@ -259,7 +265,7 @@ class DashboardService(BaseModel):
             if components is None:
                 components = await DashboardDao.get_components(one.id)
             uses_realtime = self._uses_realtime_dataset(components)
-            if uses_realtime and not self.login_user.is_admin():
+            if uses_realtime and not self._can_operate_dashboards():
                 if (
                     one.status != DashboardStatus.PUBLISHED.value
                     or not is_department_admin
@@ -274,7 +280,7 @@ class DashboardService(BaseModel):
                     tmp.user_id == self.login_user.user_id
                     or tmp.id in manage_ids
                 )
-            ) or self.login_user.is_admin():
+            ) or self._can_operate_dashboards():
                 tmp.write = True
             result.append(tmp)
         return result
@@ -398,6 +404,7 @@ class DashboardService(BaseModel):
             raise NotFoundError()
         if not is_commercial() and dashboard.dashboard_type != DashboardType.PRESET_OSS.value:
             raise NotFoundError()
+        can_operate = self._can_operate_dashboards()
         write_flag = await self.login_user.async_access_check(dashboard.user_id, target_id=str(dashboard.id),
                                                               access_type=AccessType.DASHBOARD_WRITE)
         read_flag = write_flag or await self.login_user.async_access_check(
@@ -405,12 +412,16 @@ class DashboardService(BaseModel):
             target_id=str(dashboard.id),
             access_type=AccessType.DASHBOARD,
         )
+        # 运营岗/超管列表已走 admin 口径; 详情与组件查询不能再卡 ReBAC 读 tuple.
+        if can_operate:
+            read_flag = True
+            write_flag = True
         components = await DashboardDao.get_components(dashboard_id)
         uses_realtime = self._uses_realtime_dataset(components)
         department_realtime_view = (
             uses_realtime
             and dashboard.status == DashboardStatus.PUBLISHED.value
-            and not self.login_user.is_admin()
+            and not self._can_operate_dashboards()
             and await self._is_department_admin()
         )
         if not read_flag and not department_realtime_view:
@@ -419,7 +430,7 @@ class DashboardService(BaseModel):
 
             raise UnAuthorizedError()
 
-        if uses_realtime and not self.login_user.is_admin():
+        if uses_realtime and not self._can_operate_dashboards():
             if (
                 dashboard.status != DashboardStatus.PUBLISHED.value
                 or not await self._is_department_admin()
@@ -427,7 +438,7 @@ class DashboardService(BaseModel):
                 raise UnAuthorizedError()
         result = DashboardRead.model_validate(dashboard)
         result.write = write_flag and (
-            self.login_user.is_admin() or not uses_realtime
+            self._can_operate_dashboards() or not uses_realtime
         )
         default_dashboard = await DashboardDao.get_default_dashboard(user_id=self.login_user.user_id)
         if default_dashboard and default_dashboard.dashboard_id == result.id:
@@ -539,7 +550,7 @@ class DashboardService(BaseModel):
         dashboard = await DashboardDao.get_one(dashboard_id)
         if not dashboard:
             raise NotFoundError()
-        read_flag = await self.login_user.async_access_check(
+        read_flag = True if self._can_operate_dashboards() else await self.login_user.async_access_check(
             dashboard.user_id,
             target_id=str(dashboard.id),
             access_type=AccessType.DASHBOARD,
@@ -564,7 +575,7 @@ class DashboardService(BaseModel):
             raise NotFoundError()
         if (
             component.dataset_code in self.REALTIME_DATASETS
-            and not self.login_user.is_admin()
+            and not self._can_operate_dashboards()
             and dashboard.status != DashboardStatus.PUBLISHED.value
         ):
             raise UnAuthorizedError()

--- a/src/backend/bisheng/user/api/user.py
+++ b/src/backend/bisheng/user/api/user.py
@@ -187,18 +187,11 @@ async def get_admins(login_user: LoginUser = Depends(LoginUser.get_login_user)):
         raise HTTPException(status_code=500, detail="User information failed")
 
 
-_PORTAL_ADMIN_ROLE_NAMES = frozenset({"管理员", "系统管理员", "admin"})
-
-
 def _user_info_role_label(role, role_names: list[str] | None):
-    """AdminRole 仍返回 admin；若持有门户管理员角色名则下发该名。"""
-    if role == "admin":
-        return "admin"
-    for name in role_names or []:
-        text = str(name).strip()
-        if text in _PORTAL_ADMIN_ROLE_NAMES or text.lower() == "admin":
-            return text
-    return role
+    """AdminRole 仍返回 admin; 运营岗下发「平台管理员」; 门户整页管理员名仍下发该名."""
+    from bisheng.user.domain.services.platform_operator import resolve_user_info_role_label
+
+    return resolve_user_info_role_label(role, role_names)
 
 
 @router.get("/user/info")
@@ -220,7 +213,10 @@ async def get_info(login_user: LoginUser = Depends(LoginUser.get_login_user)):
         is_department_admin=is_department_admin,
     )
     # AdminRole 仍下发 admin；持有「管理员」等门户角色名时下发该名，供 Portal isPortalAdmin。
-    role = _user_info_role_label(role, getattr(login_user, "role_names", None))
+    from bisheng.user.domain.services.platform_operator import collect_user_info_role_names
+
+    role_names = collect_user_info_role_names(login_user)
+    role = _user_info_role_label(role, role_names)
     menu_approval_mode = await login_user.compute_menu_approval_mode(db_user)
     department_projection = await UserService.get_primary_department_name_projection(user_id)
 
@@ -278,6 +274,7 @@ async def get_info(login_user: LoginUser = Depends(LoginUser.get_login_user)):
             is_child_admin=is_child_admin,
             leaf_tenant_id=leaf_tenant_id,
             leaf_tenant_name=leaf_tenant_name,
+            role_names=role_names,
             **entry,
         )
     )

--- a/src/backend/bisheng/user/domain/models/user.py
+++ b/src/backend/bisheng/user/domain/models/user.py
@@ -158,6 +158,8 @@ class UserRead(UserBase):
     has_admin_console: bool | None = None
     # ``platform`` | ``workspace`` — both areas open → platform (管理后台).
     default_entry: str | None = None
+    # 角色显示名列表; 供门户识别「平台管理员」等自定义角色, 不是新表字段.
+    role_names: list[str] | None = None
 
 
 class UserQuery(UserBase):

--- a/src/backend/bisheng/user/domain/services/platform_operator.py
+++ b/src/backend/bisheng/user/domain/services/platform_operator.py
@@ -1,0 +1,115 @@
+"""首钢门户运营岗「平台管理员」身份判定.
+
+资格只认角色显示名精确匹配, 不得写入 is_admin() / get_admin_user().
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+PLATFORM_OPERATOR_ROLE_NAME = "平台管理员"
+
+
+def has_platform_operator_role(user: Any) -> bool:
+    """当前用户是否持有精确名为「平台管理员」的角色.
+
+    只读 user.role_names; trim 后全等才算. 不把「管理员」等整页管理员名算进来.
+    """
+    if user is None:
+        return False
+    names = getattr(user, "role_names", None)
+    if not names:
+        return False
+    if isinstance(names, str):
+        candidates = [names]
+    elif isinstance(names, (list, tuple, set, frozenset)):
+        candidates = list(names)
+    else:
+        return False
+    for raw in candidates:
+        if str(raw).strip() == PLATFORM_OPERATOR_ROLE_NAME:
+            return True
+    return False
+
+
+_PORTAL_ADMIN_ROLE_NAMES = frozenset({"管理员", "系统管理员", "admin"})
+
+# 与 Platform userContext.adminMenuKeys 对齐, 另含 sys; 运营岗 WEB_MENU 必须丢掉这些.
+PLATFORM_OPERATOR_ADMIN_MENU_KEYS = frozenset(
+    {
+        "admin",
+        "backend",
+        "board",
+        "model",
+        "log",
+        "knowledge",
+        "build",
+        "evaluation",
+        "system_config",
+        "mark_task",
+        "sys",
+    }
+)
+
+
+def is_platform_operator_role_name(role_name: Any) -> bool:
+    """角色显示名是否为保留名「平台管理员」(trim 后全等)."""
+    return str(role_name or "").strip() == PLATFORM_OPERATOR_ROLE_NAME
+
+
+def collect_user_info_role_names(login_user: Any) -> list[str]:
+    """从登录态取出 role_names, 供 /user/info 回显. 缺省空列表."""
+    names = getattr(login_user, "role_names", None) or []
+    return [str(n) for n in names]
+
+
+def strip_platform_operator_admin_menus(role_name: Any, menu_ids: list[str] | None) -> list[str]:
+    """运营岗保存 WEB_MENU 时丢掉管理端 key, 只留工作台类; 其它角色原样去重.
+
+    超管误勾 board/sys 也不能靠菜单进 Platform 管理端.
+    """
+    out: list[str] = []
+    drop_admin = is_platform_operator_role_name(role_name)
+    for menu_id in menu_ids or []:
+        key = str(menu_id)
+        if drop_admin and key in PLATFORM_OPERATOR_ADMIN_MENU_KEYS:
+            continue
+        if key not in out:
+            out.append(key)
+    return out
+
+
+def resolve_user_info_role_label(role: Any, role_names: list[str] | None) -> Any:
+    """/user/info 的 role 字段.
+
+    优先级: AdminRole→admin; 门户整页名(管理员/系统管理员/admin)不降级;
+    否则精确运营岗名; 否则保持入参. 不得把平台管理员并入整页白名单.
+    """
+    if role == "admin":
+        return "admin"
+    for name in role_names or []:
+        text = str(name).strip()
+        if text in _PORTAL_ADMIN_ROLE_NAMES or text.lower() == "admin":
+            return text
+    for name in role_names or []:
+        text = str(name).strip()
+        if text == PLATFORM_OPERATOR_ROLE_NAME:
+            return PLATFORM_OPERATOR_ROLE_NAME
+    return role
+
+
+def can_platform_operate(user: Any) -> bool:
+    """运营写资格: 超管或平台管理员.
+
+    超管走 is_admin() / is_global_super; 运营岗只走角色名. 两者是并集, 不互相改写.
+    """
+    if user is None:
+        return False
+    if bool(getattr(user, "is_global_super", False)):
+        return True
+    check = getattr(user, "is_admin", None)
+    if callable(check) and bool(check()):
+        return True
+    if not callable(check) and bool(check):
+        return True
+    return has_platform_operator_role(user)

--- a/src/backend/bisheng/workstation/domain/services/tag_console_service.py
+++ b/src/backend/bisheng/workstation/domain/services/tag_console_service.py
@@ -56,8 +56,8 @@ from bisheng.workstation.domain.services.workstation_tags_service import WorkSta
 class TagConsoleService:
     """Reads for the console's library mode.
 
-    Tag Console 库管理门禁独立于门户标签审核 scope：仅超管 / 租户管理员 /
-    部门管理员可进入。库 admin/creator 即使能审标签，也不能获得全租户库管理权。
+    Tag Console 库管理门禁独立于门户标签审核 scope: 仅超管 / 运营岗 / 租户管理员 /
+    部门管理员可进入. 库 admin/creator 即使能审标签, 也不能获得全租户库管理权.
     控制台内审核子能力仍委托 ``WorkStationTagsService``（走 ReviewTagScope）。
     """
 
@@ -77,14 +77,12 @@ class TagConsoleService:
             raise TagConsolePageParamsError()
 
     async def _ensure_can_manage_tags(self) -> None:
-        """仅放行超管 / RBAC admin / 子租户管理员 / 部门管理员。"""
+        """仅放行超管 / RBAC admin / 运营岗 / 子租户管理员 / 部门管理员."""
         from bisheng.common.errcode.tag import ReviewTagPermissionDeniedError
+        from bisheng.user.domain.services.platform_operator import can_platform_operate
 
         login_user = self.login_user
-        if bool(getattr(login_user, "is_global_super", False)):
-            return
-        is_admin_fn = getattr(login_user, "is_admin", None)
-        if callable(is_admin_fn) and is_admin_fn():
+        if can_platform_operate(login_user):
             return
 
         has_tenant_admin = getattr(login_user, "has_tenant_admin", None)

--- a/src/backend/test/dictionary/test_platform_operator_dictionary.py
+++ b/src/backend/test/dictionary/test_platform_operator_dictionary.py
@@ -1,0 +1,218 @@
+"""AT-29: 运营岗可创建系统字典, 普通用户 19102 且无脏行."""
+
+from __future__ import annotations
+
+import os
+import re
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+from fastapi.responses import JSONResponse
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from bisheng.common.errcode.base import BaseErrorCode
+from bisheng.common.errcode.dictionary import DictionaryPermissionDeniedError
+from bisheng.dictionary.domain.services.dictionary_service import DictionaryService
+from bisheng.user.domain.services.platform_operator import PLATFORM_OPERATOR_ROLE_NAME
+
+
+def _ops_user(*, user_id: int = 88003001) -> SimpleNamespace:
+    return SimpleNamespace(
+        user_id=user_id,
+        user_name="ops-dict-admin",
+        tenant_id=1,
+        is_admin=lambda: False,
+        is_global_super=False,
+        role_names=[PLATFORM_OPERATOR_ROLE_NAME],
+    )
+
+
+def _plain_user(*, user_id: int = 88003002) -> SimpleNamespace:
+    return SimpleNamespace(
+        user_id=user_id,
+        user_name="plain-dict-user",
+        tenant_id=1,
+        is_admin=lambda: False,
+        is_global_super=False,
+        role_names=["普通用户"],
+    )
+
+
+def test_ensure_admin_allows_operator() -> None:
+    DictionaryService._ensure_admin(_ops_user())
+
+
+def test_ensure_admin_rejects_ordinary() -> None:
+    with pytest.raises(DictionaryPermissionDeniedError) as exc:
+        DictionaryService._ensure_admin(_plain_user())
+    assert exc.value.Code == 19102
+
+
+def _mysql_async_url() -> str:
+    override = os.environ.get("QA_EXPERT_FLOW_DATABASE_URL") or os.environ.get(
+        "PLATFORM_OPERATOR_FLOW_DATABASE_URL"
+    )
+    if override:
+        return override.replace("pymysql", "aiomysql")
+    from bisheng.core.config.settings import decrypt_token
+
+    cfg_name = os.environ.get("config", "config.yaml")
+    cfg_path = Path(__file__).resolve().parents[2] / "bisheng" / Path(cfg_name).name
+    loaded = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    url = loaded["database_url"]
+    if not isinstance(url, str):
+        raise RuntimeError("config.yaml database_url 不是字符串")
+    match = re.search(r"(?<=:)[^:]+(?=@)", url)
+    if match:
+        url = re.sub(r"(?<=:)[^:]+(?=@)", decrypt_token(match.group(0)), url)
+    if "171" not in url and not override:
+        raise RuntimeError("流转测试默认打 192.168.106.171, 请确认 config.yaml")
+    return url.replace("pymysql", "aiomysql")
+
+
+@pytest.fixture
+async def mysql_engine():
+    from bisheng.core.context.tenant import set_current_tenant_id
+    from bisheng.core.database.connection import _patch_aiomysql_pre_ping
+
+    set_current_tenant_id(1)
+    _patch_aiomysql_pre_ping()
+    engine = create_async_engine(_mysql_async_url(), pool_pre_ping=True)
+    yield engine
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_ops_create_dictionary_flow_mysql(mysql_engine):
+    """U-ops POST /dictoption/create 落 system_dictionary; 再按 type GET; U-user 19102."""
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+
+    from bisheng.common.dependencies.core_deps import get_db_session
+    from bisheng.common.dependencies.user_deps import UserPayload
+    from bisheng.core.database.connection import _patch_aiomysql_pre_ping
+    from bisheng.dictionary.api.endpoints.dictionary_endpoint import router as dict_router
+
+    _patch_aiomysql_pre_ping()
+    engine = mysql_engine
+    suffix = uuid.uuid4().hex[:8]
+    ops = _ops_user(user_id=88_003_000 + (int(suffix[:6], 16) % 90_000))
+    plain = _plain_user(user_id=ops.user_id + 1)
+    auth: dict = {"user": ops}
+    dict_type = "expert_major"
+    dict_key = f"opsdict{suffix}"
+    dict_value = f"ops-dict-flow-{suffix}"
+
+    async def patched_db():
+        session = AsyncSession(bind=engine, expire_on_commit=False)
+        try:
+            yield session
+        finally:
+            await session.close()
+
+    app = FastAPI()
+
+    @app.exception_handler(BaseErrorCode)
+    async def _biz(_req, exc: BaseErrorCode):
+        return JSONResponse(
+            {"status_code": exc.code, "status_message": exc.message, "data": None},
+            status_code=200,
+        )
+
+    app.include_router(dict_router, prefix="/api/v1")
+    app.dependency_overrides[UserPayload.get_login_user] = lambda: auth["user"]
+    app.dependency_overrides[get_db_session] = patched_db
+
+    async def _count(session, key: str = dict_key) -> int:
+        return int(
+            (
+                await session.execute(
+                    text("SELECT COUNT(*) FROM system_dictionary WHERE dict_key = :k"),
+                    {"k": key},
+                )
+            ).scalar_one()
+        )
+
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            created = await client.post(
+                "/api/v1/dictoption/create",
+                json={
+                    "type": dict_type,
+                    "dict_key": dict_key,
+                    "dict_value": dict_value,
+                    "sort_order": 0,
+                    "is_enabled": True,
+                },
+            )
+            body_created = created.json()
+            assert created.status_code == 200
+            assert body_created["status_code"] == 200, body_created
+            assert body_created["data"]["dict_key"] == dict_key
+            row_id = int(body_created["data"]["id"])
+
+            async with AsyncSession(engine, expire_on_commit=False) as session:
+                row = (
+                    await session.execute(
+                        text(
+                            "SELECT id, dict_value, is_enabled, tenant_id FROM system_dictionary "
+                            "WHERE dict_key = :k ORDER BY id DESC LIMIT 1"
+                        ),
+                        {"k": dict_key},
+                    )
+                ).first()
+                count1 = await _count(session)
+            assert row is not None, body_created
+            assert int(row[0]) == row_id
+            assert str(row[1]) == dict_value
+            assert int(row[2]) == 1
+            assert int(row[3] or 0) in {0, 1}
+            assert count1 == 1
+
+            listed = await client.get(
+                f"/api/v1/dictoption/type/{dict_type}",
+                params={"page": 1, "page_size": 500},
+            )
+            body_listed = listed.json()
+            assert listed.status_code == 200
+            assert body_listed["status_code"] == 200, body_listed
+            keys = {item["dict_key"] for item in body_listed["data"]}
+            assert dict_key in keys
+
+            again = await client.get(f"/api/v1/dictoption/query/{row_id}")
+            body_again = again.json()
+            assert again.status_code == 200
+            assert body_again["status_code"] == 200, body_again
+            assert body_again["data"]["dict_key"] == dict_key
+
+            auth["user"] = plain
+            denied = await client.post(
+                "/api/v1/dictoption/create",
+                json={
+                    "type": dict_type,
+                    "dict_key": f"{dict_key}x",
+                    "dict_value": dict_value,
+                    "sort_order": 0,
+                    "is_enabled": True,
+                },
+            )
+            body_denied = denied.json()
+            assert denied.status_code == 200
+            assert body_denied["status_code"] == 19102
+            async with AsyncSession(engine, expire_on_commit=False) as session:
+                assert await _count(session) == 1
+                extra = await _count(session, f"{dict_key}x")
+            assert int(extra) == 0
+    finally:
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            await session.execute(
+                text("DELETE FROM system_dictionary WHERE dict_key IN (:k, :kx)"),
+                {"k": dict_key, "kx": f"{dict_key}x"},
+            )
+            await session.commit()

--- a/src/backend/test/knowledge/test_knowledge_migration_auth.py
+++ b/src/backend/test/knowledge/test_knowledge_migration_auth.py
@@ -23,11 +23,22 @@ def test_system_admin_gate_uses_login_user_admin_role_only():
     assert require_system_admin(user) is user
 
 
+def test_system_admin_gate_allows_platform_operator_role_names():
+    user = SimpleNamespace(
+        is_admin=lambda: False,
+        is_global_super=False,
+        role_names=["平台管理员"],
+    )
+
+    assert require_system_admin(user) is user
+
+
 @pytest.mark.parametrize(
     "user",
     [
         FakeUser(False),
         SimpleNamespace(account="admin", user_role=["管理员"]),
+        SimpleNamespace(account="admin", is_admin=lambda: False, role_names=["管理员"]),
         None,
     ],
 )

--- a/src/backend/test/knowledge/test_platform_operator_migration.py
+++ b/src/backend/test/knowledge/test_platform_operator_migration.py
@@ -1,0 +1,280 @@
+"""AT-22/23: 运营岗可全库迁移建批, 普通用户 403 且无脏行."""
+
+from __future__ import annotations
+
+import os
+import re
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from bisheng.knowledge.domain.repositories.interfaces.knowledge_migration_source_repository import (
+    MigrationSpaceRecord,
+)
+from bisheng.knowledge.domain.services.knowledge_migration_service import (
+    NormalizedBatchInput,
+    require_system_admin,
+)
+from bisheng.user.domain.services.platform_operator import PLATFORM_OPERATOR_ROLE_NAME
+
+
+def _ops_user(*, user_id: int = 88002001) -> SimpleNamespace:
+    return SimpleNamespace(
+        user_id=user_id,
+        user_name="ops-migration-admin",
+        tenant_id=1,
+        is_admin=lambda: False,
+        is_global_super=False,
+        role_names=[PLATFORM_OPERATOR_ROLE_NAME],
+    )
+
+
+def _plain_user(*, user_id: int = 88002002) -> SimpleNamespace:
+    return SimpleNamespace(
+        user_id=user_id,
+        user_name="plain-migration-user",
+        tenant_id=1,
+        is_admin=lambda: False,
+        is_global_super=False,
+        role_names=["普通用户"],
+    )
+
+
+def test_require_system_admin_allows_operator() -> None:
+    ops = _ops_user()
+    assert require_system_admin(ops) is ops
+    assert ops.is_admin() is False
+
+
+def test_require_system_admin_rejects_ordinary() -> None:
+    with pytest.raises(HTTPException) as exc:
+        require_system_admin(_plain_user())
+    assert exc.value.status_code == 403
+
+
+def test_require_system_admin_rejects_account_name_bypass() -> None:
+    with pytest.raises(HTTPException) as exc:
+        require_system_admin(
+            SimpleNamespace(account="admin", is_admin=lambda: False, role_names=["管理员"])
+        )
+    assert exc.value.status_code == 403
+
+
+def _mysql_async_url() -> str:
+    override = os.environ.get("QA_EXPERT_FLOW_DATABASE_URL") or os.environ.get(
+        "PLATFORM_OPERATOR_FLOW_DATABASE_URL"
+    )
+    if override:
+        return override.replace("pymysql", "aiomysql")
+    from bisheng.core.config.settings import decrypt_token
+
+    cfg_name = os.environ.get("config", "config.yaml")
+    cfg_path = Path(__file__).resolve().parents[2] / "bisheng" / Path(cfg_name).name
+    loaded = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    url = loaded["database_url"]
+    if not isinstance(url, str):
+        raise RuntimeError("config.yaml database_url 不是字符串")
+    match = re.search(r"(?<=:)[^:]+(?=@)", url)
+    if match:
+        url = re.sub(r"(?<=:)[^:]+(?=@)", decrypt_token(match.group(0)), url)
+    if "171" not in url and not override:
+        raise RuntimeError("流转测试默认打 192.168.106.171, 请确认 config.yaml")
+    return url.replace("pymysql", "aiomysql")
+
+
+@pytest.fixture
+async def mysql_engine():
+    from bisheng.core.context.tenant import set_current_tenant_id
+    from bisheng.core.database.connection import _patch_aiomysql_pre_ping
+
+    set_current_tenant_id(1)
+    _patch_aiomysql_pre_ping()
+    engine = create_async_engine(_mysql_async_url(), pool_pre_ping=True)
+    yield engine
+    await engine.dispose()
+
+
+def _normalized_input() -> NormalizedBatchInput:
+    src = SimpleNamespace(id=91_000_101, name="ops-src-space", model="x")
+    dst = SimpleNamespace(id=91_000_102, name="ops-dst-space", model="x")
+    return NormalizedBatchInput(
+        selections=[{"space_id": int(src.id), "nodes": [{"node_type": "file", "node_id": 1}]}],
+        source_spaces=[
+            MigrationSpaceRecord(space=src, level="public", owner_type="user", owner_id=1)
+        ],
+        target_space=MigrationSpaceRecord(
+            space=dst, level="public", owner_type="user", owner_id=1
+        ),
+        target_folder_name=None,
+        target_path="/",
+    )
+
+
+@pytest.mark.asyncio
+async def test_ops_migration_flow_mysql(mysql_engine, monkeypatch):
+    """U-ops GET 含非本人库; POST 落 knowledge_migration_batch; U-user 403 无新行."""
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+
+    from bisheng.common.dependencies.core_deps import get_db_session
+    from bisheng.common.dependencies.user_deps import UserPayload
+    from bisheng.core.database.connection import _patch_aiomysql_pre_ping
+    from bisheng.knowledge.api.endpoints.knowledge_migration import router as migration_router
+    from bisheng.knowledge.domain.services.knowledge_migration_service import (
+        KnowledgeMigrationService,
+    )
+
+    _patch_aiomysql_pre_ping()
+    engine = mysql_engine
+    suffix = uuid.uuid4().hex[:8]
+    ops = _ops_user(user_id=88_002_000 + (int(suffix[:6], 16) % 90_000))
+    plain = _plain_user(user_id=ops.user_id + 1)
+    auth: dict = {"user": ops}
+    ops_request_id = f"ops-mig-{suffix}"
+    user_request_id = f"user-mig-{suffix}"
+    other_space_id = 91_000_201
+    mine_space_id = 91_000_202
+
+    async def patched_db():
+        session = AsyncSession(bind=engine, expire_on_commit=False)
+        try:
+            yield session
+        finally:
+            await session.close()
+
+    async def fake_list_spaces(self, *, keyword, level, offset, limit):
+        del self, keyword, level, offset, limit
+        # 与超管同一口径: 列表不按当前用户过滤, 含非本人库.
+        return (
+            [
+                MigrationSpaceRecord(
+                    space=SimpleNamespace(id=mine_space_id, name="mine-space"),
+                    level="public",
+                    owner_type="user",
+                    owner_id=ops.user_id,
+                ),
+                MigrationSpaceRecord(
+                    space=SimpleNamespace(id=other_space_id, name="other-owned"),
+                    level="public",
+                    owner_type="user",
+                    owner_id=ops.user_id + 999,
+                ),
+            ],
+            2,
+        )
+
+    async def fake_normalize(self, request):
+        del self, request
+        return _normalized_input()
+
+    monkeypatch.setattr(
+        "bisheng.knowledge.domain.repositories.implementations."
+        "knowledge_migration_source_repository_impl.KnowledgeMigrationSourceRepositoryImpl.list_spaces",
+        fake_list_spaces,
+    )
+    monkeypatch.setattr(KnowledgeMigrationService, "_normalize_create", fake_normalize)
+    monkeypatch.setattr(
+        "bisheng.knowledge.domain.services.knowledge_migration_service."
+        "CeleryKnowledgeMigrationTaskDispatcher.dispatch_preflight",
+        lambda self, batch_id: "ops-mig-preflight",
+    )
+
+    app = FastAPI()
+    app.include_router(migration_router, prefix="/api/v1")
+    app.dependency_overrides[UserPayload.get_login_user] = lambda: auth["user"]
+    app.dependency_overrides[get_db_session] = patched_db
+
+    create_body = {
+        "request_id": ops_request_id,
+        "source_selections": [{"space_id": 91_000_101, "nodes": [{"node_type": "file", "node_id": 1}]}],
+        "target_space_id": 91_000_102,
+        "preserve_structure": True,
+        "conflict_strategy": "skip",
+    }
+
+    async def _count(session, request_id: str) -> int:
+        return int(
+            (
+                await session.execute(
+                    text(
+                        "SELECT COUNT(*) FROM knowledge_migration_batch "
+                        "WHERE tenant_id = 1 AND request_id = :rid AND deleted_at IS NULL"
+                    ),
+                    {"rid": request_id},
+                )
+            ).scalar_one()
+        )
+
+    batch_no = None
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            spaces = await client.get("/api/v1/knowledge/migrations/spaces")
+            body_spaces = spaces.json()
+            assert spaces.status_code == 200
+            assert body_spaces["status_code"] == 200, body_spaces
+            space_ids = {int(item["id"]) for item in body_spaces["data"]["data"]}
+            assert other_space_id in space_ids
+            assert mine_space_id in space_ids
+
+            created = await client.post("/api/v1/knowledge/migrations/batches", json=create_body)
+            body_created = created.json()
+            assert created.status_code == 200
+            assert body_created["status_code"] == 200, body_created
+            batch_no = body_created["data"]["batch_no"]
+            assert body_created["data"]["operator_id"] == ops.user_id
+
+            async with AsyncSession(engine, expire_on_commit=False) as session:
+                row = (
+                    await session.execute(
+                        text(
+                            "SELECT operator_id, operator_name, request_id FROM knowledge_migration_batch "
+                            "WHERE tenant_id = 1 AND batch_no = :bno AND deleted_at IS NULL"
+                        ),
+                        {"bno": batch_no},
+                    )
+                ).first()
+                ops_count = await _count(session, ops_request_id)
+            assert row is not None
+            assert int(row[0]) == ops.user_id
+            assert str(row[1]) == ops.user_name
+            assert str(row[2]) == ops_request_id
+            assert ops_count == 1
+
+            again = await client.get(f"/api/v1/knowledge/migrations/batches/{batch_no}")
+            body_again = again.json()
+            assert again.status_code == 200
+            assert body_again["status_code"] == 200, body_again
+            assert body_again["data"]["batch_no"] == batch_no
+            assert body_again["data"]["operator_id"] == ops.user_id
+
+            auth["user"] = plain
+            denied = await client.post(
+                "/api/v1/knowledge/migrations/batches",
+                json={**create_body, "request_id": user_request_id},
+            )
+            assert denied.status_code == 403
+
+            spaces_denied = await client.get("/api/v1/knowledge/migrations/spaces")
+            assert spaces_denied.status_code == 403
+
+            async with AsyncSession(engine, expire_on_commit=False) as session:
+                assert await _count(session, user_request_id) == 0
+                assert await _count(session, ops_request_id) == 1
+    finally:
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            await session.execute(
+                text(
+                    "DELETE FROM knowledge_migration_batch "
+                    "WHERE tenant_id = 1 AND request_id IN (:ops_rid, :user_rid)"
+                ),
+                {"ops_rid": ops_request_id, "user_rid": user_request_id},
+            )
+            await session.commit()

--- a/src/backend/test/points/test_platform_operator_points_admin.py
+++ b/src/backend/test/points/test_platform_operator_points_admin.py
@@ -1,0 +1,245 @@
+"""AT-21/48/80: 运营岗可积分调账, 不是超管, 解绑失效, 不能专家问答违规删."""
+
+from __future__ import annotations
+
+import os
+import re
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+import yaml
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from bisheng.common.errcode.points import PointsPermissionDeniedError
+from bisheng.points.domain.services.points_auth import is_platform_super_admin, require_platform_admin
+from bisheng.qa_expert.domain.moderate_delete_service import ModerateDeleteService
+from bisheng.user.domain.services.platform_operator import PLATFORM_OPERATOR_ROLE_NAME
+
+
+def _ops_user(*, user_id: int = 88001001) -> SimpleNamespace:
+    return SimpleNamespace(
+        user_id=user_id,
+        user_name="ops-points-admin",
+        tenant_id=1,
+        is_admin=lambda: False,
+        is_global_super=False,
+        role_names=[PLATFORM_OPERATOR_ROLE_NAME],
+    )
+
+
+def _plain_user(*, user_id: int = 88001002) -> SimpleNamespace:
+    return SimpleNamespace(
+        user_id=user_id,
+        user_name="plain-points-user",
+        tenant_id=1,
+        is_admin=lambda: False,
+        is_global_super=False,
+        role_names=["普通用户"],
+    )
+
+
+def test_is_platform_super_admin_rejects_operator() -> None:
+    ops = _ops_user()
+    assert is_platform_super_admin(ops) is False
+    assert ops.is_admin() is False
+
+
+def test_require_platform_admin_allows_operator() -> None:
+    require_platform_admin(_ops_user())
+
+
+def test_require_platform_admin_still_rejects_ordinary() -> None:
+    with pytest.raises(PointsPermissionDeniedError) as exc:
+        require_platform_admin(_plain_user())
+    assert exc.value.Code == 18201
+
+
+@pytest.mark.asyncio
+async def test_moderate_delete_rejects_operator() -> None:
+    """AT-48: 扩积分闸门后, 专家问答违规删仍只认超管."""
+    svc = ModerateDeleteService()
+    svc.question_repo = AsyncMock()
+    with pytest.raises(PointsPermissionDeniedError) as exc:
+        await svc.moderate_delete(operator=_ops_user(), target_type="question", target_id=1)
+    assert exc.value.Code == 18201
+    svc.question_repo.get_by_id.assert_not_called()
+
+
+def _mysql_async_url() -> str:
+    override = os.environ.get("QA_EXPERT_FLOW_DATABASE_URL") or os.environ.get("PLATFORM_OPERATOR_FLOW_DATABASE_URL")
+    if override:
+        return override.replace("pymysql", "aiomysql")
+    from bisheng.core.config.settings import decrypt_token
+
+    cfg_name = os.environ.get("config", "config.yaml")
+    cfg_path = Path(__file__).resolve().parents[2] / "bisheng" / Path(cfg_name).name
+    loaded = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    url = loaded["database_url"]
+    if not isinstance(url, str):
+        raise RuntimeError("config.yaml database_url 不是字符串")
+    match = re.search(r"(?<=:)[^:]+(?=@)", url)
+    if match:
+        url = re.sub(r"(?<=:)[^:]+(?=@)", decrypt_token(match.group(0)), url)
+    if "171" not in url and not override:
+        raise RuntimeError("流转测试默认打 192.168.106.171, 请确认 config.yaml")
+    return url.replace("pymysql", "aiomysql")
+
+
+@pytest.fixture
+async def mysql_engine():
+    from bisheng.core.context.tenant import set_current_tenant_id
+    from bisheng.core.database.connection import _patch_aiomysql_pre_ping
+
+    set_current_tenant_id(1)
+    _patch_aiomysql_pre_ping()
+    engine = create_async_engine(_mysql_async_url(), pool_pre_ping=True)
+    yield engine
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_ops_adjust_flow_mysql(mysql_engine, monkeypatch):
+    """U-ops 调账落库; U-user 18201 无脏行; 清空 role_names 后再调 18201."""
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+
+    from bisheng.common.dependencies.core_deps import get_db_session
+    from bisheng.common.dependencies.user_deps import UserPayload
+    from bisheng.core.database.connection import _patch_aiomysql_pre_ping
+    from bisheng.points.api.endpoints.admin import router as points_admin_router
+
+    _patch_aiomysql_pre_ping()
+    engine = mysql_engine
+    suffix = uuid.uuid4().hex[:8]
+    target_uid = 88_001_000 + (int(suffix[:6], 16) % 90_000)
+    remark = f"ops-pts-flow-{suffix}-adjust"
+    delta = 7
+    auth: dict = {"user": _ops_user(user_id=target_uid + 1)}
+
+    async def patched_db():
+        session = AsyncSession(bind=engine, expire_on_commit=False)
+        try:
+            yield session
+        finally:
+            await session.close()
+
+    monkeypatch.setattr(
+        "bisheng.points.domain.services.points_notify_service.PointsNotifyService.notify",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "bisheng.points.domain.services.points_query_service.PointsQueryService._leaderboard_display_maps",
+        AsyncMock(return_value=({target_uid: "target"}, {})),
+    )
+
+    async def _fake_user_types(_ids):
+        return {int(i): "普通用户" for i in _ids}
+
+    monkeypatch.setattr(
+        "bisheng.points.domain.constants.admin_user_type.resolve_user_types_for_admin_list",
+        _fake_user_types,
+    )
+
+    app = FastAPI()
+    app.include_router(points_admin_router, prefix="/api/v1/points")
+    app.dependency_overrides[UserPayload.get_login_user] = lambda: auth["user"]
+    app.dependency_overrides[get_db_session] = patched_db
+
+    async def _log_count(session) -> int:
+        return int(
+            (
+                await session.execute(
+                    text("SELECT COUNT(*) FROM user_point_log WHERE tenant_id = 1 AND user_id = :uid AND remark = :r"),
+                    {"uid": target_uid, "r": remark},
+                )
+            ).scalar_one()
+        )
+
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            r1 = await client.post(
+                "/api/v1/points/admin/adjust",
+                json={"user_id": target_uid, "delta": delta, "remark": remark},
+            )
+            body1 = r1.json()
+            assert r1.status_code == 200
+            assert body1["status_code"] == 200, body1
+            assert body1["data"]["delta"] == delta
+
+            async with AsyncSession(engine, expire_on_commit=False) as session:
+                log_row = (
+                    await session.execute(
+                        text(
+                            "SELECT delta, balance_after, operator_id FROM user_point_log "
+                            "WHERE tenant_id = 1 AND user_id = :uid AND remark = :r "
+                            "ORDER BY id DESC LIMIT 1"
+                        ),
+                        {"uid": target_uid, "r": remark},
+                    )
+                ).first()
+                bal = (
+                    await session.execute(
+                        text("SELECT balance FROM user_point_account WHERE tenant_id = 1 AND user_id = :uid"),
+                        {"uid": target_uid},
+                    )
+                ).scalar_one()
+                count1 = await _log_count(session)
+            assert log_row is not None
+            assert int(log_row[0]) == delta
+            assert int(log_row[1]) == int(bal)
+            assert int(log_row[2]) == auth["user"].user_id
+            assert count1 == 1
+
+            r2 = await client.get(f"/api/v1/points/admin/users/{target_uid}/detail")
+            body2 = r2.json()
+            assert r2.status_code == 200
+            assert body2["status_code"] == 200, body2
+            assert int(body2["data"]["balance"]) == int(bal)
+
+            auth["user"] = _plain_user(user_id=target_uid + 2)
+            r3 = await client.post(
+                "/api/v1/points/admin/adjust",
+                json={"user_id": target_uid, "delta": delta, "remark": remark},
+            )
+            body3 = r3.json()
+            assert r3.status_code == 200
+            assert body3["status_code"] == 18201
+            async with AsyncSession(engine, expire_on_commit=False) as session:
+                assert await _log_count(session) == count1
+
+            unbound = _ops_user(user_id=target_uid + 1)
+            unbound.role_names = []
+            auth["user"] = unbound
+            r4 = await client.post(
+                "/api/v1/points/admin/adjust",
+                json={"user_id": target_uid, "delta": delta, "remark": remark},
+            )
+            body4 = r4.json()
+            assert r4.status_code == 200
+            assert body4["status_code"] == 18201
+            async with AsyncSession(engine, expire_on_commit=False) as session:
+                assert await _log_count(session) == count1
+    finally:
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            await session.execute(
+                text(
+                    "DELETE FROM point_sync_outbox WHERE log_id IN "
+                    "(SELECT id FROM user_point_log WHERE tenant_id = 1 AND user_id = :uid)"
+                ),
+                {"uid": target_uid},
+            )
+            await session.execute(
+                text("DELETE FROM user_point_log WHERE tenant_id = 1 AND user_id = :uid"),
+                {"uid": target_uid},
+            )
+            await session.execute(
+                text("DELETE FROM user_point_account WHERE tenant_id = 1 AND user_id = :uid"),
+                {"uid": target_uid},
+            )
+            await session.commit()

--- a/src/backend/test/role/test_platform_operator_reserved_name.py
+++ b/src/backend/test/role/test_platform_operator_reserved_name.py
@@ -1,0 +1,521 @@
+"""AT-01/02/04/90: 保留名「平台管理员」租户内唯一、禁改名删除、剥离管理端菜单."""
+
+from __future__ import annotations
+
+import os
+import re
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from bisheng.common.errcode.role import RoleBuiltinProtectedError, RoleNameDuplicateError
+from bisheng.role.domain.schemas.role_schema import RoleCreateRequest, RoleUpdateRequest
+from bisheng.role.domain.services.role_service import RoleService
+from bisheng.user.domain.services.platform_operator import (
+    PLATFORM_OPERATOR_ROLE_NAME,
+    strip_platform_operator_admin_menus,
+)
+
+
+def _admin_user():
+    user = MagicMock()
+    user.user_id = 1
+    user.tenant_id = 1
+    user.is_admin.return_value = True
+    return user
+
+
+def _make_role(role_id, role_name=PLATFORM_OPERATOR_ROLE_NAME, role_type="global", department_id=None):
+    role = MagicMock()
+    role.id = role_id
+    role.role_name = role_name
+    role.role_type = role_type
+    role.department_id = department_id
+    role.tenant_id = 1
+    role.remark = None
+    return role
+
+
+def test_strip_admin_menus_drops_board_and_sys_for_operator() -> None:
+    kept = strip_platform_operator_admin_menus(
+        PLATFORM_OPERATOR_ROLE_NAME,
+        ["board", "sys", "workstation", "board", "frontend"],
+    )
+    assert "board" not in kept
+    assert "sys" not in kept
+    assert "workstation" in kept
+    assert "frontend" in kept
+
+
+def test_strip_admin_menus_keeps_board_for_other_roles() -> None:
+    kept = strip_platform_operator_admin_menus("普通用户", ["board", "workstation"])
+    assert "board" in kept
+    assert "workstation" in kept
+
+
+def test_normalize_menu_ids_strips_operator_admin_keys() -> None:
+    out = RoleService._normalize_menu_ids(
+        ["board", "sys", "workstation", "system_config"],
+        role_name=PLATFORM_OPERATOR_ROLE_NAME,
+    )
+    assert "board" not in out
+    assert "sys" not in out
+    assert "system_config" not in out
+    assert "workstation" in out
+
+
+@pytest.mark.asyncio
+async def test_create_reserved_name_unique_across_department() -> None:
+    """同租户任意 department 再创建保留名 → 24002."""
+    admin = _admin_user()
+    first = RoleCreateRequest(role_name=PLATFORM_OPERATOR_ROLE_NAME)
+    second = RoleCreateRequest(role_name=PLATFORM_OPERATOR_ROLE_NAME, department_id=99)
+    created = _make_role(41)
+
+    with (
+        patch.object(RoleService, "_check_role_permission", new=AsyncMock()),
+        patch.object(RoleService, "_ensure_create_scope", new=AsyncMock()),
+        patch.object(RoleService, "_validate_department", new=AsyncMock()),
+        patch("bisheng.role.domain.services.role_service.Role") as mock_role_cls,
+        patch("bisheng.role.domain.services.role_service.RoleDao") as mock_dao,
+        patch("bisheng.role.domain.services.role_service.QuotaService"),
+    ):
+        mock_role_cls.return_value = created
+        mock_dao.aget_role_by_name = AsyncMock(return_value=None)
+        mock_dao.ainsert_role = AsyncMock(return_value=created)
+        mock_dao.aget_role_by_exact_name_in_tenant = AsyncMock(side_effect=[None, created])
+
+        result = await RoleService.create_role(first, admin)
+        assert result.id == 41
+
+        with pytest.raises(RoleNameDuplicateError) as exc:
+            await RoleService.create_role(second, admin)
+        assert exc.value.Code == 24002
+
+
+@pytest.mark.asyncio
+async def test_create_operator_can_coexist_with_portal_admin_name() -> None:
+    admin = _admin_user()
+    req = RoleCreateRequest(role_name=PLATFORM_OPERATOR_ROLE_NAME)
+    created = _make_role(42)
+
+    with (
+        patch.object(RoleService, "_check_role_permission", new=AsyncMock()),
+        patch.object(RoleService, "_ensure_create_scope", new=AsyncMock()),
+        patch("bisheng.role.domain.services.role_service.Role") as mock_role_cls,
+        patch("bisheng.role.domain.services.role_service.RoleDao") as mock_dao,
+        patch("bisheng.role.domain.services.role_service.QuotaService"),
+    ):
+        mock_role_cls.return_value = created
+        mock_dao.aget_role_by_name = AsyncMock(return_value=None)
+        mock_dao.ainsert_role = AsyncMock(return_value=created)
+        mock_dao.aget_role_by_exact_name_in_tenant = AsyncMock(return_value=None)
+
+        result = await RoleService.create_role(req, admin)
+
+    assert result.role_name == PLATFORM_OPERATOR_ROLE_NAME
+    mock_dao.aget_role_by_name.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_update_reserved_name_is_protected() -> None:
+    admin = _admin_user()
+    role = _make_role(50)
+    req = RoleUpdateRequest(role_name="运营改名")
+
+    with (
+        patch.object(RoleService, "_check_role_permission", new=AsyncMock()),
+        patch.object(RoleService, "_ensure_role_mutation_access", new=AsyncMock()),
+        patch("bisheng.role.domain.services.role_service.RoleDao") as mock_dao,
+        patch("bisheng.role.domain.services.role_service.QuotaService"),
+    ):
+        mock_dao.aget_role_by_id = AsyncMock(return_value=role)
+        with pytest.raises(RoleBuiltinProtectedError) as exc:
+            await RoleService.update_role(50, req, admin)
+        assert exc.value.Code == 24004
+        mock_dao.update_role.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_reserved_name_is_protected() -> None:
+    admin = _admin_user()
+    role = _make_role(50)
+
+    with (
+        patch.object(RoleService, "_check_role_permission", new=AsyncMock()),
+        patch.object(RoleService, "_ensure_role_mutation_access", new=AsyncMock()),
+        patch("bisheng.role.domain.services.role_service.RoleDao") as mock_dao,
+    ):
+        mock_dao.aget_role_by_id = AsyncMock(return_value=role)
+        with pytest.raises(RoleBuiltinProtectedError) as exc:
+            await RoleService.delete_role(50, admin)
+        assert exc.value.Code == 24004
+        mock_dao.adelete_role.assert_not_called()
+
+
+def _mysql_async_url() -> str:
+    override = os.environ.get("QA_EXPERT_FLOW_DATABASE_URL") or os.environ.get("PLATFORM_OPERATOR_FLOW_DATABASE_URL")
+    if override:
+        return override.replace("pymysql", "aiomysql")
+    from bisheng.core.config.settings import decrypt_token
+
+    cfg_name = os.environ.get("config", "config.yaml")
+    cfg_path = Path(__file__).resolve().parents[2] / "bisheng" / Path(cfg_name).name
+    loaded = __import__("yaml").safe_load(cfg_path.read_text(encoding="utf-8"))
+    url = loaded["database_url"]
+    if not isinstance(url, str):
+        raise RuntimeError("config.yaml database_url 不是字符串")
+    match = re.search(r"(?<=:)[^:]+(?=@)", url)
+    if match:
+        url = re.sub(r"(?<=:)[^:]+(?=@)", decrypt_token(match.group(0)), url)
+    if "171" not in url and not override:
+        raise RuntimeError("流转测试默认打 192.168.106.171, 请确认 config.yaml")
+    return url.replace("pymysql", "aiomysql")
+
+
+@pytest.fixture
+async def mysql_engine():
+    from bisheng.core.context.tenant import set_current_tenant_id
+    from bisheng.core.database.connection import _patch_aiomysql_pre_ping
+
+    set_current_tenant_id(1)
+    _patch_aiomysql_pre_ping()
+    engine = create_async_engine(_mysql_async_url(), pool_pre_ping=True)
+    yield engine
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_reserved_name_flow_mysql(mysql_engine, monkeypatch):
+    """171: 创建保留名落库, 跨 scope 24002, 改名/删除 24004, WEB_MENU 无 board/sys."""
+    from fastapi import FastAPI
+    from fastapi.responses import JSONResponse
+    from httpx import ASGITransport, AsyncClient
+
+    from bisheng.common.errcode.base import BaseErrorCode
+    from bisheng.core.database.connection import _patch_aiomysql_pre_ping
+    from bisheng.role.api.endpoints.role import router as role_router
+    from bisheng.role.api.endpoints.role_access import router as menu_router
+    from bisheng.user.domain.services.auth import LoginUser
+
+    _patch_aiomysql_pre_ping()
+    engine = mysql_engine
+    suffix = uuid.uuid4().hex[:8]
+    remark = f"ops-role-flow-{suffix}"
+    created_ids: list[int] = []
+
+    @asynccontextmanager
+    async def patched_session():
+        session = AsyncSession(bind=engine, expire_on_commit=False)
+        try:
+            yield session
+        finally:
+            await session.close()
+
+    async def sql_insert(role):
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            await session.execute(
+                text(
+                    "INSERT INTO role (role_name, role_type, department_id, remark, create_user, tenant_id) "
+                    "VALUES (:n, :t, :d, :r, :u, :tid)"
+                ),
+                {
+                    "n": role.role_name,
+                    "t": getattr(role, "role_type", "global"),
+                    "d": getattr(role, "department_id", None),
+                    "r": getattr(role, "remark", None),
+                    "u": getattr(role, "create_user", 1),
+                    "tid": getattr(role, "tenant_id", 1),
+                },
+            )
+            await session.commit()
+            role_id = (await session.execute(text("SELECT LAST_INSERT_ID()"))).scalar_one()
+        ns = SimpleNamespace(
+            id=int(role_id),
+            role_name=role.role_name,
+            role_type=getattr(role, "role_type", "global"),
+            department_id=getattr(role, "department_id", None),
+            quota_config=getattr(role, "quota_config", None),
+            remark=getattr(role, "remark", None),
+            create_user=getattr(role, "create_user", 1),
+            tenant_id=getattr(role, "tenant_id", 1),
+            create_time=None,
+            update_time=None,
+        )
+        created_ids.append(ns.id)
+        return ns
+
+    async def sql_get_by_id(role_id: int):
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            row = (
+                await session.execute(
+                    text("SELECT id, role_name, role_type, department_id, remark, tenant_id FROM role WHERE id = :id"),
+                    {"id": role_id},
+                )
+            ).first()
+        if not row:
+            return None
+        return SimpleNamespace(
+            id=int(row[0]),
+            role_name=row[1],
+            role_type=row[2],
+            department_id=row[3],
+            remark=row[4],
+            tenant_id=row[5],
+            quota_config=None,
+        )
+
+    async def sql_get_by_name(tenant_id, role_type, role_name, department_id):
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            if department_id is None:
+                row = (
+                    await session.execute(
+                        text(
+                            "SELECT id, role_name FROM role "
+                            "WHERE tenant_id = :t AND role_type = :rt AND role_name = :n "
+                            "AND department_id IS NULL LIMIT 1"
+                        ),
+                        {"t": tenant_id, "rt": role_type, "n": role_name},
+                    )
+                ).first()
+            else:
+                row = (
+                    await session.execute(
+                        text(
+                            "SELECT id, role_name FROM role "
+                            "WHERE tenant_id = :t AND role_type = :rt AND role_name = :n "
+                            "AND department_id = :d LIMIT 1"
+                        ),
+                        {"t": tenant_id, "rt": role_type, "n": role_name, "d": department_id},
+                    )
+                ).first()
+        if not row:
+            return None
+        return SimpleNamespace(id=int(row[0]), role_name=row[1])
+
+    async def sql_get_exact_in_tenant(tenant_id, role_name, exclude_id=None):
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            row = (
+                await session.execute(
+                    text(
+                        "SELECT id, role_name, department_id FROM role WHERE tenant_id = :t AND role_name = :n LIMIT 1"
+                    ),
+                    {"t": tenant_id, "n": role_name},
+                )
+            ).first()
+        if not row:
+            return None
+        if exclude_id is not None and int(row[0]) == int(exclude_id):
+            return None
+        return SimpleNamespace(id=int(row[0]), role_name=row[1], department_id=row[2])
+
+    async def sql_replace_menus(_session, role_id: int, menu_ids: list[str]) -> None:
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            await session.execute(
+                text("DELETE FROM roleaccess WHERE role_id = :rid AND type = 99"),
+                {"rid": role_id},
+            )
+            for menu_id in menu_ids:
+                await session.execute(
+                    text("INSERT INTO roleaccess (role_id, third_id, type, tenant_id) VALUES (:rid, :tid, 99, 1)"),
+                    {"rid": role_id, "tid": menu_id},
+                )
+            await session.commit()
+
+    def role_factory(**kwargs):
+        return SimpleNamespace(id=None, **kwargs)
+
+    dao = MagicMock()
+    dao.aget_role_by_name = sql_get_by_name
+    dao.ainsert_role = sql_insert
+    dao.aget_role_by_id = sql_get_by_id
+    dao.aget_role_by_exact_name_in_tenant = sql_get_exact_in_tenant
+    dao.update_role = AsyncMock(side_effect=lambda role: role)
+    dao.adelete_role = AsyncMock()
+
+    monkeypatch.setattr("bisheng.role.domain.services.role_service.RoleDao", dao)
+    monkeypatch.setattr("bisheng.role.domain.services.role_service.Role", role_factory)
+    monkeypatch.setattr(
+        "bisheng.role.domain.services.role_service.get_async_db_session",
+        patched_session,
+    )
+    monkeypatch.setattr(
+        RoleService,
+        "_replace_menu_access_in_session",
+        sql_replace_menus,
+    )
+    async def update_menu_sql(cls, role_id, menu_ids, login_user):
+        # premock 下 Role 不能进 select(); 菜单剥离仍走 _normalize_menu_ids, 落库走 SQL.
+        role = await sql_get_by_id(role_id)
+        if not role:
+            from bisheng.common.errcode.role import RoleNotFoundError
+
+            raise RoleNotFoundError()
+        normalized = cls._normalize_menu_ids(menu_ids, role_name=role.role_name)
+        await sql_replace_menus(None, role_id, normalized)
+
+    async def get_menu_sql(cls, role_id, login_user):
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            rows = (
+                await session.execute(
+                    text("SELECT third_id FROM roleaccess WHERE role_id = :id AND type = 99"),
+                    {"id": role_id},
+                )
+            ).all()
+        return [row[0] for row in rows]
+
+    monkeypatch.setattr(RoleService, "update_menu", classmethod(update_menu_sql))
+    monkeypatch.setattr(RoleService, "get_menu", classmethod(get_menu_sql))
+    monkeypatch.setattr(RoleService, "_validate_department", AsyncMock())
+    monkeypatch.setattr(
+        "bisheng.role.api.endpoints.role._audit_log_service",
+        lambda: MagicMock(),
+    )
+    monkeypatch.setattr(
+        "bisheng.permission.domain.services.legacy_rbac_sync_service.LegacyRBACSyncService.sync_role_deleted",
+        AsyncMock(),
+    )
+
+    admin = SimpleNamespace(
+        user_id=1,
+        user_name="ops-role-flow-admin",
+        tenant_id=1,
+        is_admin=lambda: True,
+        is_global_super=True,
+    )
+
+    app = FastAPI()
+
+    @app.exception_handler(BaseErrorCode)
+    async def _biz(_req, exc: BaseErrorCode):
+        return JSONResponse(
+            {"status_code": exc.code, "status_message": exc.message, "data": None},
+            status_code=200,
+        )
+
+    app.include_router(role_router, prefix="/api/v1")
+    app.include_router(menu_router, prefix="/api/v1")
+    app.dependency_overrides[LoginUser.get_login_user] = lambda: admin
+
+    dept_id = None
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        await session.execute(
+            text(
+                "DELETE FROM roleaccess WHERE role_id IN "
+                "(SELECT id FROM role WHERE remark LIKE 'ops-role-flow-%')"
+            )
+        )
+        await session.execute(text("DELETE FROM role WHERE remark LIKE 'ops-role-flow-%'"))
+        await session.commit()
+        dept_id = (
+            await session.execute(
+                text("SELECT id FROM department WHERE tenant_id = 1 AND status = 'active' LIMIT 1")
+            )
+        ).scalar()
+
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            r1 = await client.post(
+                "/api/v1/roles",
+                json={"role_name": PLATFORM_OPERATOR_ROLE_NAME, "remark": remark},
+            )
+            body1 = r1.json()
+            assert r1.status_code == 200
+            assert body1["status_code"] == 200, body1
+            assert body1["data"]["role_name"] == PLATFORM_OPERATOR_ROLE_NAME
+            role_id = int(body1["data"]["id"])
+
+            async with AsyncSession(engine, expire_on_commit=False) as session:
+                count1 = (
+                    await session.execute(
+                        text("SELECT COUNT(*) FROM role WHERE tenant_id = 1 AND role_name = :n"),
+                        {"n": PLATFORM_OPERATOR_ROLE_NAME},
+                    )
+                ).scalar_one()
+            assert int(count1) == 1
+
+            dup_payload = {"role_name": PLATFORM_OPERATOR_ROLE_NAME, "remark": f"{remark}-dup"}
+            if dept_id is not None:
+                dup_payload["department_id"] = int(dept_id)
+            r2 = await client.post("/api/v1/roles", json=dup_payload)
+            body2 = r2.json()
+            assert r2.status_code == 200
+            assert body2["status_code"] == 24002
+
+            async with AsyncSession(engine, expire_on_commit=False) as session:
+                count2 = (
+                    await session.execute(
+                        text("SELECT COUNT(*) FROM role WHERE tenant_id = 1 AND role_name = :n"),
+                        {"n": PLATFORM_OPERATOR_ROLE_NAME},
+                    )
+                ).scalar_one()
+            assert int(count2) == 1
+
+            r3 = await client.put(
+                f"/api/v1/roles/{role_id}",
+                json={"role_name": "不该改名"},
+            )
+            body3 = r3.json()
+            assert r3.status_code == 200
+            assert body3["status_code"] == 24004
+
+            r4 = await client.delete(f"/api/v1/roles/{role_id}")
+            body4 = r4.json()
+            assert r4.status_code == 200
+            assert body4["status_code"] == 24004
+
+            async with AsyncSession(engine, expire_on_commit=False) as session:
+                still = (
+                    await session.execute(
+                        text("SELECT role_name FROM role WHERE id = :id"),
+                        {"id": role_id},
+                    )
+                ).scalar_one()
+            assert still == PLATFORM_OPERATOR_ROLE_NAME
+
+            r5 = await client.post(
+                f"/api/v1/roles/{role_id}/menu",
+                json={"menu_ids": ["board", "sys", "workstation"]},
+            )
+            assert r5.status_code == 200
+            assert r5.json()["status_code"] == 200
+
+            async with AsyncSession(engine, expire_on_commit=False) as session:
+                menus = [
+                    row[0]
+                    for row in (
+                        await session.execute(
+                            text("SELECT third_id FROM roleaccess WHERE role_id = :id AND type = 99"),
+                            {"id": role_id},
+                        )
+                    ).all()
+                ]
+            assert "board" not in menus
+            assert "sys" not in menus
+            assert "workstation" in menus
+
+            r6 = await client.get(f"/api/v1/roles/{role_id}/menu")
+            assert r6.status_code == 200
+            assert "board" not in (r6.json().get("data") or [])
+    finally:
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            ids = list({*created_ids})
+            if ids:
+                id_list = ",".join(str(i) for i in ids)
+                await session.execute(text(f"DELETE FROM roleaccess WHERE role_id IN ({id_list})"))
+            await session.execute(
+                text(
+                    "DELETE FROM roleaccess WHERE role_id IN "
+                    "(SELECT id FROM role WHERE remark LIKE 'ops-role-flow-%')"
+                )
+            )
+            await session.execute(text("DELETE FROM role WHERE remark LIKE 'ops-role-flow-%'"))
+            await session.commit()

--- a/src/backend/test/telemetry_search/test_platform_operator_dashboard_detail.py
+++ b/src/backend/test/telemetry_search/test_platform_operator_dashboard_detail.py
@@ -1,0 +1,214 @@
+"""AT-30: 运营岗看板详情/组件查询在无 ReBAC tuple 时仍可读."""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+import yaml
+
+from bisheng.user.domain.services.platform_operator import PLATFORM_OPERATOR_ROLE_NAME
+
+
+def _ops_user(*, user_id: int = 88004001) -> SimpleNamespace:
+    return SimpleNamespace(
+        user_id=user_id,
+        user_name="ops-dashboard",
+        tenant_id=1,
+        is_admin=lambda: False,
+        is_global_super=False,
+        role_names=[PLATFORM_OPERATOR_ROLE_NAME],
+        async_access_check=AsyncMock(return_value=False),
+    )
+
+
+@pytest.mark.asyncio
+async def test_ops_dashboard_detail_without_rebac_read(monkeypatch):
+    from bisheng.telemetry_search.domain.models.dashboard import (
+        Dashboard,
+        DashboardComponent,
+        DashboardStatus,
+        DashboardType,
+    )
+    from bisheng.telemetry_search.domain.services import dashboard as module
+
+    dashboard = Dashboard(
+        id=10,
+        title="统计看板",
+        status=DashboardStatus.PUBLISHED.value,
+        dashboard_type=DashboardType.PRESET_OSS.value,
+        user_id=1,
+    )
+    component = DashboardComponent(
+        id="comp-1",
+        dashboard_id=10,
+        type="chart",
+        dataset_code="mid_knowledge_space_content_stat",
+    )
+    monkeypatch.setattr(module.DashboardDao, "get_one", AsyncMock(return_value=dashboard))
+    monkeypatch.setattr(module.DashboardDao, "get_components", AsyncMock(return_value=[component]))
+    monkeypatch.setattr(module.DashboardDao, "get_default_dashboard", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        module.UserService,
+        "get_user_by_id",
+        AsyncMock(return_value=SimpleNamespace(user_name="admin")),
+    )
+
+    service = module.DashboardService.model_construct(login_user=_ops_user())
+    detail = await service.get_dashboard_detail(10, from_share=False)
+
+    assert detail.id == 10
+    assert detail.write is True
+    assert detail.components[0].id == "comp-1"
+
+
+@pytest.mark.asyncio
+async def test_ops_query_component_data_without_rebac_read(monkeypatch):
+    from bisheng.telemetry_search.domain.models.dashboard import (
+        Dashboard,
+        DashboardComponent,
+        DashboardStatus,
+        DashboardType,
+    )
+    from bisheng.telemetry_search.domain.services import dashboard as module
+
+    dashboard = Dashboard(
+        id=10,
+        title="统计看板",
+        status=DashboardStatus.PUBLISHED.value,
+        dashboard_type=DashboardType.PRESET_OSS.value,
+        user_id=1,
+    )
+    component = DashboardComponent(
+        id="comp-1",
+        dashboard_id=10,
+        type="chart",
+        dataset_code="mid_knowledge_space_content_stat",
+        data_config={"metrics": [], "dimensions": []},
+    )
+    monkeypatch.setattr(module.DashboardDao, "get_one", AsyncMock(return_value=dashboard))
+    monkeypatch.setattr(module.DashboardDao, "get_one_component", AsyncMock(return_value=component))
+    monkeypatch.setattr(module.DashboardDao, "get_components", AsyncMock(return_value=[component]))
+    monkeypatch.setattr(
+        module.DataQueryService,
+        "query_telemetry_data",
+        AsyncMock(return_value={"rows": []}),
+    )
+
+    service = module.DashboardService.model_construct(login_user=_ops_user())
+    result = await service.query_component_data(10, component_id="comp-1")
+
+    assert result == {"rows": []}
+
+
+def _mysql_async_url() -> str:
+    override = os.environ.get("PLATFORM_OPERATOR_FLOW_DATABASE_URL")
+    if override:
+        return override.replace("pymysql", "aiomysql")
+    from bisheng.core.config.settings import decrypt_token
+
+    cfg_name = os.environ.get("config", "config.yaml")
+    cfg_path = Path(__file__).resolve().parents[2] / "bisheng" / Path(cfg_name).name
+    loaded = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    url = loaded["database_url"]
+    if not isinstance(url, str):
+        raise RuntimeError("config.yaml database_url 不是字符串")
+    match = re.search(r"(?<=:)[^:]+(?=@)", url)
+    if match:
+        url = re.sub(r"(?<=:)[^:]+(?=@)", decrypt_token(match.group(0)), url)
+    if "171" not in url and not override:
+        raise RuntimeError("流转测试默认打 192.168.106.171, 请确认 config.yaml")
+    return url.replace("pymysql", "aiomysql")
+
+
+@pytest.fixture
+async def mysql_engine():
+    from bisheng.core.context.tenant import set_current_tenant_id
+    from bisheng.core.database.connection import _patch_aiomysql_pre_ping
+
+    set_current_tenant_id(1)
+    _patch_aiomysql_pre_ping()
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    engine = create_async_engine(_mysql_async_url(), pool_pre_ping=True)
+    yield engine
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_ops_dashboard_detail_api_flow_mysql(mysql_engine, monkeypatch):
+    """U-ops GET 看板详情 200; 响应与 dashboard 表一致."""
+    from contextlib import asynccontextmanager
+
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+    from sqlalchemy import text
+    from sqlmodel.ext.asyncio.session import AsyncSession
+
+    from bisheng.common.dependencies.user_deps import UserPayload
+    from bisheng.core.context.tenant import set_current_tenant_id
+    from bisheng.core.database.connection import _patch_aiomysql_pre_ping
+    from bisheng.telemetry_search.api.endpoints.dashboard import router as dashboard_router
+
+    _patch_aiomysql_pre_ping()
+    engine = mysql_engine
+    set_current_tenant_id(1)
+
+    login_user = UserPayload(
+        user_id=838,
+        user_name="ht056-ops",
+        user_role=[2, 9],
+        role_names=["普通用户", PLATFORM_OPERATOR_ROLE_NAME],
+        tenant_id=1,
+        is_global_super=False,
+    )
+
+    @asynccontextmanager
+    async def patched_async_session():
+        session = AsyncSession(bind=engine, expire_on_commit=False)
+        try:
+            yield session
+        finally:
+            await session.close()
+
+    monkeypatch.setattr(
+        "bisheng.telemetry_search.domain.models.dashboard_dao.get_async_db_session",
+        patched_async_session,
+    )
+    monkeypatch.setattr(
+        "bisheng.user.domain.services.user.UserService.get_user_by_id",
+        AsyncMock(return_value=SimpleNamespace(user_name="admin")),
+    )
+
+    async with AsyncSession(bind=engine, expire_on_commit=False) as session:
+        row = (
+            await session.execute(
+                text(
+                    "SELECT id, title FROM dashboard "
+                    "WHERE dashboard_type = 'preset_oss' ORDER BY id ASC LIMIT 1"
+                )
+            )
+        ).first()
+    assert row is not None, "171 上应至少有一个 preset_oss 看板"
+    dashboard_id, db_title = row[0], row[1]
+
+    app = FastAPI()
+    app.include_router(dashboard_router, prefix="/api/v1")
+    app.dependency_overrides[UserPayload.get_login_user] = lambda: login_user
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(f"/api/v1/dashboard/{dashboard_id}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status_code"] == 200
+        assert body["data"]["id"] == dashboard_id
+        assert body["data"]["title"] == db_title
+
+        again = await client.get(f"/api/v1/dashboard/{dashboard_id}")
+        assert again.status_code == 200
+        assert again.json()["data"]["id"] == dashboard_id

--- a/src/backend/test/user/test_platform_operator_identity.py
+++ b/src/backend/test/user/test_platform_operator_identity.py
@@ -1,0 +1,128 @@
+"""AT-03: 运营岗角色名精确匹配, 且不把人变成超管."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from bisheng.user.domain.services.platform_operator import (
+    PLATFORM_OPERATOR_ROLE_NAME,
+    can_platform_operate,
+    collect_user_info_role_names,
+    has_platform_operator_role,
+    resolve_user_info_role_label,
+)
+
+
+class _User:
+    """可控 is_admin 的夹具; 运营岗不得把该标志改成 True."""
+
+    def __init__(
+        self,
+        *,
+        admin: bool = False,
+        is_global_super: bool = False,
+        role_names: list[str] | None = None,
+    ) -> None:
+        self._admin = admin
+        self.is_global_super = is_global_super
+        self.role_names = list(role_names or [])
+
+    def is_admin(self) -> bool:
+        return self._admin
+
+
+def test_helper_constant_is_exact_display_name() -> None:
+    assert PLATFORM_OPERATOR_ROLE_NAME == "平台管理员"
+
+
+@pytest.mark.parametrize(
+    ("role_names", "expected"),
+    [
+        (["平台管理员"], True),
+        ([" 平台管理员 "], True),
+        (["普通用户", "平台管理员"], True),
+        ([], False),
+        (["管理员"], False),
+        (["系统管理员"], False),
+        (["admin"], False),
+        (["xx平台管理员"], False),
+        (["平台管理员x"], False),
+        (["平台 管理员"], False),
+    ],
+)
+def test_helper_has_platform_operator_role_exact_match(
+    role_names: list[str],
+    expected: bool,
+) -> None:
+    user = _User(role_names=role_names)
+    assert has_platform_operator_role(user) is expected
+    assert user.is_admin() is False
+
+
+def test_helper_has_platform_operator_role_rejects_none_and_missing() -> None:
+    assert has_platform_operator_role(None) is False
+    assert has_platform_operator_role(SimpleNamespace()) is False
+    assert has_platform_operator_role(SimpleNamespace(role_names=None)) is False
+
+
+def test_helper_can_platform_operate_super_admin_and_operator() -> None:
+    assert can_platform_operate(_User(admin=True)) is True
+    assert can_platform_operate(_User(is_global_super=True)) is True
+    operator = _User(role_names=["平台管理员"])
+    assert can_platform_operate(operator) is True
+    assert operator.is_admin() is False
+
+
+def test_helper_can_platform_operate_rejects_ordinary_and_portal_admin_names() -> None:
+    assert can_platform_operate(None) is False
+    assert can_platform_operate(_User()) is False
+    assert can_platform_operate(_User(role_names=["管理员"])) is False
+    assert can_platform_operate(_User(role_names=["系统管理员"])) is False
+    assert can_platform_operate(_User(role_names=["admin"])) is False
+
+
+def test_user_info_role_label_emits_operator_name() -> None:
+    assert resolve_user_info_role_label([5], ["平台管理员"]) == "平台管理员"
+    assert resolve_user_info_role_label([5], [" 平台管理员 "]) == "平台管理员"
+
+
+def test_user_info_role_label_admin_and_portal_admin_unchanged() -> None:
+    assert resolve_user_info_role_label("admin", ["平台管理员"]) == "admin"
+    assert resolve_user_info_role_label([5], ["管理员"]) == "管理员"
+    assert resolve_user_info_role_label([5], ["系统管理员"]) == "系统管理员"
+    # 整页管理员 + 运营岗: 不降级成运营岗.
+    assert resolve_user_info_role_label([5], ["管理员", "平台管理员"]) == "管理员"
+
+
+def test_user_read_exposes_role_names() -> None:
+    # UserRead 在 conftest 里被 premock, 不能实例化真 schema; 测下发 helper + 源码字段.
+    operator = _User(role_names=["平台管理员"])
+    assert collect_user_info_role_names(operator) == ["平台管理员"]
+    from pathlib import Path
+
+    model_src = (Path(__file__).resolve().parents[2] / "bisheng" / "user" / "domain" / "models" / "user.py").read_text(
+        encoding="utf-8"
+    )
+    assert "role_names: list[str] | None = None" in model_src
+
+
+@pytest.mark.asyncio
+async def test_get_admin_user_rejects_platform_operator() -> None:
+    from fastapi import HTTPException
+
+    from bisheng.user.domain.services.auth import LoginUser
+
+    operator = _User(role_names=["平台管理员"])
+    assert operator.is_admin() is False
+    denied = HTTPException(status_code=403, detail="No permission to operate")
+    with patch.object(LoginUser, "get_login_user", new=AsyncMock(return_value=operator)):
+        with patch(
+            "bisheng.user.domain.services.auth.UnAuthorizedError.http_exception",
+            return_value=denied,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await LoginUser.get_admin_user(auth_jwt=object())
+    assert exc_info.value.status_code == 403

--- a/src/backend/test/workstation/test_platform_operator_tag_and_sensitive.py
+++ b/src/backend/test/workstation/test_platform_operator_tag_and_sensitive.py
@@ -1,0 +1,276 @@
+"""AT-30/47: 运营岗可看板/标签/敏感词; 审批超管 API 仍 403."""
+
+from __future__ import annotations
+
+import os
+import re
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+import yaml
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from bisheng.common.errcode.tag import ReviewTagPermissionDeniedError
+from bisheng.user.domain.services.platform_operator import PLATFORM_OPERATOR_ROLE_NAME
+
+
+def _ops_user(*, user_id: int = 88004001) -> SimpleNamespace:
+    return SimpleNamespace(
+        user_id=user_id,
+        user_name="ops-tag-admin",
+        tenant_id=1,
+        is_admin=lambda: False,
+        is_global_super=False,
+        role_names=[PLATFORM_OPERATOR_ROLE_NAME],
+        has_tenant_admin=AsyncMock(return_value=False),
+        aget_user_access_resource_ids=AsyncMock(return_value=[]),
+    )
+
+
+def _plain_user(*, user_id: int = 88004002) -> SimpleNamespace:
+    return SimpleNamespace(
+        user_id=user_id,
+        user_name="plain-tag-user",
+        tenant_id=1,
+        is_admin=lambda: False,
+        is_global_super=False,
+        role_names=["普通用户"],
+        has_tenant_admin=AsyncMock(return_value=False),
+        aget_user_access_resource_ids=AsyncMock(return_value=[]),
+    )
+
+
+@pytest.mark.asyncio
+async def test_tag_console_allows_operator(monkeypatch):
+    from bisheng.workstation.domain.services.tag_console_service import TagConsoleService
+
+    monkeypatch.setattr(
+        "bisheng.database.models.department.DepartmentDao.aget_user_admin_departments",
+        AsyncMock(return_value=[]),
+    )
+    svc = TagConsoleService(login_user=_ops_user(), repository=AsyncMock(), tags_service=AsyncMock())
+    await svc._ensure_can_manage_tags()
+
+
+@pytest.mark.asyncio
+async def test_tag_console_rejects_ordinary(monkeypatch):
+    from bisheng.workstation.domain.services.tag_console_service import TagConsoleService
+
+    monkeypatch.setattr(
+        "bisheng.database.models.department.DepartmentDao.aget_user_admin_departments",
+        AsyncMock(return_value=[]),
+    )
+    svc = TagConsoleService(login_user=_plain_user(), repository=AsyncMock(), tags_service=AsyncMock())
+    with pytest.raises(ReviewTagPermissionDeniedError) as exc:
+        await svc._ensure_can_manage_tags()
+    assert exc.value.Code == 10712
+
+
+@pytest.mark.asyncio
+async def test_ops_dashboard_list_uses_admin_scope(monkeypatch):
+    from bisheng.telemetry_search.domain.models.dashboard_dao import DashboardDao
+    from bisheng.telemetry_search.domain.services.dashboard import DashboardService
+
+    captured: dict = {}
+
+    async def fake_get_dashboards(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(DashboardDao, "get_dashboards", fake_get_dashboards)
+    monkeypatch.setattr(DashboardDao, "get_default_dashboard", AsyncMock(return_value=None))
+    svc = DashboardService.model_construct(login_user=_ops_user())
+    result = await svc.get_dashboards()
+    assert result == []
+    assert "user_id" not in captured
+
+
+@pytest.mark.asyncio
+async def test_approval_admin_still_rejects_operator():
+    from bisheng.approval.api.endpoints.approval_admin import _ensure_admin
+
+    with pytest.raises(HTTPException) as exc:
+        await _ensure_admin(_ops_user())
+    assert exc.value.status_code == 403
+
+
+def _mysql_async_url() -> str:
+    override = os.environ.get("QA_EXPERT_FLOW_DATABASE_URL") or os.environ.get(
+        "PLATFORM_OPERATOR_FLOW_DATABASE_URL"
+    )
+    if override:
+        return override.replace("pymysql", "aiomysql")
+    from bisheng.core.config.settings import decrypt_token
+
+    cfg_name = os.environ.get("config", "config.yaml")
+    cfg_path = Path(__file__).resolve().parents[2] / "bisheng" / Path(cfg_name).name
+    loaded = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    url = loaded["database_url"]
+    if not isinstance(url, str):
+        raise RuntimeError("config.yaml database_url 不是字符串")
+    match = re.search(r"(?<=:)[^:]+(?=@)", url)
+    if match:
+        url = re.sub(r"(?<=:)[^:]+(?=@)", decrypt_token(match.group(0)), url)
+    if "171" not in url and not override:
+        raise RuntimeError("流转测试默认打 192.168.106.171, 请确认 config.yaml")
+    return url.replace("pymysql", "aiomysql")
+
+
+@pytest.fixture
+async def mysql_engine():
+    from bisheng.core.context.tenant import set_current_tenant_id
+    from bisheng.core.database.connection import _patch_aiomysql_pre_ping
+
+    set_current_tenant_id(1)
+    _patch_aiomysql_pre_ping()
+    engine = create_async_engine(_mysql_async_url(), pool_pre_ping=True)
+    yield engine
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_ops_sensitive_word_policy_flow_mysql(mysql_engine, monkeypatch):
+    """U-ops GET/PUT 敏感词; 落库一致再 GET; U-user 19801 且表不变."""
+    from contextlib import asynccontextmanager
+
+    from fastapi import FastAPI
+    from fastapi.responses import JSONResponse
+    from httpx import ASGITransport, AsyncClient
+
+    from bisheng.common.dependencies.user_deps import UserPayload
+    from bisheng.common.errcode.base import BaseErrorCode
+    from bisheng.core.database.connection import _patch_aiomysql_pre_ping
+    from bisheng.sensitive_word.api.endpoints.policies import router as policy_router
+
+    _patch_aiomysql_pre_ping()
+    engine = mysql_engine
+    suffix = uuid.uuid4().hex[:8]
+    ops = _ops_user()
+    plain = _plain_user()
+    auth: dict = {"user": ops}
+    biz = "knowledge_space_file_parse"
+    marker = f"ops-sw-{suffix}"
+
+    @asynccontextmanager
+    async def patched_async_session():
+        session = AsyncSession(bind=engine, expire_on_commit=False)
+        try:
+            yield session
+        finally:
+            await session.close()
+
+    monkeypatch.setattr(
+        "bisheng.sensitive_word.domain.models.sensitive_word_policy.get_async_db_session",
+        patched_async_session,
+    )
+
+    app = FastAPI()
+
+    @app.exception_handler(BaseErrorCode)
+    async def _biz(_req, exc: BaseErrorCode):
+        return JSONResponse(
+            {"status_code": exc.code, "status_message": exc.message, "data": None},
+            status_code=200,
+        )
+
+    app.include_router(policy_router, prefix="/api/v1")
+    app.dependency_overrides[UserPayload.get_login_user] = lambda: auth["user"]
+
+    async def _load(session):
+        return (
+            await session.execute(
+                text(
+                    "SELECT enabled, auto_reply, custom_words, words_types FROM sensitive_word_policy "
+                    "WHERE tenant_id = 1 AND business_type = :b AND logic_delete = 0 "
+                    "ORDER BY id DESC LIMIT 1"
+                ),
+                {"b": biz},
+            )
+        ).first()
+
+    original = None
+    created_row = False
+    try:
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            original = await _load(session)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            put = await client.put(
+                f"/api/v1/sensitive-word-policies/{biz}",
+                json={
+                    "enabled": True,
+                    "words_types": ["custom"],
+                    "custom_words": marker,
+                    "auto_reply": marker,
+                    "extra_config": {},
+                },
+            )
+            body_put = put.json()
+            assert put.status_code == 200
+            assert body_put["status_code"] == 200, body_put
+            assert body_put["data"]["auto_reply"] == marker
+
+            async with AsyncSession(engine, expire_on_commit=False) as session:
+                row = await _load(session)
+            assert row is not None
+            assert int(row[0]) == 1
+            assert str(row[1]) == marker
+            created_row = original is None
+
+            got = await client.get(f"/api/v1/sensitive-word-policies/{biz}")
+            body_got = got.json()
+            assert got.status_code == 200
+            assert body_got["status_code"] == 200, body_got
+            assert body_got["data"]["auto_reply"] == marker
+            assert body_got["data"]["custom_words"] == marker
+
+            auth["user"] = plain
+            denied = await client.put(
+                f"/api/v1/sensitive-word-policies/{biz}",
+                json={
+                    "enabled": False,
+                    "words_types": ["custom"],
+                    "custom_words": f"{marker}-denied",
+                    "auto_reply": f"{marker}-denied",
+                    "extra_config": {},
+                },
+            )
+            body_denied = denied.json()
+            assert denied.status_code == 200
+            assert body_denied["status_code"] == 19801
+            async with AsyncSession(engine, expire_on_commit=False) as session:
+                after = await _load(session)
+            assert after is not None
+            assert str(after[1]) == marker
+    finally:
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            if created_row:
+                await session.execute(
+                    text(
+                        "DELETE FROM sensitive_word_policy "
+                        "WHERE tenant_id = 1 AND business_type = :b AND custom_words = :m"
+                    ),
+                    {"b": biz, "m": marker},
+                )
+            elif original is not None:
+                await session.execute(
+                    text(
+                        "UPDATE sensitive_word_policy SET enabled = :e, auto_reply = :a, "
+                        "custom_words = :c, words_types = :w "
+                        "WHERE tenant_id = 1 AND business_type = :b AND logic_delete = 0"
+                    ),
+                    {
+                        "e": int(original[0]),
+                        "a": str(original[1]),
+                        "c": str(original[2] or ""),
+                        "w": original[3],
+                        "b": biz,
+                    },
+                )
+            await session.commit()

--- a/src/frontend/platform/src/contexts/userContext.tsx
+++ b/src/frontend/platform/src/contexts/userContext.tsx
@@ -1,5 +1,6 @@
 import { toast } from "@/components/bs-ui/toast/use-toast";
 import { resolveRoutePermissions } from "@/routes";
+import { resolveNoAdminConsoleAction } from "@/routes/standalone";
 import { getWorkspaceClientUrl } from "@/utils/workspaceUrl";
 import i18next from "i18next";
 import { ReactNode, createContext, useLayoutEffect, useState } from "react";
@@ -169,30 +170,42 @@ export function UserProvider({ children }: { children: ReactNode }) {
                     || web_menu.some((k: string) => adminMenuKeys.has(k))
                 )
             if (!canAccessPlatform) {
-                // Check if the user can at least access the workspace client.
-                // If neither platform nor workspace is accessible, redirect to /403
-                // to avoid a back-and-forth redirect loop between the two apps.
-                const canAccessWorkspace =
-                    res.has_workbench
-                    ?? (
-                        web_menu.includes('workstation')
-                        || web_menu.includes('frontend')
-                    )
-                if (!canAccessWorkspace) {
+                // 已登录运营岗: 白名单 iframe 留下; 其它 standalone 进 403; 有壳管理页仍踢走.
+                // 未登录仍走下面踢走/403, 不把无 session 的人留在 iframe.
+                const noAdminAction = res.user_id
+                    ? resolveNoAdminConsoleAction(location.pathname, BASE_URL)
+                    : "kick"
+                if (noAdminAction === "allow-standalone") {
+                    // fall through: 不 replace workspace, 也不按 web_menu 滤 iframe
+                } else if (noAdminAction === "standalone-403") {
                     history.pushState(null, '', BASE_URL + '/403')
                     return
+                } else {
+                    // Check if the user can at least access the workspace client.
+                    // If neither platform nor workspace is accessible, redirect to /403
+                    // to avoid a back-and-forth redirect loop between the two apps.
+                    const canAccessWorkspace =
+                        res.has_workbench
+                        ?? (
+                            web_menu.includes('workstation')
+                            || web_menu.includes('frontend')
+                        )
+                    if (!canAccessWorkspace) {
+                        history.pushState(null, '', BASE_URL + '/403')
+                        return
+                    }
+                    toast({
+                        variant: 'error',
+                        description: i18next.t('menu.noAdminConsoleAccess'),
+                    })
+                    // Hard-navigate to the workspace client. Must NOT use history.back()
+                    // here: under the SSO flow the previous history entry is the IdP /
+                    // portal page, so "going back" silently re-triggers SSO and produces
+                    // an infinite redirect loop for non-admin users. replace() also drops
+                    // the un-usable platform URL from history.
+                    window.location.replace(getWorkspaceClientUrl('/'))
+                    return
                 }
-                toast({
-                    variant: 'error',
-                    description: i18next.t('menu.noAdminConsoleAccess'),
-                })
-                // Hard-navigate to the workspace client. Must NOT use history.back()
-                // here: under the SSO flow the previous history entry is the IdP /
-                // portal page, so "going back" silently re-triggers SSO and produces
-                // an infinite redirect loop for non-admin users. replace() also drops
-                // the un-usable platform URL from history.
-                window.location.replace(getWorkspaceClientUrl('/'))
-                return
             }
 
             const pathName = location.pathname.replace(BASE_URL, '');

--- a/src/frontend/platform/src/routes/standalone.ts
+++ b/src/frontend/platform/src/routes/standalone.ts
@@ -9,9 +9,62 @@ import { useLocation } from "react-router-dom"
  */
 export const STANDALONE_PREFIX = "/standalone"
 
+/** 运营岗 iframe 允许的 standalone 前缀; 不含 approval/sys/log. */
+const PLATFORM_OPERATOR_STANDALONE_PREFIXES = [
+    "/standalone/dashboard",
+    "/standalone/knowledge-tag-library",
+    "/standalone/content-security",
+] as const
+
+export type NoAdminConsoleAction = "allow-standalone" | "standalone-403" | "kick"
+
 /** True when `pathname` (basename already stripped by react-router) is standalone. */
 export function isStandalonePath(pathname: string): boolean {
     return pathname === STANDALONE_PREFIX || pathname.startsWith(`${STANDALONE_PREFIX}/`)
+}
+
+/**
+ * 去掉 basename 与尾斜杠, 得到与 react-router 一致的 pathname.
+ */
+export function normalizePlatformPathname(pathname: string, baseUrl = ""): string {
+    const raw = (pathname || "/").split("?")[0]
+    const base = (baseUrl || "").replace(/\/+$/, "")
+    let path = raw.startsWith("/") ? raw : `/${raw}`
+    if (base && (path === base || path.startsWith(`${base}/`))) {
+        path = path.slice(base.length) || "/"
+    }
+    if (!path.startsWith("/")) {
+        path = `/${path}`
+    }
+    if (path.length > 1 && path.endsWith("/")) {
+        path = path.slice(0, -1)
+    }
+    return path
+}
+
+/**
+ * 是否运营岗可留在当前 standalone 页 (门户 iframe 三条).
+ * 精确前缀匹配, 允许 /standalone/dashboard/:id; 不含 approval/sys/log 与有壳 /dashboard.
+ */
+export function isPlatformOperatorStandalonePath(pathname: string, baseUrl = ""): boolean {
+    const path = normalizePlatformPathname(pathname, baseUrl)
+    return PLATFORM_OPERATOR_STANDALONE_PREFIXES.some(
+        (prefix) => path === prefix || path.startsWith(`${prefix}/`),
+    )
+}
+
+/**
+ * 无管理端 WEB_MENU 时对当前 URL 的处置: 白名单留下, 其它 standalone 进 403, 有壳管理页踢走.
+ */
+export function resolveNoAdminConsoleAction(pathname: string, baseUrl = ""): NoAdminConsoleAction {
+    const path = normalizePlatformPathname(pathname, baseUrl)
+    if (isPlatformOperatorStandalonePath(path)) {
+        return "allow-standalone"
+    }
+    if (isStandalonePath(path)) {
+        return "standalone-403"
+    }
+    return "kick"
 }
 
 /**

--- a/src/frontend/platform/src/test/platformOperatorStandalonePath.test.ts
+++ b/src/frontend/platform/src/test/platformOperatorStandalonePath.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+import {
+    isPlatformOperatorStandalonePath,
+    isStandalonePath,
+    resolveNoAdminConsoleAction,
+} from "@/routes/standalone"
+
+const here = dirname(fileURLToPath(import.meta.url))
+const userContextSource = readFileSync(
+    resolve(here, "../contexts/userContext.tsx"),
+    "utf8",
+)
+
+describe("isPlatformOperatorStandalonePath", () => {
+    it("allows the three iframe standalone pages and dashboard editor subpath", () => {
+        expect(isPlatformOperatorStandalonePath("/standalone/dashboard")).toBe(true)
+        expect(isPlatformOperatorStandalonePath("/standalone/dashboard/abc")).toBe(true)
+        expect(isPlatformOperatorStandalonePath("/standalone/knowledge-tag-library")).toBe(true)
+        expect(isPlatformOperatorStandalonePath("/standalone/content-security")).toBe(true)
+        expect(
+            isPlatformOperatorStandalonePath("/platform/standalone/dashboard", "/platform"),
+        ).toBe(true)
+        expect(isPlatformOperatorStandalonePath("/standalone/dashboard/")).toBe(true)
+    })
+
+    it("rejects approval/sys/log standalone, shelled admin pages, and substring traps", () => {
+        expect(isPlatformOperatorStandalonePath("/standalone/approval")).toBe(false)
+        expect(isPlatformOperatorStandalonePath("/standalone/sys")).toBe(false)
+        expect(isPlatformOperatorStandalonePath("/standalone/log")).toBe(false)
+        expect(isPlatformOperatorStandalonePath("/standalone/log/chatlog/1/2/3")).toBe(false)
+        expect(isPlatformOperatorStandalonePath("/sys")).toBe(false)
+        expect(isPlatformOperatorStandalonePath("/dashboard")).toBe(false)
+        expect(isPlatformOperatorStandalonePath("/log")).toBe(false)
+        expect(isPlatformOperatorStandalonePath("/admin")).toBe(false)
+        expect(isPlatformOperatorStandalonePath("/standalone")).toBe(false)
+        expect(isPlatformOperatorStandalonePath("/standalone/dashboard-evil")).toBe(false)
+        expect(isStandalonePath("/standalone/approval")).toBe(true)
+        expect(isStandalonePath("/dashboard")).toBe(false)
+    })
+})
+
+describe("resolveNoAdminConsoleAction", () => {
+    it("stays on whitelist standalone, 403s other standalone, kicks shelled admin", () => {
+        expect(resolveNoAdminConsoleAction("/standalone/dashboard")).toBe("allow-standalone")
+        expect(resolveNoAdminConsoleAction("/standalone/content-security")).toBe("allow-standalone")
+        expect(resolveNoAdminConsoleAction("/standalone/approval")).toBe("standalone-403")
+        expect(resolveNoAdminConsoleAction("/standalone/sys")).toBe("standalone-403")
+        expect(resolveNoAdminConsoleAction("/dashboard")).toBe("kick")
+        expect(resolveNoAdminConsoleAction("/sys")).toBe("kick")
+        expect(resolveNoAdminConsoleAction("/admin")).toBe("kick")
+    })
+
+    it("userContext skips the workspace kick using the resolver", () => {
+        expect(userContextSource).toMatch(/resolveNoAdminConsoleAction\(/)
+        expect(userContextSource).toMatch(/allow-standalone/)
+        expect(userContextSource).toMatch(/standalone-403/)
+    })
+})


### PR DESCRIPTION
引入精确匹配「平台管理员」角色及 can_platform_operate 写口径, 覆盖积分/迁移/字典/看板/tag/敏感词; Platform standalone 放行数据看板等三页; 修复看板详情仍校验 ReBAC 读权限导致运营岗 403.

## What

简要描述做了什么改动。

## Why

为什么需要这个改动？

## How

实现方式、设计决策（如有）。

## Test

- [ ] 本地测试通过
- [ ] 114 测试服务器验证通过

## Related

- Issue/ticket:
