### PR TITLE
feat(qa_expert): 专家硬删/批量操作与按状态过滤

### DIFF
--- a/src/backend/bisheng/common/errcode/qa_expert.py
+++ b/src/backend/bisheng/common/errcode/qa_expert.py
@@ -80,3 +80,9 @@ class QaExpertAssetInvalidError(BaseErrorCode):
     """提问/回答图片或附件引用不合法（数量、格式、路径等）。"""
 
     Code, Msg = 18313, "问答图片或附件不合法"
+
+
+class QaExpertHasAnswersCannotDeleteError(BaseErrorCode):
+    """专家已有问答记录, 不可从专家库硬删。"""
+
+    Code, Msg = 18314, "该专家已有回答记录, 不可删除, 请使用停用"

--- a/src/backend/bisheng/qa_expert/api/endpoints.py
+++ b/src/backend/bisheng/qa_expert/api/endpoints.py
@@ -119,6 +119,8 @@ async def list_experts(
     answer_desc: bool | None = Query(None, description="回答数排序"),
     adoption_desc: bool | None = Query(None, description="采纳数排序"),
     vote_desc: bool | None = Query(None, description="点赞数排序"),
+    # 查询串是字符串 "1"；用 int + ge/le，不要用 Literal[0, 1]（Pydantic 不把 "1" 当成 1）
+    status: int | None = Query(None, ge=0, le=1, description="专家状态: 1有效 0停用, 缺省全部"),
     page: int = Query(1, ge=1, description="页码"),
     limit: int = Query(20, ge=1, le=500, description="每页数量"),
     service: ExpertService = Depends(get_expert_service),
@@ -139,6 +141,7 @@ async def list_experts(
         answer_desc=answer_desc,
         adoption_desc=adoption_desc,
         vote_desc=vote_desc,
+        status=status,
     )
     return resp_200(data={"experts": experts, "total": total})
 

--- a/src/backend/bisheng/qa_expert/api/endpoints.py
+++ b/src/backend/bisheng/qa_expert/api/endpoints.py
@@ -30,6 +30,7 @@ from bisheng.qa_expert.domain.schemas import (
     CommentCreateRequest,
     CommentDetailResponse,
     CommentPageData,
+    ExpertBatchIdsRequest,
     ExpertCreateRequest,
     ExpertResponse,
     ExpertUpdateRequest,
@@ -169,6 +170,38 @@ async def create_expert(
         return resp_500(code=500, message=str(e))
 
 
+@router.post("/experts/batch-disable")
+async def batch_disable_experts(
+    request: ExpertBatchIdsRequest,
+    user: UserPayload = Depends(UserPayload.get_login_user),
+    service: ExpertService = Depends(get_expert_service),
+):
+    """批量停用专家"""
+    try:
+        result = await service.batch_disable_experts(request.expert_ids, user)
+        return resp_200(data=result)
+    except BaseErrorCode as exc:
+        return exc.return_resp_instance()
+    except Exception as e:
+        return resp_500(code=500, message=str(e))
+
+
+@router.post("/experts/batch-delete")
+async def batch_hard_delete_experts(
+    request: ExpertBatchIdsRequest,
+    user: UserPayload = Depends(UserPayload.get_login_user),
+    service: ExpertService = Depends(get_expert_service),
+):
+    """批量硬删专家档案(无回答记录时可删)"""
+    try:
+        result = await service.batch_hard_delete_experts(request.expert_ids, user)
+        return resp_200(data=result)
+    except BaseErrorCode as exc:
+        return exc.return_resp_instance()
+    except Exception as e:
+        return resp_500(code=500, message=str(e))
+
+
 @router.put("/experts/{expert_id}", response_model=ExpertResponse)
 async def update_expert(
     expert_id: int,
@@ -198,6 +231,22 @@ async def delete_expert(
         if not success:
             return resp_500(code=500, message="Failed to disable expert")
         return resp_200(data={"message": "Expert disabled successfully", "deprecated": True})
+    except BaseErrorCode as exc:
+        return exc.return_resp_instance()
+    except Exception as e:
+        return resp_500(code=500, message=str(e))
+
+
+@router.post("/experts/{expert_id}/delete")
+async def hard_delete_expert(
+    expert_id: int,
+    user: UserPayload = Depends(UserPayload.get_login_user),
+    service: ExpertService = Depends(get_expert_service),
+):
+    """硬删专家档案(无回答记录时可删)"""
+    try:
+        await service.hard_delete_expert(expert_id, user)
+        return resp_200(data={"message": "Expert deleted successfully", "expert_id": expert_id})
     except BaseErrorCode as exc:
         return exc.return_resp_instance()
     except Exception as e:

--- a/src/backend/bisheng/qa_expert/api/router.py
+++ b/src/backend/bisheng/qa_expert/api/router.py
@@ -25,7 +25,10 @@ router.add_api_route(
     methods=["GET"],
 )
 router.add_api_route("/experts", endpoints.create_expert, methods=["POST"])
+router.add_api_route("/experts/batch-disable", endpoints.batch_disable_experts, methods=["POST"])
+router.add_api_route("/experts/batch-delete", endpoints.batch_hard_delete_experts, methods=["POST"])
 router.add_api_route("/experts/{expert_id}", endpoints.update_expert, methods=["PUT"])
+router.add_api_route("/experts/{expert_id}/delete", endpoints.hard_delete_expert, methods=["POST"])
 router.add_api_route("/experts/{expert_id}/disable", endpoints.disable_expert, methods=["POST"])
 router.add_api_route("/experts/{expert_id}/enable", endpoints.enable_expert, methods=["POST"])
 router.add_api_route("/experts/{expert_id}", endpoints.delete_expert, methods=["DELETE"])

--- a/src/backend/bisheng/qa_expert/domain/repositories.py
+++ b/src/backend/bisheng/qa_expert/domain/repositories.py
@@ -85,6 +85,7 @@ class ExpertRepository:
         answer_desc: bool | None = None,
         adoption_desc: bool | None = None,
         vote_desc: bool | None = None,
+        status: int | None = None,
     ) -> tuple[list[Expert], int]:
         """列表查询专家"""
         async with get_async_db_session() as session:
@@ -116,6 +117,9 @@ class ExpertRepository:
             for column, value in exact_filters:
                 if value and value.strip():
                     base_stmt = base_stmt.where(func.trim(column) == value.strip())
+
+            if status is not None:
+                base_stmt = base_stmt.where(Expert.status == status)
 
             # 2. 执行计数查询（应用了相同的筛选条件）
             count_stmt = select(func.count()).select_from(base_stmt.subquery())

--- a/src/backend/bisheng/qa_expert/domain/repositories.py
+++ b/src/backend/bisheng/qa_expert/domain/repositories.py
@@ -225,7 +225,7 @@ class ExpertRepository:
             return expert
 
     async def delete(self, expert_id: int) -> bool:
-        """删除专家"""
+        """硬删专家档案行"""
         async with get_async_db_session() as session:
             expert = await self.get_by_id(expert_id)
             if not expert:
@@ -234,6 +234,15 @@ class ExpertRepository:
             await session.commit()
             await session.flush()
             return True
+
+    async def count_by_ids(self, expert_ids: list[int]) -> int:
+        """统计给定 ID 中仍存在的专家档案数"""
+        if not expert_ids:
+            return 0
+        async with get_async_db_session() as session:
+            stmt = select(func.count()).select_from(Expert).where(Expert.id.in_(expert_ids))
+            result = await session.exec(stmt)
+            return int(result.one())
 
     async def get_expertinfo(self, expert_name: str):
         """原子性增加专家的回答数量"""
@@ -321,6 +330,15 @@ class QuestionInviteRepository:
             stmt = select(QuestionInvite.question_id).where(QuestionInvite.user_id == user_id)
             result = await session.exec(stmt)
             return [int(item) for item in result.all()]
+
+    async def delete_by_expert_id(self, expert_id: int) -> None:
+        """删除专家相关的全部邀请行(硬删前清理)"""
+        async with get_async_db_session() as session:
+            stmt = select(QuestionInvite).where(QuestionInvite.expert_id == expert_id)
+            result = await session.exec(stmt)
+            for row in result.all():
+                await session.delete(row)
+            await session.commit()
 
 
 class QuestionRepository:
@@ -663,6 +681,17 @@ class AnswerRepository:
             result = await session.exec(stmt)
 
             return result.first()
+
+    async def count_active_by_expert_id(self, expert_id: int) -> int:
+        """统计专家未软删的回答数(硬删前校验)"""
+        async with get_async_db_session() as session:
+            stmt = (
+                select(func.count())
+                .select_from(Answer)
+                .where(and_(Answer.expert_id == expert_id, Answer.status != 3))
+            )
+            result = await session.exec(stmt)
+            return int(result.one())
 
     async def count_adopted_by_question_id(self, question_id: int) -> int:
         """统计同题未软删且已采纳的回答数（用于最多 3 个最佳答案上限）。"""

--- a/src/backend/bisheng/qa_expert/domain/schemas.py
+++ b/src/backend/bisheng/qa_expert/domain/schemas.py
@@ -109,6 +109,42 @@ class ExpertCreateRequest(BaseModel):
     wechat_user_id: str | None = Field(None, description="绑定企业微信用户id")
 
 
+class ExpertBatchIdsRequest(BaseModel):
+    """批量操作专家 - 请求"""
+
+    expert_ids: list[int] = Field(..., min_length=1, max_length=200, description="专家档案 ID 列表")
+
+    @field_validator("expert_ids")
+    @classmethod
+    def _normalize_expert_ids(cls, value: list[int]) -> list[int]:
+        seen: set[int] = set()
+        normalized: list[int] = []
+        for item in value:
+            expert_id = int(item)
+            if expert_id <= 0 or expert_id in seen:
+                continue
+            seen.add(expert_id)
+            normalized.append(expert_id)
+        if not normalized:
+            raise ValueError("expert_ids must contain at least one valid id")
+        return normalized
+
+
+class ExpertBatchItemFailure(BaseModel):
+    """批量操作单条失败项"""
+
+    expert_id: int
+    code: int
+    message: str
+
+
+class ExpertBatchOperationResult(BaseModel):
+    """批量操作专家 - 响应"""
+
+    succeeded: list[int] = Field(default_factory=list)
+    failed: list[ExpertBatchItemFailure] = Field(default_factory=list)
+
+
 class ExpertUpdateRequest(BaseModel):
     """更新专家 - 请求"""
 

--- a/src/backend/bisheng/qa_expert/domain/services.py
+++ b/src/backend/bisheng/qa_expert/domain/services.py
@@ -283,6 +283,7 @@ class ExpertService:
         answer_desc: bool | None = None,
         adoption_desc: bool | None = None,
         vote_desc: bool | None = None,
+        status: int | None = None,
     ) -> tuple[list[dict], int]:
         """列表查询专家"""
         sort_by_department = sort_by == "department"
@@ -300,6 +301,7 @@ class ExpertService:
             answer_desc=answer_desc,
             adoption_desc=adoption_desc,
             vote_desc=vote_desc,
+            status=status,
         )
         experts_all = await self._build_expert_rows(experts)
         if sort_by_department:

--- a/src/backend/bisheng/qa_expert/domain/services.py
+++ b/src/backend/bisheng/qa_expert/domain/services.py
@@ -25,6 +25,7 @@ from bisheng.common.errcode.qa_expert import (
     QaExpertCommentNotAllowedError,
     QaExpertContentLockedError,
     QaExpertDisabledError,
+    QaExpertHasAnswersCannotDeleteError,
     QaExpertQuestionAccessDeniedError,
 )
 from bisheng.common.utils.beijing_time import beijing_epoch_seconds, dump_qa_datetimes, to_beijing_iso
@@ -182,6 +183,8 @@ class ExpertService:
 
     def __init__(self):
         self.repository = ExpertRepository()
+        self.invite_repository = QuestionInviteRepository()
+        self.answer_repository = AnswerRepository()
         self.publish_service = None
 
     def _publish(self):
@@ -477,6 +480,48 @@ class ExpertService:
         """兼容 DELETE：映射为停用，不硬删。"""
         await self.disable_expert(expert_id, user)
         return True
+
+    async def hard_delete_expert(self, expert_id: int, user) -> None:
+        """硬删专家档案：无未软删回答时可删；历史回答保留 expert_id 引用。"""
+        self._require_admin(user)
+        expert = await self.repository.get_by_id(expert_id)
+        if not expert:
+            raise ExpertNotFoundError()
+        answer_count = await self.answer_repository.count_active_by_expert_id(expert_id)
+        if answer_count > 0:
+            raise QaExpertHasAnswersCannotDeleteError()
+        if int(expert.status) == EXPERT_STATUS_ACTIVE:
+            await self._publish().on_expert_disabled(int(expert.user_id))
+        await self.invite_repository.delete_by_expert_id(expert_id)
+        deleted = await self.repository.delete(expert_id)
+        if not deleted:
+            raise ExpertNotFoundError()
+
+    async def batch_disable_experts(self, expert_ids: list[int], user) -> dict:
+        """批量停用专家，单条失败不影响其余条目。"""
+        self._require_admin(user)
+        succeeded: list[int] = []
+        failed: list[dict] = []
+        for expert_id in expert_ids:
+            try:
+                await self.disable_expert(expert_id, user)
+                succeeded.append(expert_id)
+            except BaseErrorCode as exc:
+                failed.append({"expert_id": expert_id, "code": exc.code, "message": exc.message})
+        return {"succeeded": succeeded, "failed": failed}
+
+    async def batch_hard_delete_experts(self, expert_ids: list[int], user) -> dict:
+        """批量硬删专家档案，单条失败不影响其余条目。"""
+        self._require_admin(user)
+        succeeded: list[int] = []
+        failed: list[dict] = []
+        for expert_id in expert_ids:
+            try:
+                await self.hard_delete_expert(expert_id, user)
+                succeeded.append(expert_id)
+            except BaseErrorCode as exc:
+                failed.append({"expert_id": expert_id, "code": exc.code, "message": exc.message})
+        return {"succeeded": succeeded, "failed": failed}
 
     async def get_expertinfo(self, expert_name: str) -> dict | None:
         """获取专家信息"""

--- a/src/backend/test/qa_expert/test_expert_hard_delete.py
+++ b/src/backend/test/qa_expert/test_expert_hard_delete.py
@@ -1,0 +1,111 @@
+# ruff: noqa: RUF002
+"""专家硬删与批量停用/删除流转测试。"""
+
+from sqlalchemy import text
+
+from bisheng.database.models.qa_expert import Answer, Expert, QuestionInvite
+from bisheng.qa_expert.domain.repositories import AnswerRepository
+
+
+async def test_hard_delete_removes_expert_row(flow_env):
+    env = flow_env
+    env.as_user(env.portal_admin)
+    expert = await env.seed_expert(user_id=501, name="hard-del")
+    expert_id = int(expert.id)
+
+    resp = await env.client.post(f"/api/v1/qa_experts/experts/{expert_id}/delete")
+    body = resp.json()
+    assert body["status_code"] == 200
+
+    row = await env.reload_row(Expert, id=expert_id)
+    assert row is None
+
+
+async def test_hard_delete_rejects_expert_with_answers(flow_env):
+    env = flow_env
+    env.as_user(env.portal_admin)
+    expert = await env.seed_expert(user_id=502, name="has-answer")
+    expert_id = int(expert.id)
+
+    await AnswerRepository().create(
+        Answer(
+            tenant_id=1,
+            question_id=999999,
+            expert_id=expert_id,
+            user_id=int(expert.user_id),
+            expert_name=expert.expert_name,
+            content="ans",
+            status=1,
+        )
+    )
+
+    resp = await env.client.post(f"/api/v1/qa_experts/experts/{expert_id}/delete")
+    body = resp.json()
+    assert body["status_code"] == 18314
+
+    row = await env.reload_row(Expert, id=expert_id)
+    assert row is not None
+
+    async with env.engine.connect() as conn:
+        await conn.execute(text("DELETE FROM qa_answer WHERE expert_id = :eid"), {"eid": expert_id})
+        await conn.commit()
+
+
+async def test_batch_disable_and_batch_delete(flow_env):
+    env = flow_env
+    env.as_user(env.portal_admin)
+    a = await env.seed_expert(user_id=503, name="batch-a")
+    b = await env.seed_expert(user_id=504, name="batch-b")
+    c = await env.seed_expert(user_id=505, name="batch-c")
+    ids = [int(a.id), int(b.id)]
+
+    disable_resp = await env.client.post(
+        "/api/v1/qa_experts/experts/batch-disable",
+        json={"expert_ids": ids},
+    )
+    disable_body = disable_resp.json()
+    assert disable_body["status_code"] == 200
+    assert set(disable_body["data"]["succeeded"]) == set(ids)
+    assert disable_body["data"]["failed"] == []
+
+    for expert_id in ids:
+        row = await env.reload_row(Expert, id=expert_id)
+        assert int(row.status) == 0
+
+    delete_ids = [int(a.id), int(c.id)]
+    delete_resp = await env.client.post(
+        "/api/v1/qa_experts/experts/batch-delete",
+        json={"expert_ids": delete_ids},
+    )
+    delete_body = delete_resp.json()
+    assert delete_body["status_code"] == 200
+    assert set(delete_body["data"]["succeeded"]) == set(delete_ids)
+
+    for expert_id in delete_ids:
+        assert await env.reload_row(Expert, id=expert_id) is None
+
+    remaining = await env.reload_row(Expert, id=int(b.id))
+    assert remaining is not None
+
+
+async def test_hard_delete_clears_invites(flow_env):
+    env = flow_env
+    env.as_user(env.portal_admin)
+    expert = await env.seed_expert(user_id=506, name="invite-clean")
+    expert_id = int(expert.id)
+
+    async with env.engine.connect() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO qa_question_invite (tenant_id, question_id, expert_id, user_id) "
+                "VALUES (1, 999998, :eid, :uid)"
+            ),
+            {"eid": expert_id, "uid": int(expert.user_id)},
+        )
+        await conn.commit()
+
+    resp = await env.client.post(f"/api/v1/qa_experts/experts/{expert_id}/delete")
+    assert resp.json()["status_code"] == 200
+
+    invites = await env.reload_all(QuestionInvite, expert_id=expert_id)
+    assert invites == []

--- a/src/backend/test/qa_expert/test_expert_list_active_only.py
+++ b/src/backend/test/qa_expert/test_expert_list_active_only.py
@@ -1,0 +1,64 @@
+# ruff: noqa: RUF002
+"""邀请/榜单列表只返回有效专家；管理列表默认仍含停用。"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from bisheng.database.models.qa_expert import Expert
+from bisheng.qa_expert.api import endpoints
+from bisheng.qa_expert.api.router import router
+from bisheng.qa_expert.domain.repositories import ExpertRepository
+
+
+async def test_list_status_one_hides_disabled_experts(flow_env):
+    env = flow_env
+    env.as_user(env.portal_admin)
+    active = await env.seed_expert(user_id=601, name="active-list")
+    disabled = await env.seed_expert(user_id=602, name="disabled-list")
+
+    disable_resp = await env.client.post(f"/api/v1/qa_experts/experts/{int(disabled.id)}/disable")
+    assert disable_resp.json()["status_code"] == 200
+    row = await env.reload_row(Expert, id=int(disabled.id))
+    assert int(row.status) == 0
+
+    repo = ExpertRepository()
+    all_rows, _all_total = await repo.list_all(skip=0, limit=200)
+    all_ids = {int(item.id) for item in all_rows}
+    assert int(active.id) in all_ids
+    assert int(disabled.id) in all_ids
+
+    active_rows, _active_total = await repo.list_all(skip=0, limit=200, status=1)
+    active_ids = {int(item.id) for item in active_rows}
+    assert int(active.id) in active_ids
+    assert int(disabled.id) not in active_ids
+
+    again_rows, _ = await repo.list_all(skip=0, limit=200, status=1)
+    assert int(disabled.id) not in {int(item.id) for item in again_rows}
+
+
+def test_list_experts_query_status_accepts_string_one():
+    """门户榜单会带 status=1 查询串, 必须能转成整数, 不能 422。"""
+    service = SimpleNamespace(list_experts=AsyncMock(return_value=([], 0)))
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1")
+    app.dependency_overrides[endpoints.get_expert_service] = lambda: service
+    client = TestClient(app)
+
+    resp = client.get(
+        "/api/v1/qa_experts/experts",
+        params={
+            "page": 1,
+            "limit": 8,
+            "sort_by": "expert_score",
+            "sort_order": "desc",
+            "status": "1",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status_code"] == 200
+    service.list_experts.assert_awaited()
+    assert service.list_experts.await_args.kwargs["status"] == 1

--- a/src/backend/test/qa_expert/test_expert_management_list.py
+++ b/src/backend/test/qa_expert/test_expert_management_list.py
@@ -224,6 +224,7 @@ async def test_service_sorts_department_names_before_paginating(monkeypatch) -> 
         answer_desc=None,
         adoption_desc=None,
         vote_desc=None,
+        status=None,
     )
 
 
@@ -253,3 +254,23 @@ async def test_service_maps_department_filter_options(monkeypatch) -> None:
         {"id": "102", "name": "设备部", "short_name": "设备", "display_name": "设备"},
         {"id": "101", "name": "质量部", "short_name": None, "display_name": "质量部"},
     ]
+
+
+async def test_repository_status_filter_excludes_disabled(expert_engine) -> None:
+    await _seed_experts(expert_engine)
+    async with AsyncSession(expert_engine, expire_on_commit=False) as session:
+        expert = await session.get(Expert, 2)
+        expert.status = 0
+        session.add(expert)
+        await session.commit()
+
+    _all_rows, all_total = await repository_module.ExpertRepository().list_all(skip=0, limit=10)
+    active_rows, active_total = await repository_module.ExpertRepository().list_all(
+        skip=0,
+        limit=10,
+        status=1,
+    )
+
+    assert all_total == 3
+    assert active_total == 2
+    assert {row.expert_name for row in active_rows} == {"甲专家", "丙专家"}


### PR DESCRIPTION
## Summary
- `DELETE /experts/{id}` 仍为停用；新增 `POST /experts/{id}/delete` 硬删（有未软删回答则 18314，请改用停用）
- 新增批量停用 / 批量硬删：`POST /experts/batch-disable`、`POST /experts/batch-delete`
- `GET /experts` 增加可选 `status`（1 有效 / 0 停用）；查询串 `status=1` 用 int 接收，避免 Literal 校验 422

## Test plan
- [ ] 停用专家后管理列表仍能看到；邀请与榜单带 `status=1` 不再出现停用专家
- [ ] 无回答记录的专家可硬删；有回答记录返回 18314 且行仍在
- [ ] 批量停用 / 批量删除接口与落库一致
- [ ] `pytest test/qa_expert/test_expert_hard_delete.py test/qa_expert/test_expert_list_active_only.py test/qa_expert/test_expert_management_list.py`


Made with [Cursor](https://cursor.com)