### PR TITLE
fix(approval): show message counts on approval-center sub-tabs (IKC9IB)

### DIFF
--- a/src/frontend/client/src/components/approval/ApprovalCenterDialog.tsx
+++ b/src/frontend/client/src/components/approval/ApprovalCenterDialog.tsx
@@ -221,6 +221,17 @@ export function ApprovalCenterDialog({ open, onOpenChange, target }: ApprovalCen
     );
   }, [requestItems, requestsFilter, searchQuery]);
 
+  // Per-sub-filter counts shown next to the tab labels (外显消息数量). Derived from the fully
+  // loaded list in state — the list APIs return every item, so these are true totals, not page counts.
+  const taskCounts = useMemo(() => {
+    const pending = taskItems.filter((t) => t.status === "pending").length;
+    return { pending_me: pending, processed: taskItems.length - pending };
+  }, [taskItems]);
+  const requestCounts = useMemo(() => {
+    const inProgress = requestItems.filter((i) => IN_PROGRESS_STATUSES.has(i.status ?? "")).length;
+    return { in_progress: inProgress, completed: requestItems.length - inProgress };
+  }, [requestItems]);
+
   const toast = (ok: boolean) => showToast({
     message: localize(ok ? "com_approval_toast_success" : "com_approval_toast_failed"),
     severity: ok ? NotificationSeverity.SUCCESS : NotificationSeverity.INFO,
@@ -442,6 +453,7 @@ export function ApprovalCenterDialog({ open, onOpenChange, target }: ApprovalCen
                           taskFilter === f ? "border-[#212121] text-text-1 font-medium" : "text-text-3 font-normal")}
                         onClick={() => setTaskFilter(f)}>
                         {f === "pending_me" ? localize("com_approval_task_filter_pending") : localize("com_approval_task_filter_processed")}
+                        <span className="ml-1 text-text-4">({taskCounts[f]})</span>
                       </button>
                     ))
                   : (["in_progress", "completed"] as RequestsFilter[]).map((f) => (
@@ -451,6 +463,7 @@ export function ApprovalCenterDialog({ open, onOpenChange, target }: ApprovalCen
                           requestsFilter === f ? "border-[#212121] text-text-1 font-medium" : "text-text-3 font-normal")}
                         onClick={() => setRequestsFilter(f)}>
                         {f === "in_progress" ? localize("com_approval_status_pending") : localize("com_approval_tab_completed")}
+                        <span className="ml-1 text-text-4">({requestCounts[f]})</span>
                       </button>
                     ))}
               </div>


### PR DESCRIPTION
## Summary
- 审批中心弹窗中「我的申请」子 tab（审批中/已完成）与「我的审批」子 tab（待我处理/已处理）此前只显示纯文本，没有外显消息数量（Gitee issue IKC9IB）
- 数量随列表接口全量返回，直接从本地 state 派生计数，tab 标签后以 `(N)` 展示，无需新增后端接口
- 修改文件：`src/frontend/client/src/components/approval/ApprovalCenterDialog.tsx`

## Issue
- https://gitee.com/Data-Elem_1/dashboard/issues?id=IKC9IB

## Test plan
- [x] `pnpm typecheck`（client）：修改文件无错误（存量 Linsight 相关 6 个错误与本次无关）
- [x] `eslint ApprovalCenterDialog.tsx` 通过
- [ ] 手动验证：打开审批中心 →「我的申请」，tab 显示如「审批中 (3)」「已完成 (2)」，切换/撤回/搜索后数量正确