### PR TITLE
fix(knowledge): retain embedded images when parsing Excel files

### DIFF
--- a/src/backend/bisheng/knowledge/rag/base_file_pipeline.py
+++ b/src/backend/bisheng/knowledge/rag/base_file_pipeline.py
@@ -160,6 +160,7 @@ class BaseFilePipeline(BasePipeline):
             ],
             data_rows=self.file_split_rule.excel_rule.slice_length,
             append_header=self.file_split_rule.excel_rule.append_header,
+            retain_images=self.file_split_rule.retain_images == 1,
         )
 
     def _init_txt_loader(self) -> BaseBishengLoader:

--- a/src/backend/bisheng/knowledge/rag/pipeline/loader/excel.py
+++ b/src/backend/bisheng/knowledge/rag/pipeline/loader/excel.py
@@ -9,22 +9,33 @@ from bisheng.knowledge.rag.pipeline.loader.utils.md_from_excel import convert_fi
 
 
 class ExcelLoader(BaseBishengLoader):
-    def __init__(self, header_rows: List[int] = None, data_rows: int = 12, append_header=True,
-                 *args, **kwargs):
+    def __init__(
+        self,
+        header_rows: List[int] = None,
+        data_rows: int = 12,
+        append_header=True,
+        retain_images: bool = True,
+        *args,
+        **kwargs,
+    ):
         super(ExcelLoader, self).__init__(*args, **kwargs)
         self.header_rows = header_rows or [0, 1]
         self.data_rows = data_rows
         self.append_header = append_header
+        self.retain_images = retain_images
         self.max_chunk_limit = 10000
 
     def load(self) -> List[Document]:
         md_file_path = os.path.join(self.tmp_dir, "chunk_md")
 
-        convert_file_to_markdown(input_file_path=self.file_path,
-                                 num_header_rows=self.header_rows,
-                                 rows_per_markdown=self.data_rows,
-                                 base_output_dir=md_file_path,
-                                 append_header=self.append_header)
+        convert_file_to_markdown(
+            input_file_path=self.file_path,
+            num_header_rows=self.header_rows,
+            rows_per_markdown=self.data_rows,
+            base_output_dir=md_file_path,
+            append_header=self.append_header,
+            image_dir=self.ensure_local_image_dir() if self.retain_images else None,
+        )
 
         files = sorted([f for f in os.listdir(md_file_path) if f.endswith(".md")])
 
@@ -35,6 +46,8 @@ class ExcelLoader(BaseBishengLoader):
             full_file_name = f"{md_file_path}/{file_name}"
             with open(full_file_name, "r", encoding="utf-8") as f:
                 content = f.read()
+                if self.retain_images:
+                    content = self.rewrite_local_image_refs(content)
                 one_metadata = self.file_metadata.copy()
                 one_metadata["chunk_index"] = chunk_index
                 one_metadata["bbox"] = ""

--- a/src/backend/bisheng/knowledge/rag/pipeline/loader/utils/md_from_excel.py
+++ b/src/backend/bisheng/knowledge/rag/pipeline/loader/utils/md_from_excel.py
@@ -42,7 +42,7 @@ def xls_to_xlsx(xls_path):
         return xlsx_path
 
     except Exception as e:
-        logger.exception(f'xls_to_xlsx error: ')
+        logger.exception(f"xls_to_xlsx error: ")
         return None
 
 
@@ -55,6 +55,39 @@ def remove_characters(s, chars_to_remove=["\n", "\r"]):
     for char in chars_to_remove:
         s = s.replace(char, "")
     return s.strip()
+
+
+SENTINEL_ROW = 1 << 30
+
+
+def extract_sheet_images(sheet_obj, image_dir: str, sheet_index: int) -> dict:
+    """Extract embedded images of a worksheet into the flat staging ``image_dir``.
+
+    Returns a mapping of 0-based row index -> list of markdown image lines.
+    Images are placed at their anchor row; images without a usable anchor fall
+    back to a sentinel row so they are appended at the end of the sheet content.
+    Callers rewrite the local paths to their final storage URLs afterwards.
+    """
+    result = {}
+    images = getattr(sheet_obj, "_images", None) or []
+    for img_idx, image in enumerate(images):
+        try:
+            data = image._data()
+        except Exception as e:
+            logger.warning("skip unreadable image {} in sheet {}: {}", img_idx, sheet_obj.title, e)
+            continue
+        ext = (getattr(image, "format", None) or "png").lower()
+        filename = f"excel_s{sheet_index}_img{img_idx}.{ext}"
+        try:
+            with open(os.path.join(image_dir, filename), "wb") as f:
+                f.write(data)
+        except Exception as e:
+            logger.warning("skip unsavable image {} in sheet {}: {}", img_idx, sheet_obj.title, e)
+            continue
+        from_row = getattr(getattr(getattr(image, "anchor", None), "_from", None), "row", None)
+        row = from_row if isinstance(from_row, int) else SENTINEL_ROW
+        result.setdefault(row, []).append(f"![{filename}]({image_dir}/{filename})")
+    return result
 
 
 def unmerge_and_read_sheet(sheet_obj):
@@ -82,7 +115,7 @@ def unmerge_and_read_sheet(sheet_obj):
         row_empty = True
 
         for c_idx, cell in enumerate(row):
-            value = merged_map.get((r_idx+1, c_idx+1), cell.value)
+            value = merged_map.get((r_idx + 1, c_idx + 1), cell.value)
             row_data.append(value)
 
             if value is not None and str(value).strip() != "":
@@ -113,10 +146,10 @@ def unmerge_and_read_sheet(sheet_obj):
 
 
 def generate_markdown_table_string(
-        header_rows_list_of_lists,
-        data_rows_list_of_lists,
-        num_columns,
-        separator_placement_index=1,
+    header_rows_list_of_lists,
+    data_rows_list_of_lists,
+    num_columns,
+    separator_placement_index=1,
 ):
     """
     Generate from new rulesMarkdownTable String
@@ -129,12 +162,7 @@ def generate_markdown_table_string(
         pre_separator_header = header_rows_list_of_lists[:separator_placement_index]
         for row_values in pre_separator_header:
             md_lines.append(
-                "| "
-                + " | ".join(
-                    remove_characters(str(v)) if v is not None else ""
-                    for v in row_values
-                )
-                + " |"
+                "| " + " | ".join(remove_characters(str(v)) if v is not None else "" for v in row_values) + " |"
             )
 
         # Insert below the header in the first rowMarkdownSeparator
@@ -144,38 +172,32 @@ def generate_markdown_table_string(
         post_separator_header = header_rows_list_of_lists[separator_placement_index:]
         for row_values in post_separator_header:
             md_lines.append(
-                "| "
-                + " | ".join(
-                    remove_characters(str(v)) if v is not None else ""
-                    for v in row_values
-                )
-                + " |"
+                "| " + " | ".join(remove_characters(str(v)) if v is not None else "" for v in row_values) + " |"
             )
 
     # Always process data rows
     for row_values in data_rows_list_of_lists:
         md_lines.append(
-            "| "
-            + " | ".join(
-                remove_characters(str(v)) if v is not None else "" for v in row_values
-            )
-            + " |"
+            "| " + " | ".join(remove_characters(str(v)) if v is not None else "" for v in row_values) + " |"
         )
 
     return "\n".join(md_lines)
 
 
 def process_dataframe_to_markdown_files(
-        df,
-        sheet_index: str,
-        num_header_rows,
-        rows_per_markdown,
-        output_dir,
-        append_header=True,
+    df,
+    sheet_index: str,
+    num_header_rows,
+    rows_per_markdown,
+    output_dir,
+    append_header=True,
+    image_lines_by_row=None,
 ):
     """
     - append_header=True: Tekan num_header_rows Separate the header and data.
     - append_header=False: All content is treated as data, table header is empty, ignored num_header_rows。
+    - image_lines_by_row: optional mapping of original df row index -> markdown
+      image lines to append to the chunk containing that row.
     """
     if df.empty:
         logger.warning(f"  feed '{sheet_index}' DataDataFrameEmpty, skippingMarkdownBuat")
@@ -193,41 +215,48 @@ def process_dataframe_to_markdown_files(
         append_header = False
 
     # --- Core Logic Modified: According to append_header Decide how to split the data ---
+    original_row_indices = []
     if append_header:
         # Handle header index outliers based on user rules
         if start_header_idx >= rows:
             logger.warning(
-                f"Table Header Start Row {start_header_idx} Total lines exceeded {rows}. The first row will be used as the table header.")
+                f"Table Header Start Row {start_header_idx} Total lines exceeded {rows}. The first row will be used as the table header."
+            )
             start_header_idx, end_header_idx = 0, 0
         elif end_header_idx >= rows:
             logger.warning(
-                f"Table Header End Row {end_header_idx} Total lines exceeded {rows}. will be truncated to the last line.")
+                f"Table Header End Row {end_header_idx} Total lines exceeded {rows}. will be truncated to the last line."
+            )
             end_header_idx = rows - 1
 
         # Make sure the index is legitimate
-        if start_header_idx < 0: start_header_idx = 0
-        if end_header_idx < start_header_idx: end_header_idx = start_header_idx
+        if start_header_idx < 0:
+            start_header_idx = 0
+        if end_header_idx < start_header_idx:
+            end_header_idx = start_header_idx
 
         try:
             header_slice = slice(start_header_idx, end_header_idx + 1)
             header_block_df = df.iloc[header_slice]
-            data_block_df = df.drop(df.index[header_slice]).reset_index(drop=True)
+            data_block_source = df.drop(df.index[header_slice])
+            original_row_indices = data_block_source.index.tolist()
+            data_block_df = data_block_source.reset_index(drop=True)
             header_rows_as_lists = header_block_df.values.tolist()
         except Exception as e:
             logger.error(
-                f"  At Source '{sheet_index}' Index by header in [{start_header_idx}, {end_header_idx}] Error Splitting Data: {e}Skip")
+                f"  At Source '{sheet_index}' Index by header in [{start_header_idx}, {end_header_idx}] Error Splitting Data: {e}Skip"
+            )
             return
     else:
         # when append_header are False , everything is treated as data and the header list is empty
         header_rows_as_lists = []
+        original_row_indices = df.index.tolist()
         data_block_df = df.reset_index(drop=True)
 
     # --- Subsequent pagination logic ---
     if data_block_df.empty:
         if append_header and not header_block_df.empty:
-            markdown_content = generate_markdown_table_string(
-                header_rows_as_lists, [], num_columns
-            )
+            markdown_content = generate_markdown_table_string(header_rows_as_lists, [], num_columns)
             # BUG FIX: Use zfill for proper padding. This is file '000' for the sheet.
             file_name = f"{str(sheet_index).zfill(2)}000.md"
             file_path = os.path.join(output_dir, file_name)
@@ -240,8 +269,11 @@ def process_dataframe_to_markdown_files(
         return
 
     num_data_rows_total = len(data_block_df)
-    num_files_to_create = math.ceil(num_data_rows_total / rows_per_markdown) if rows_per_markdown > 0 else (
-        1 if num_data_rows_total > 0 else 0)
+    num_files_to_create = (
+        math.ceil(num_data_rows_total / rows_per_markdown)
+        if rows_per_markdown > 0
+        else (1 if num_data_rows_total > 0 else 0)
+    )
 
     for i in range(num_files_to_create):
         start_idx = i * rows_per_markdown
@@ -256,9 +288,20 @@ def process_dataframe_to_markdown_files(
             final_header_for_chunk = [current_data_chunk_as_lists[0]]
             final_data_for_chunk = current_data_chunk_as_lists[1:]
 
-        markdown_content = generate_markdown_table_string(
-            final_header_for_chunk, final_data_for_chunk, num_columns
-        )
+        markdown_content = generate_markdown_table_string(final_header_for_chunk, final_data_for_chunk, num_columns)
+
+        # Append embedded-image lines anchored to rows inside this chunk;
+        # images anchored beyond the data range ride on the last chunk
+        if image_lines_by_row:
+            chunk_rows = original_row_indices[start_idx:end_idx]
+            image_lines = [line for row in chunk_rows for line in image_lines_by_row.get(row, [])]
+            if i == num_files_to_create - 1:
+                covered_rows = set(original_row_indices)
+                for row in sorted(image_lines_by_row):
+                    if row not in covered_rows:
+                        image_lines.extend(image_lines_by_row[row])
+            if image_lines:
+                markdown_content += "\n" + "\n".join(image_lines)
 
         # BUG FIX: Use zfill for proper 2-digit sheet and 3-digit file padding.
         file_name = f"{str(sheet_index).zfill(2)}{str(i).zfill(3)}.md"
@@ -267,9 +310,7 @@ def process_dataframe_to_markdown_files(
         try:
             with open(file_path, "w", encoding="utf-8") as f:
                 f.write(markdown_content)
-            logger.debug(
-                f"  Sudah disimpan'{file_path}' (incl.  {len(current_data_chunk_as_lists)} Row Raw Data)"
-            )
+            logger.debug(f"  Sudah disimpan'{file_path}' (incl.  {len(current_data_chunk_as_lists)} Row Raw Data)")
         except Exception as e:
             logger.debug(f"  Save file '{file_path}' Error during: {e}")
 
@@ -283,11 +324,16 @@ def is_list_of_lists_empty(data_list):
     # Use any() and generator expressions for efficient judgment
     # any(row) Check for non-empty lines
     # any(cell is not None and cell != '' for cell in row) Check if there are non-empty cells in the row
-    return not any(any(cell is not None and str(cell).strip() != '' for cell in row) for row in data_list)
+    return not any(any(cell is not None and str(cell).strip() != "" for cell in row) for row in data_list)
 
 
 def excel_file_to_markdown(
-        excel_path, num_header_rows, rows_per_markdown, output_dir, append_header=True
+    excel_path,
+    num_header_rows,
+    rows_per_markdown,
+    output_dir,
+    append_header=True,
+    image_dir=None,
 ):
     logger.debug(f"\nStart ProcessingExcelDocumentation:'{excel_path}'")
     try:
@@ -300,12 +346,26 @@ def excel_file_to_markdown(
     for sheet_name in workbook.sheetnames:
         logger.debug(f"\n  (In work)ExcelWorksheet'{sheet_name}'...")
         sheet_obj = workbook[sheet_name]
+
+        # Extract embedded images before reading cells so image-only sheets
+        # are not silently dropped.
+        image_lines_by_row = None
+        if image_dir:
+            image_lines_by_row = extract_sheet_images(sheet_obj, image_dir, sheet_index)
+
         unmerged_data_list_of_lists = unmerge_and_read_sheet(sheet_obj)
         logger.debug(f"\n  <read all data>Excel<UNK>'{sheet_name}'...{len(unmerged_data_list_of_lists)}")
 
         # Using the new decision function
         if is_list_of_lists_empty(unmerged_data_list_of_lists):
-            logger.debug(f"  Worksheet '{sheet_name}' Empty or no valid data, skipping.")
+            if image_lines_by_row:
+                # Image-only sheet: still emit its images as a markdown file.
+                file_path = os.path.join(output_dir, f"{str(sheet_index).zfill(2)}000.md")
+                with open(file_path, "w", encoding="utf-8") as f:
+                    f.write("\n".join(line for _row in sorted(image_lines_by_row) for line in image_lines_by_row[_row]))
+                sheet_index += 1
+            else:
+                logger.debug(f"  Worksheet '{sheet_name}' Empty or no valid data, skipping.")
             continue
 
         df = pd.DataFrame(unmerged_data_list_of_lists)
@@ -321,6 +381,7 @@ def excel_file_to_markdown(
             rows_per_markdown,
             output_dir,
             append_header=append_header,
+            image_lines_by_row=image_lines_by_row,
         )
         sheet_index += 1
 
@@ -330,13 +391,13 @@ def excel_file_to_markdown(
 
 
 def csv_file_to_markdown(
-        csv_path,
-        num_header_rows,
-        rows_per_markdown,
-        output_dir,
-        csv_encoding="utf-8",
-        csv_delimiter=",",
-        append_header=True,
+    csv_path,
+    num_header_rows,
+    rows_per_markdown,
+    output_dir,
+    csv_encoding="utf-8",
+    csv_delimiter=",",
+    append_header=True,
 ):
     logger.debug(f"\nStart ProcessingCSVDocumentation:'{csv_path}'")
     try:
@@ -376,16 +437,20 @@ def csv_file_to_markdown(
 
 
 def convert_file_to_markdown(
-        input_file_path,
-        num_header_rows,
-        rows_per_markdown,
-        base_output_dir="output_markdown_files",
-        csv_encoding="utf-8",
-        csv_delimiter=",",
-        append_header=True,
+    input_file_path,
+    num_header_rows,
+    rows_per_markdown,
+    base_output_dir="output_markdown_files",
+    csv_encoding="utf-8",
+    csv_delimiter=",",
+    append_header=True,
+    image_dir=None,
 ):
     """
     will be Excel OR CSV Convert files to multiple Markdown files.
+
+    ``image_dir``: optional flat staging dir; when set, embedded images of the
+    Excel sheets are extracted there and referenced from the markdown output.
     """
     if not os.path.exists(input_file_path):
         logger.debug(f"Error: Input file '{input_file_path}' Nothing found.")
@@ -407,6 +472,7 @@ def convert_file_to_markdown(
             rows_per_markdown,
             base_output_dir,
             append_header,
+            image_dir=image_dir,
         )
     elif file_extension == ".csv":
         csv_file_to_markdown(
@@ -425,11 +491,11 @@ def convert_file_to_markdown(
 
 
 def handler(
-        cache_dir,
-        file_name: str,
-        header_rows: List[int] = [0, 1],
-        data_rows: int = 12,
-        append_header=True,
+    cache_dir,
+    file_name: str,
+    header_rows: List[int] = [0, 1],
+    data_rows: int = 12,
+    append_header=True,
 ):
     """
     The main function that handles file conversions.

--- a/src/backend/bisheng/knowledge/rag/pipeline/loader/x_create.py
+++ b/src/backend/bisheng/knowledge/rag/pipeline/loader/x_create.py
@@ -22,13 +22,13 @@ class XinChuangFormatterLoader(BaseBishengLoader):
     }
 
     def __init__(
-            self,
-            retain_images: bool = True,
-            header_rows: list[int] | None = None,
-            data_rows: int = 12,
-            append_header: bool = True,
-            *args,
-            **kwargs,
+        self,
+        retain_images: bool = True,
+        header_rows: list[int] | None = None,
+        data_rows: int = 12,
+        append_header: bool = True,
+        *args,
+        **kwargs,
     ):
         super().__init__(*args, **kwargs)
         self.retain_images = retain_images
@@ -64,9 +64,7 @@ class XinChuangFormatterLoader(BaseBishengLoader):
             raise RuntimeError(f"failed to convert {self.file_name} to {target_ext}")
         return converted_path
 
-    def _build_delegate_loader(
-            self, file_path: str, file_extension: str, loader_type: str
-    ) -> BaseBishengLoader:
+    def _build_delegate_loader(self, file_path: str, file_extension: str, loader_type: str) -> BaseBishengLoader:
         params = {
             "file_path": file_path,
             "file_metadata": self.file_metadata,
@@ -82,6 +80,7 @@ class XinChuangFormatterLoader(BaseBishengLoader):
                 header_rows=self.header_rows,
                 data_rows=self.data_rows,
                 append_header=self.append_header,
+                retain_images=self.retain_images,
             )
         if loader_type == "ppt":
             return BishengPptLoader(**params, retain_images=self.retain_images)

--- a/src/backend/test/knowledge/test_md_from_excel_images.py
+++ b/src/backend/test/knowledge/test_md_from_excel_images.py
@@ -1,0 +1,110 @@
+"""Regression tests: multi-sheet Excel parsing must retain embedded images.
+
+Issue: a multi-sheet xlsx containing embedded images lost every image during
+knowledge parsing — md_from_excel only exported cell values, so image-bearing
+sheets lost their visual content and image-only sheets were dropped entirely.
+"""
+
+import openpyxl
+import pytest
+from openpyxl.drawing.image import Image as XLImage
+
+from bisheng.knowledge.rag.pipeline.loader.utils.md_from_excel import (
+    convert_file_to_markdown,
+    extract_sheet_images,
+)
+
+
+@pytest.fixture
+def tiny_png_bytes() -> bytes:
+    # 1x1 red PNG
+    import struct
+    import zlib
+
+    def chunk(typ, data):
+        c = struct.pack(">I", len(data)) + typ + data
+        return c + struct.pack(">I", zlib.crc32(typ + data) & 0xFFFFFFFF)
+
+    ihdr = chunk(b"IHDR", struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0))
+    idat = chunk(b"IDAT", zlib.compress(b"\x00\xff\x00\x00"))
+    iend = chunk(b"IEND", b"")
+    return b"\x89PNG\r\n\x1a\n" + ihdr + idat + iend
+
+
+def _build_workbook(path, png_path):
+    wb = openpyxl.Workbook()
+    ws1 = wb.active
+    ws1.title = "Data1"
+    ws1.append(["name", "score"])
+    ws1.append(["alice", 95])
+
+    ws2 = wb.create_sheet("Data2")
+    ws2.append(["date", "value"])
+    ws2.append(["2026-06-08", 15.99])
+    ws2.append(["2026-06-09", 16.29])
+    img = XLImage(png_path)
+    ws2.add_image(img, "B10")
+
+    ws3 = wb.create_sheet("OnlyImage")
+    img2 = XLImage(png_path)
+    ws3.add_image(img2, "A1")
+    wb.save(path)
+
+
+@pytest.fixture
+def multi_sheet_xlsx(tmp_path, tiny_png_bytes):
+    png_path = tmp_path / "tiny.png"
+    png_path.write_bytes(tiny_png_bytes)
+    xlsx_path = tmp_path / "multi.xlsx"
+    _build_workbook(str(xlsx_path), str(png_path))
+    return str(xlsx_path)
+
+
+def test_extract_sheet_images_maps_anchor_row(tmp_path, multi_sheet_xlsx):
+    image_dir = tmp_path / "images"
+    image_dir.mkdir()
+    wb = openpyxl.load_workbook(multi_sheet_xlsx)
+    result = extract_sheet_images(wb["Data2"], str(image_dir), 1)
+
+    # image anchored at B10 -> 0-based row 9
+    assert 9 in result
+    (line,) = result[9]
+    filename = line.split("(")[1].rstrip(")").rsplit("/", 1)[-1]
+    assert (image_dir / filename).exists()
+    assert (image_dir / filename).read_bytes().startswith(b"\x89PNG")
+
+
+def test_convert_keeps_images_in_markdown(tmp_path, multi_sheet_xlsx):
+    out_dir = tmp_path / "md"
+    image_dir = tmp_path / "images"
+    image_dir.mkdir()
+    convert_file_to_markdown(multi_sheet_xlsx, [0, 1], 12, str(out_dir), image_dir=str(image_dir))
+
+    files = sorted(f for f in out_dir.iterdir())
+    # sheet0 (Data1) + sheet1 (Data2, with image) + sheet2 (image-only)
+    assert len(files) == 3
+
+    data2_content = (out_dir / "01000.md").read_text(encoding="utf-8")
+    assert "| date | value |" in data2_content
+    assert "![" in data2_content
+    assert str(image_dir) in data2_content
+
+    # image-only sheet still produces content
+    image_only_content = (out_dir / "02000.md").read_text(encoding="utf-8")
+    assert "![" in image_only_content
+
+    # extracted image bytes staged for the upload transformer
+    staged = list(image_dir.iterdir())
+    assert len(staged) == 2
+    for f in staged:
+        assert f.read_bytes().startswith(b"\x89PNG")
+
+
+def test_convert_without_image_dir_unchanged(tmp_path, multi_sheet_xlsx):
+    out_dir = tmp_path / "md"
+    convert_file_to_markdown(multi_sheet_xlsx, [0, 1], 12, str(out_dir))
+
+    # legacy behavior: image-only sheet dropped, no image refs anywhere
+    assert not (out_dir / "02000.md").exists()
+    for f in out_dir.iterdir():
+        assert "![" not in f.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Gitee issue IKC7BU: 带图片的多 sheet Excel 文件解析后图片内容全部丢失（解析格式与原文件不一致）。

**Root cause**: `md_from_excel` (the fixed Excel → markdown parse path for xlsx/xls in the knowledge pipeline) only exported cell values. Every embedded image was silently dropped; a sheet whose content was only an image was skipped as "empty".

**Changes**:
- `md_from_excel.py`: extract each sheet's embedded images (openpyxl) into the loader's flat image staging dir; reference them from the generated markdown at the image's anchor row. Images anchored beyond the data range ride on the last chunk; image-only sheets now emit their images instead of being dropped.
- `ExcelLoader` / `XinChuangFormatterLoader` (`et` format): honor the file rule's `retain_images` flag, rewrite local image refs to final MinIO URLs via the existing `rewrite_local_image_refs` contract — `ImageUploadTransformer` uploads the staged bytes unchanged (both Knowledge and Preview pipelines already wire it for excel).
- Legacy `handler()` path (`patch_130`) keeps its previous behavior.

## Test plan

- [x] New regression tests `test/knowledge/test_md_from_excel_images.py` (3 passed): anchor-row extraction, multi-sheet markdown keeps image refs, image-only sheet retained, legacy no-`image_dir` behavior unchanged
- [x] Chunked parse (30 rows / 10 per chunk) places the image in the chunk containing its anchor row
- [ ] CI

Refs: Gitee issue IKC7BU (https://gitee.com/Data-Elem_1/dashboard/issues?id=IKC7BU)