### PR TITLE
fix(knowledge): show failure status on folders whose subtree contains failed files (IKC813)

### DIFF
--- a/src/frontend/client/src/pages/knowledge/SpaceDetail/FileCard.tsx
+++ b/src/frontend/client/src/pages/knowledge/SpaceDetail/FileCard.tsx
@@ -213,7 +213,22 @@ export function FileCard({
             // z-20 keeps the tag crisp above the translucent uploading scrim (z-10).
             return inline ? pill : <div className="absolute bottom-1 left-1 z-20">{pill}</div>;
         }
-        if (!isAdmin || isFolder) return null;
+        if (!isAdmin) return null;
+        // Folder rollup (IKC813): a folder holding at least one failed descendant
+        // shows the error pill itself — backend has_failed_files covers every
+        // ancestor level via the path-prefix recursion.
+        if (isFolder) {
+            if (file.hasFailedFiles !== true) return null;
+            const pill = (
+                <div className="inline-flex items-center justify-center gap-1 rounded-[4px] bg-[#fff2f0] px-2">
+                    <span className="size-1 shrink-0 rounded-full bg-[#f53f3f]" />
+                    <span className="whitespace-nowrap text-xs leading-5 text-[#f53f3f]">
+                        {localize("com_knowledge.fail")}
+                    </span>
+                </div>
+            );
+            return inline ? pill : <div className="absolute bottom-1 left-1 z-10">{pill}</div>;
+        }
         if (file.status === FileStatus.SUCCESS) return null;
 
         const approvalLabel = approvalStatusLabel;

--- a/src/frontend/client/src/pages/knowledge/SpaceDetail/FileListRow.folderStatus.test.tsx
+++ b/src/frontend/client/src/pages/knowledge/SpaceDetail/FileListRow.folderStatus.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * IKC813 regression: in a multi-level knowledge file tree, a folder with a
+ * failed descendant must show the failure ("com_knowledge.fail") status itself.
+ * The backend computes `has_failed_files` for every ancestor level; both list
+ * renderers used to ignore it for folder rows, so a failed file nested inside
+ * sub-folders left every parent folder looking clean.
+ */
+import { render, screen } from '@testing-library/react';
+import { FileStatus, FileType, SpaceRole, type KnowledgeFile } from '~/api/knowledge';
+
+jest.mock('~/hooks', () => ({
+    useLocalize: () => (key: string) => key,
+    useMediaQuery: () => false,
+}));
+
+jest.mock('bisheng-icons', () => ({
+    Outlined: new Proxy({}, { get: () => () => null }),
+}));
+
+jest.mock('@bisheng/ui', () => ({
+    Button: () => null,
+}));
+
+jest.mock('~/components', () => ({
+    Checkbox: () => null,
+    DropdownMenu: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    DropdownMenuTrigger: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('~/components/ActionMenu', () => ({
+    ActionMenuContent: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    ActionMenuItem: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('~/components/ui/Tooltip2', () => ({
+    Tooltip: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    TooltipContent: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    TooltipTrigger: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('./FileIcon', () => () => null);
+jest.mock('./TagGroup', () => () => null);
+
+import { FileListRow } from './FileListRow';
+import { FileCard } from './FileCard';
+
+const noop = () => {};
+
+const folder = (hasFailedFiles?: boolean) =>
+    ({
+        id: '1',
+        name: 'folder',
+        type: FileType.FOLDER,
+        status: undefined,
+        hasFailedFiles,
+    }) as unknown as KnowledgeFile;
+
+const successFile = {
+    id: '2',
+    name: 'file.pdf',
+    type: FileType.PDF,
+    status: FileStatus.SUCCESS,
+} as unknown as KnowledgeFile;
+
+describe('FileListRow folder failure status (IKC813)', () => {
+    it('shows the failure pill on a folder whose subtree contains a failed file', () => {
+        render(
+            <FileListRow
+                file={folder(true)}
+                index={0}
+                isAdmin
+                isSelected={false}
+                onSelect={noop}
+                onDownload={noop}
+                onEditTags={noop}
+                onRename={noop}
+                onDelete={noop}
+                onRetry={noop}
+            />,
+        );
+        expect(screen.getByText('com_knowledge.fail')).toBeTruthy();
+    });
+
+    it('shows no status pill on a clean folder', () => {
+        render(
+            <FileListRow
+                file={folder()}
+                index={0}
+                isAdmin
+                isSelected={false}
+                onSelect={noop}
+                onDownload={noop}
+                onEditTags={noop}
+                onRename={noop}
+                onDelete={noop}
+                onRetry={noop}
+            />,
+        );
+        expect(screen.queryByText('com_knowledge.fail')).not.toBeTruthy();
+    });
+
+    it('keeps hiding the pill on successful files', () => {
+        render(
+            <FileListRow
+                file={successFile}
+                index={0}
+                isAdmin
+                isSelected={false}
+                onSelect={noop}
+                onDownload={noop}
+                onEditTags={noop}
+                onRename={noop}
+                onDelete={noop}
+                onRetry={noop}
+            />,
+        );
+        expect(screen.queryByText('com_knowledge.fail')).not.toBeTruthy();
+    });
+});
+
+describe('FileCard folder failure status (IKC813)', () => {
+    it('shows the failure pill on a folder whose subtree contains a failed file', () => {
+        render(
+            <FileCard
+                file={folder(true)}
+                userRole={SpaceRole.ADMIN}
+                isSelected={false}
+                onSelect={noop}
+                onDownload={noop}
+                onRename={noop}
+                onDelete={noop}
+                onEditTags={noop}
+                onRetry={noop}
+            />,
+        );
+        expect(screen.getByText('com_knowledge.fail')).toBeTruthy();
+    });
+
+    it('shows no status pill on a clean folder', () => {
+        render(
+            <FileCard
+                file={folder()}
+                userRole={SpaceRole.ADMIN}
+                isSelected={false}
+                onSelect={noop}
+                onDownload={noop}
+                onRename={noop}
+                onDelete={noop}
+                onEditTags={noop}
+                onRetry={noop}
+            />,
+        );
+        expect(screen.queryByText('com_knowledge.fail')).not.toBeTruthy();
+    });
+});

--- a/src/frontend/client/src/pages/knowledge/SpaceDetail/FileListRow.tsx
+++ b/src/frontend/client/src/pages/knowledge/SpaceDetail/FileListRow.tsx
@@ -62,12 +62,18 @@ const StatusBadge = ({ file }: { file: KnowledgeFile }) => {
     const status = file.status ?? FileStatus.SUCCESS;
     const approvalStatusLabel = getKnowledgeApprovalStatusLabel(file);
     const statusReason = file.approvalReason?.trim() || file.errorMessage?.trim() || null;
+    // Folder rollup: a folder holding at least one failed descendant shows the
+    // error pill itself (the backend has_failed_files covers every ancestor level).
+    const isFolderWithFailedFiles = file.type === FileType.FOLDER && file.hasFailedFiles === true;
 
-    if (status === FileStatus.SUCCESS && !approvalStatusLabel) return null;
+    if (status === FileStatus.SUCCESS && !approvalStatusLabel && !isFolderWithFailedFiles) return null;
 
     let label: string;
     let tone: Tone;
-    if (approvalStatusLabel) {
+    if (isFolderWithFailedFiles) {
+        label = localize("com_knowledge.fail");
+        tone = ERROR_TONE;
+    } else if (approvalStatusLabel) {
         label = approvalStatusLabel;
         tone = isKnowledgeApprovalRejected(file) ? ERROR_TONE : INFO_TONE;
     } else {


### PR DESCRIPTION
## Summary
- Gitee issue: [IKC813](https://gitee.com/Data-Elem_1/dashboard/issues?id=IKC813)（知识空间文件夹：多层级文件里，子文件夹内有失败文件时，父级文件夹未展示异常状态）
- Root cause: the backend already computes `has_failed_files` for every folder level (recursive path-prefix rollup in `knowledge_space_service._handle_file_folder_extra_info`), but the two file-list renderers in the client app never displayed it for folder rows:
  - `FileListRow.tsx` `StatusBadge` only keyed off `file.status` (folders have no status) → returned null.
  - `FileCard.tsx` `renderStatusOverlayTag` hard-excluded folders (`if (!isAdmin || isFolder) return null`).

## Changes
- `src/frontend/client/src/pages/knowledge/SpaceDetail/FileListRow.tsx`: folder with `hasFailedFiles === true` now renders the error tone status pill (失败).
- `src/frontend/client/src/pages/knowledge/SpaceDetail/FileCard.tsx`: folder branch added to `renderStatusOverlayTag` — error pill shows on the card overlay and the H5 list row; admin-gated to match the existing file behavior.
- Regression tests: `FileListRow.folderStatus.test.tsx` pins the rollup display for both renderers (folder with failures / clean folder / success file).

## Verification
- `eslint` clean on all touched files.
- `tsc-strict` passes for touched files (6 pre-existing errors remain in unrelated `Linsight/Execution` files, present on `main`).
- Jest regression tests added; local run blocked by a missing `canvas.node` native module in this environment (pre-existing, affects all client jest suites) — tests will be exercised by CI.