### PR TITLE
feat(knowledge): 按角色矩阵开放知识库与文件夹拖拽排序

### DIFF
--- a/features/v2.6.0/README.md
+++ b/features/v2.6.0/README.md
@@ -19,6 +19,7 @@
 | F083 | [portal-department-display-name](./083-portal-department-display-name/) | P0 | ✅ 已实现，人工 E2E 待执行 | F082, F025, F060, F064, F065 |
 | F098 | [distribution-aware-container-delete](./098-distribution-aware-container-delete/) | P0 | ✅ 已实现并通过 171 端到端验证 | F059, F071 |
 | F100 | [migration-preserve-link](./100-migration-preserve-link/) | P1 | 🚧 实现中 | F059, F098, 知识迁移批次 |
+| F106 | [knowledge-reorder-auth](./106-knowledge-reorder-auth/) | P0 | 🔲 方案+用例+tasks 待确认 | 现有 sort_weight、F013、部门绑定、运营岗身份 |
 
 ---
 
@@ -40,6 +41,7 @@
 | 日期 | 变更 |
 |------|------|
 | 2026-05-18 | 初始化 v2.6.0 版本目录，并迁入 **F025-approval-center-unification** 规格与任务。 |
+| 2026-09-01 | 新增 **F106-knowledge-reorder-auth**：系统管理员排序能力保留，按矩阵向运营岗/部门管理员/库与文件夹管理员开放拖拽；无 DDL。 |
 | 2026-08-26 | 新增 **F098-distribution-aware-container-delete**：容器删除不再被软链拦截，三条删除路径统一为一条分发规则。 |
 | 2026-07-14 | 登记并完成 **F054-file-publish-submit-performance** 第一阶段：定向目标校验、发布通知异步化、审批任务批量写入与分段性能日志。 |
 | 2026-08-07 | 登记 **F079-tag-management-console**：独立页面标签管理控制台（左右布局、统一分页、批量审核、审核留痕字段）。相似标签处理、正文高亮与上下切换、AI标签开关本期不做。 |

--- a/features/v2.6.0/release-contract.md
+++ b/features/v2.6.0/release-contract.md
@@ -57,6 +57,7 @@
 | INV-14 | 积分规则配置、全站调分与说明文案仅平台超级管理员可写；公共库管理员不得改规则；站内不做申诉流程；积分站内信文案为代码常量不可运营配置 | PointRule, PointCopy, UserPointLog | F070 |
 | INV-15 | 首钢门户范围内的动态部门展示统一为 `trim(short_name) or name`，部门路径逐级应用同一规则，搜索同时匹配正式名称和简称，展示排序按展示名称稳定排序；既有 `name` / `department_name` 继续表达正式名称，部门 ID、权限、同步匹配及历史审批快照不得被简称替代或批量改写。该不变量不适用于 Platform 组织架构、首页无部门 ID 的硬编码积分榜、Filelib/同步/遥测事实字段。 | Department, User, Knowledge, Permission, Approval, QAExpert | F083 |
 | INV-16 | `POST /api/v2/filelib/retrieve` 仅可为已通过 Developer Token 校验、且已按 F069 业务用户上下文通过文件 `view_file` 可见性过滤的检索结果签发原文件预签名 URL；签发不再要求 `download_file`，也不进入门户下载额度、审计、水印或分发限制链路。URL 是签发后 7 天内无需 Developer Token 的 Bearer 凭证，必须只指向原文件对象、不得记录完整签名；无权文件不得进入响应，文件记录或原对象缺失时对应 URL 必须为空。 | DeveloperToken, KnowledgeFile, Permission, MinIO | F084 |
+| INV-17 | 知识库 / 文件夹手动顺序只写已有 `knowledge.sort_weight` 与 `knowledgefile.sort_weight`；写路径资格由毕昇 `KnowledgeSpaceService` 按角色矩阵计算并在写接口再检，Client 下发的 `can_reorder*` 不得作为唯一鉴权。系统管理员既有排序能力不得回退。部门管理员只能移动管辖部门（含下级）在 `department_knowledge_space` 上已绑定的团队/科室库。运营岗不得写入 `is_admin()`。 | Knowledge, KnowledgeFile, DepartmentKnowledgeSpace | F106 |
 
 **规则**：
 - 新增不变量：先在此表追加，再写 AC
@@ -83,6 +84,7 @@
 | F070-points-system | F002, F004, F009, F012, F025（发布审批结果只读）, 现有 knowledge/qa_expert/message/telemetry | 新建积分域；扩展 Department.org_level；挂钩只读/调用知识上传发布、收藏、采纳、日活与站内信，不取得其写所有权；外部协同办公同步不阻塞 MVP |
 | F082-department-short-name | F002, F009, F014/F015 | 扩展 F002 的 Department 字段与既有创建/详情/更新链路；简称由本地维护，F009/F014/F015 组织同步不得覆盖 |
 | F083-portal-department-display-name | F082, F025, F060, F064, F065 | 只读 F082 的 `Department.short_name`，统一首钢门户、嵌入式知识门户、成员管理、审批、专家和水印展示；保留正式名称、历史快照、权限与同步契约，不新增领域对象或数据迁移 |
+| F106-knowledge-reorder-auth | F013, 现有 knowledge sort_weight、department_knowledge_space、运营岗身份 | 只扩展谁能写已有 `sort_weight` 并下发 `can_reorder*`；不取得 Knowledge / KnowledgeFile / 部门绑定表写所有权，不改置顶与个人库 |
 
 ---
 
@@ -122,3 +124,4 @@
 | 2026-08-10 | 登记 F082 部门简称：为 `Department.short_name` 建立字段扩展所有权，明确可空 64 字符、本地维护、同步不覆盖及不改变组织树/搜索/权限边界 | F082, F002, F009, F014, F015 |
 | 2026-08-10 | 登记 F083 门户部门简称统一展示：新增 INV-11 与 F082/F025/F060/F064/F065 依赖；门户动态展示、搜索、排序和路径使用简称回退，正式名称字段、历史快照、部门 ID、权限及同步事实保持不变 | F083, F082, User, Knowledge, Permission, Approval, QAExpert |
 | 2026-08-21 | 登记 F084 Filelib 检索原文件链接：新增 INV-16 与 F069/F017 依赖，明确 `view_file` 可见结果可获得 7 天原文件 Bearer URL，并显式绕过 `download_file`、门户下载额度、审计、水印和分发限制；无权或原对象缺失时不得签发 | F084, F069, F017, DeveloperToken, KnowledgeFile, Permission, MinIO |
+| 2026-09-01 | 登记 F106 库/文件夹排序权限：新增 INV-17；不新增领域对象与错误码段，复用 18040/18041；部门管理员按绑定表，运营岗不得写入 `is_admin()` | F106, INV-17, Knowledge, KnowledgeFile |

--- a/src/backend/bisheng/common/errcode/qa_expert.py
+++ b/src/backend/bisheng/common/errcode/qa_expert.py
@@ -80,3 +80,9 @@ class QaExpertAssetInvalidError(BaseErrorCode):
     """提问/回答图片或附件引用不合法（数量、格式、路径等）。"""
 
     Code, Msg = 18313, "问答图片或附件不合法"
+
+
+class QaExpertHasAnswersCannotDeleteError(BaseErrorCode):
+    """专家已有问答记录, 不可从专家库硬删。"""
+
+    Code, Msg = 18314, "该专家已有回答记录, 不可删除, 请使用停用"

--- a/src/backend/bisheng/knowledge/api/endpoints/knowledge_space.py
+++ b/src/backend/bisheng/knowledge/api/endpoints/knowledge_space.py
@@ -250,9 +250,10 @@ async def reorder_space(
     next_space_id: int | None = Body(default=None, embed=True),
     svc: KnowledgeSpaceService = Depends(get_knowledge_space_service),
 ):
-    """调整知识库在其层级内的管理员排序（系统管理员）。
+    """调整知识库在其工作集内的排序.
 
-    传入拖拽后左右相邻的知识库 ID（列表首/尾时对应一侧为空），只改被拖动的这一条。
+    传入拖拽后左右相邻的知识库 ID (列表首/尾时对应一侧为空), 只改被拖动的这一条.
+    系统管理员 / 运营岗 / 部门管理员按服务端矩阵鉴权, 无权返回 18040.
     """
     await svc.reorder_space(space_id, prev_space_id=prev_space_id, next_space_id=next_space_id)
     return resp_200(data=True)
@@ -266,10 +267,10 @@ async def reorder_folder(
     next_folder_id: int | None = Body(default=None, embed=True),
     svc: KnowledgeSpaceService = Depends(get_knowledge_space_service),
 ):
-    """调整文件夹在其所在目录内的管理员排序（系统管理员）。
+    """调整文件夹在其所在目录内的排序.
 
-    传入拖拽后上下相邻的文件夹 ID（列表首/尾时对应一侧为空），只改被拖动的这一条。
-    仅文件夹参与排序，文件保持原有排序规则。
+    传入拖拽后上下相邻的文件夹 ID (列表首/尾时对应一侧为空), 只改被拖动的这一条.
+    仅文件夹参与排序, 文件保持原有排序规则. 鉴权当前父目录 can_manage.
     """
     await svc.reorder_folder(
         space_id,
@@ -571,7 +572,7 @@ async def list_space_children(
 ) -> Any:
     """List space children (F027 cursor-based pagination).
 
-    Response shape (PageInfiniteCursorData): ``{data, page_size, has_more, next_cursor}``.
+    Response shape: ``{data, page_size, has_more, next_cursor, can_reorder_folders}``.
     The legacy ``total`` / ``page`` fields have been removed (AC-03).
     """
     result = await svc.list_space_children(
@@ -763,9 +764,7 @@ async def preflight_delete_folder(
     svc: KnowledgeSpaceService = Depends(get_knowledge_space_service),
 ) -> Any:
     """What deleting this folder would do to files published or shared elsewhere."""
-    return resp_200(
-        await svc.preflight_container_delete(space_id=space_id, folder_id=folder_id)
-    )
+    return resp_200(await svc.preflight_container_delete(space_id=space_id, folder_id=folder_id))
 
 
 @router.delete("/{space_id}/folders/{folder_id}")

--- a/src/backend/bisheng/knowledge/domain/schemas/knowledge_space_schema.py
+++ b/src/backend/bisheng/knowledge/domain/schemas/knowledge_space_schema.py
@@ -12,6 +12,7 @@ from pydantic import (
 )
 
 from bisheng.common.models.space_channel_member import UserRoleEnum
+from bisheng.common.schemas.api import PageInfiniteCursorData
 from bisheng.knowledge.domain import knowledge_fulltext_constants
 from bisheng.knowledge.domain.constants import normalize_business_domain_code, normalize_file_category_code
 from bisheng.knowledge.domain.models.knowledge import AuthTypeEnum, KnowledgeBase
@@ -92,6 +93,10 @@ class KnowledgeSpaceInfoResp(KnowledgeBase):
         description="Current user subscription status",
     )
     can_unsubscribe: bool = Field(default=False, description="Whether current user can unsubscribe from this space")
+    can_reorder: bool = Field(
+        default=False,
+        description="Whether the current user can drag this knowledge space in its sidebar group",
+    )
     user_role: UserRoleEnum | None = Field(default=None, description="Knowledge Space user role")
     space_kind: Literal["normal", "department"] = Field(default="normal", description="Knowledge space kind")
     is_clinic: bool = Field(
@@ -739,9 +744,7 @@ class ShougangPortalFileItemResp(BaseModel):
     applied_entry_generation: int = 0
     projection_status: str = "ready"
     projection_ready: bool = True
-    capabilities: KnowledgeDocumentEntryCapabilities = Field(
-        default_factory=KnowledgeDocumentEntryCapabilities
-    )
+    capabilities: KnowledgeDocumentEntryCapabilities = Field(default_factory=KnowledgeDocumentEntryCapabilities)
 
     @model_serializer(mode="wrap")
     def serialize_with_content_access_allowlist(self, handler):
@@ -1293,8 +1296,15 @@ class KnowledgeSpaceFileResponse(KnowledgeFileRead):
     manager_space_id: int | None = None
     distribution_invalid_reason: str | None = None
     projection_ready: bool = True
-    capabilities: KnowledgeDocumentEntryCapabilities = Field(
-        default_factory=KnowledgeDocumentEntryCapabilities
+    capabilities: KnowledgeDocumentEntryCapabilities = Field(default_factory=KnowledgeDocumentEntryCapabilities)
+
+
+class KnowledgeSpaceChildrenPage(PageInfiniteCursorData[KnowledgeSpaceFileResponse]):
+    """知识空间当前目录的分页列表, 附带本目录能否拖拽文件夹."""
+
+    can_reorder_folders: bool = Field(
+        default=False,
+        description="Whether the current user can reorder folders under this parent directory",
     )
 
 

--- a/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
+++ b/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
@@ -90,7 +90,7 @@ from bisheng.common.models.space_channel_member import (
     SpaceChannelMemberDao,
     UserRoleEnum,
 )
-from bisheng.common.schemas.api import PageData, PageInfiniteCursorData
+from bisheng.common.schemas.api import PageData
 from bisheng.common.schemas.telemetry.event_data_schema import (
     PortalDocumentDownloadEventData,
     PortalDocumentReadEventData,
@@ -200,6 +200,7 @@ from bisheng.knowledge.domain.schemas.knowledge_space_schema import (
     BatchAliasActionResult,
     BatchAliasFailure,
     GroupedKnowledgeSpacesResp,
+    KnowledgeSpaceChildrenPage,
     KnowledgeSpaceCreateOptionDepartment,
     KnowledgeSpaceCreateOptionDepartmentsResp,
     KnowledgeSpaceCreateOptionsResp,
@@ -308,6 +309,16 @@ from bisheng.knowledge.domain.services.portal_recommendation_service import (
     PortalRecommendationService,
 )
 from bisheng.knowledge.domain.services.space_list_cache import SpaceListCache
+from bisheng.knowledge.domain.services.space_reorder_auth import (
+    assert_can_reorder_folders,
+    assert_neighbours_in_workset,
+    assert_space_in_workset,
+    attach_can_reorder_flags,
+    can_reorder_folders,
+    folder_parent_id,
+    is_system_admin,
+    resolve_space_reorder_workset_ids,
+)
 from bisheng.knowledge.domain.services.tag_library_tag_service import TagLibraryTagService
 from bisheng.knowledge.domain.services.web_link_import_service import (
     KnowledgeWebLinkImportService,
@@ -356,6 +367,7 @@ from bisheng.shougang_portal_config.domain.services.portal_config_service import
 )
 from bisheng.telemetry.domain.mid_table.knowledge_space_content import KnowledgeSpaceContentStat
 from bisheng.user.domain.models.user import UserDao
+from bisheng.user.domain.services.platform_operator import has_platform_operator_role
 from bisheng.utils import get_request_ip
 from bisheng.workstation.domain.services.workstation_service import WorkStationService
 
@@ -2969,7 +2981,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
             decorate_ms,
             (time.perf_counter() - t0) * 1000,
         )
-        return result
+        return await self._attach_space_reorder_flags(result)
 
     async def _require_write_permission(self, space_id: int) -> None:
         """
@@ -4584,6 +4596,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                     self.login_user.user_id,
                 )
 
+        await self._attach_space_reorder_flags([result])
         return result
 
     async def get_shougang_portal_space_levels(self) -> list[dict]:
@@ -7941,8 +7954,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 if (
                     space is not None
                     and int(space.type) == KnowledgeTypeEnum.SPACE.value
-                    and int(getattr(space, "tenant_id", 0) or 0)
-                    == int(self.login_user.tenant_id)
+                    and int(getattr(space, "tenant_id", 0) or 0) == int(self.login_user.tenant_id)
                 ):
                     return file, [space]
             return None, []
@@ -12571,6 +12583,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 )
             )
         result = await self._decorate_department_metadata(spaces)
+        result = await self._attach_space_reorder_flags(result)
         return await KnowledgeSpacePinService.apply_pins(result, self.login_user.user_id)
 
     async def get_my_created_spaces(self, order_by: str = "update_time") -> list[KnowledgeRead]:
@@ -12835,6 +12848,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
             if user_role is not None:
                 payload["user_role"] = user_role.value
             result.append(payload)
+        result = await self._attach_space_reorder_flags(result)
         return await KnowledgeSpacePinService.apply_pins(result, self.login_user.user_id)
 
     async def global_search_files(
@@ -12978,21 +12992,71 @@ class KnowledgeSpaceService(KnowledgeUtils):
             space.sort_weight = weights[int(space.id)]
         return weights
 
+    async def _space_reorder_admin_department_ids(self) -> set[int]:
+        """部门管理员管辖子树; 系统管理员与运营岗不需要."""
+        if is_system_admin(self.login_user) or has_platform_operator_role(self.login_user):
+            return set()
+        return await self._admin_department_ids()
+
+    async def _attach_space_reorder_flags(self, items: list) -> list:
+        """批量写入 can_reorder, 每个 level 只算一次工作集."""
+        if not items:
+            return items
+        await attach_can_reorder_flags(
+            self.login_user,
+            items,
+            admin_department_ids=await self._space_reorder_admin_department_ids(),
+        )
+        return items
+
+    async def _visible_ids_for_space_reorder(self, level: KnowledgeSpaceLevelEnum) -> set[int] | None:
+        """写接口可见集. None 表示不再与可见集求交.
+
+        不用 get_spaces_by_level: 那条路径会拉成员表和列表装饰, 写鉴权只要 ID.
+        运营岗 TEAM 工作集为空, 这里直接空集, 避免无意义的可见查询.
+        """
+        if is_system_admin(self.login_user):
+            return None
+        if has_platform_operator_role(self.login_user):
+            if level in {
+                KnowledgeSpaceLevelEnum.PUBLIC,
+                KnowledgeSpaceLevelEnum.DEPARTMENT,
+            }:
+                return None
+            return set()
+        if level not in {KnowledgeSpaceLevelEnum.TEAM, KnowledgeSpaceLevelEnum.TEAM_KS}:
+            return set()
+        if not await self._space_reorder_admin_department_ids():
+            return set()
+        readable = await PermissionService.list_accessible_ids(
+            user_id=self.login_user.user_id,
+            relation="can_read",
+            object_type="knowledge_space",
+            login_user=self.login_user,
+        )
+        if readable is None:
+            return None
+        manageable = await PermissionService.list_accessible_ids(
+            user_id=self.login_user.user_id,
+            relation="can_manage",
+            object_type="knowledge_space",
+            login_user=self.login_user,
+        )
+        visible = {int(space_id) for space_id in readable if str(space_id).isdigit()}
+        visible |= {int(space_id) for space_id in (manageable or []) if str(space_id).isdigit()}
+        return visible
+
     async def reorder_space(
         self,
         space_id: int,
         prev_space_id: int | None = None,
         next_space_id: int | None = None,
     ) -> None:
-        """Move a space between two neighbours in its level's admin-defined order.
+        """按当前用户工作集移动一条库的 sort_weight.
 
-        Callers pass the ids the space is dropped between (either may be None at the
-        list edges); the new weight is the midpoint, so only this row is written no
-        matter how many spaces the level holds.
+        传入拖拽后左右邻居 ID (列表首/尾时一侧为空); 只改被拖动这一行.
+        工作集外 18040; 邻居不在工作集 18041; 个人库 18041.
         """
-        if not self.login_user.is_admin():
-            raise SpacePermissionDeniedError()
-
         space = await KnowledgeDao.aquery_by_id(space_id)
         if not space or space.type != KnowledgeTypeEnum.SPACE.value:
             raise SpaceNotFoundError()
@@ -13007,15 +13071,19 @@ class KnowledgeSpaceService(KnowledgeUtils):
             # Personal spaces are per-user and have no shared order to define.
             raise SpaceInvalidLevelError()
 
-        spaces = await self._load_level_spaces_in_display_order(level)
+        workset = await resolve_space_reorder_workset_ids(
+            self.login_user,
+            dragged_level=level,
+            visible_space_ids=await self._visible_ids_for_space_reorder(level),
+            admin_department_ids=await self._space_reorder_admin_department_ids(),
+        )
+        assert_space_in_workset(space_id, workset)
+        assert_neighbours_in_workset(prev_space_id, next_space_id, workset)
+
+        spaces = await KnowledgeDao.async_get_spaces_by_ids(list(workset), order_by="sort_weight")
         space_by_id = {int(item.id): item for item in spaces}
         if int(space_id) not in space_by_id:
             raise SpaceNotFoundError()
-        for neighbour_id in (prev_space_id, next_space_id):
-            if neighbour_id is not None and int(neighbour_id) not in space_by_id:
-                # Neighbour from another level (or a stale client view) would place the
-                # space against an order it isn't part of.
-                raise SpaceInvalidLevelError()
 
         if any(item.sort_weight is None for item in spaces):
             # First drag in this level: freeze the order currently on screen, then move.
@@ -13087,12 +13155,14 @@ class KnowledgeSpaceService(KnowledgeUtils):
         how many folders the directory holds. Only folders take part — files keep a NULL
         weight and their existing ordering.
         """
-        if not self.login_user.is_admin():
-            raise SpacePermissionDeniedError()
-
         folder = await KnowledgeFileDao.query_by_id(folder_id)
         if not folder or int(folder.knowledge_id) != int(space_id) or folder.file_type != FileType.DIR.value:
             raise SpaceFolderNotFoundError()
+        await assert_can_reorder_folders(
+            self.login_user,
+            space_id=space_id,
+            parent_folder_id=folder_parent_id(folder.file_level_path),
+        )
 
         folders = await self._load_sibling_folders_in_display_order(folder)
         folder_by_id = {int(item.id): item for item in folders}
@@ -14614,10 +14684,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
             primary_versions = await self.version_repo.find_primary_versions_by_file_ids(
                 [int(one.id) for one in file_items]
             )
-            doc_by_file = {
-                int(version.knowledge_file_id): int(version.document_id)
-                for version in primary_versions
-            }
+            doc_by_file = {int(version.knowledge_file_id): int(version.document_id) for version in primary_versions}
         for one in file_items:
             document_id = doc_by_file.get(int(one.id))
             if document_id is None and one.reference_document_id:
@@ -14698,9 +14765,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
 
         pending_publish_start = time.perf_counter()
         pending_publish_file_ids = (
-            await self._find_pending_publish_approval_file_ids(res)
-            if enrich_files and file_ids
-            else set()
+            await self._find_pending_publish_approval_file_ids(res) if enrich_files and file_ids else set()
         )
         pending_publish_ms = (time.perf_counter() - pending_publish_start) * 1000
 
@@ -14986,17 +15051,16 @@ class KnowledgeSpaceService(KnowledgeUtils):
         file_type: int | None = None,
         enrich_files: bool = True,
         folder_count_mode: str = "none",
-    ) -> "PageInfiniteCursorData":
+    ) -> "KnowledgeSpaceChildrenPage":
         """F027 cursor-paginated listing of direct children under a parent folder.
 
-        Response shape (PageInfiniteCursorData): ``{data, page_size, has_more,
-        next_cursor}``. Legacy ``total`` / ``page`` fields removed (AC-03);
+        Response shape: ``{data, page_size, has_more, next_cursor, can_reorder_folders}``.
+        Legacy ``total`` / ``page`` fields removed (AC-03);
         clients drive infinite-scroll via ``has_more`` + ``next_cursor``.
         """
         perf_start = time.perf_counter()
         from bisheng.common.cursor import CursorDecodeError, decode_cursor, encode_cursor
         from bisheng.common.errcode.knowledge_space import KnowledgeSpaceInvalidCursorError
-        from bisheng.common.schemas.api import PageInfiniteCursorData
         from bisheng.knowledge.domain.models.knowledge_space_file import (
             build_child_order_cursor_key,
             child_order_cursor_key_len,
@@ -15099,11 +15163,17 @@ class KnowledgeSpaceService(KnowledgeUtils):
             extra_info_ms,
             (time.perf_counter() - perf_start) * 1000,
         )
-        return PageInfiniteCursorData(
+        can_reorder = await can_reorder_folders(
+            self.login_user,
+            space_id=space_id,
+            parent_folder_id=parent_id,
+        )
+        return KnowledgeSpaceChildrenPage(
             data=data,
             page_size=page_size,
             has_more=has_more,
             next_cursor=next_cursor,
+            can_reorder_folders=can_reorder,
         )
 
     async def resolve_qa_scope_file_ids(

--- a/src/backend/bisheng/knowledge/domain/services/space_reorder_auth.py
+++ b/src/backend/bisheng/knowledge/domain/services/space_reorder_auth.py
@@ -1,0 +1,202 @@
+"""库与文件夹拖拽排序鉴权, 以及列表 can_reorder 标志.
+
+工作集规则见 F106 design.md. 运营岗只用 has_platform_operator_role, 禁止写入 is_admin().
+TEAM 工作集不得用 can_platform_operate (其中含超管, 会让运营岗排到团队库).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from typing import Any
+
+from bisheng.common.errcode.knowledge_space import SpaceInvalidLevelError, SpacePermissionDeniedError
+from bisheng.knowledge.domain.models.department_knowledge_space import DepartmentKnowledgeSpaceDao
+from bisheng.knowledge.domain.models.knowledge_space_scope import KnowledgeSpaceLevelEnum, KnowledgeSpaceScopeDao
+from bisheng.user.domain.services.platform_operator import has_platform_operator_role
+
+TEAM_GROUP_LEVELS = (KnowledgeSpaceLevelEnum.TEAM, KnowledgeSpaceLevelEnum.TEAM_KS)
+PUBLIC_OR_DEPARTMENT = frozenset(
+    {KnowledgeSpaceLevelEnum.PUBLIC, KnowledgeSpaceLevelEnum.DEPARTMENT},
+)
+
+
+def is_system_admin(user: Any) -> bool:
+    """系统管理员判定, 与 login_user.is_admin() 对齐, 不把运营岗算进来."""
+    if user is None:
+        return False
+    check = getattr(user, "is_admin", None)
+    if callable(check):
+        return bool(check())
+    return bool(check)
+
+
+def _space_id(item: Any) -> int:
+    if isinstance(item, dict):
+        return int(item["id"])
+    return int(item.id)
+
+
+def _space_level(item: Any) -> KnowledgeSpaceLevelEnum | None:
+    raw = item.get("space_level") if isinstance(item, dict) else getattr(item, "space_level", None)
+    if raw is None:
+        return None
+    value = getattr(raw, "value", raw)
+    try:
+        return KnowledgeSpaceLevelEnum(str(value))
+    except ValueError:
+        return None
+
+
+def _set_can_reorder(item: Any, flag: bool) -> None:
+    if isinstance(item, dict):
+        item["can_reorder"] = flag
+        return
+    item.can_reorder = flag
+
+
+async def resolve_space_reorder_workset_ids(
+    login_user: Any,
+    *,
+    dragged_level: KnowledgeSpaceLevelEnum,
+    visible_space_ids: set[int] | None = None,
+    admin_department_ids: set[int] | None = None,
+) -> set[int]:
+    """当前用户可改序的空间 ID.
+
+    visible_space_ids 为 None 表示不再与可见集求交 (系统管理员 / 运营岗的 PUBLIC|DEPARTMENT).
+    部门管理员 TEAM 必须传入管辖部门 ID, 并与绑定表、可见集求交.
+    """
+    if dragged_level == KnowledgeSpaceLevelEnum.PERSONAL:
+        return set()
+
+    if dragged_level in PUBLIC_OR_DEPARTMENT:
+        if is_system_admin(login_user) or has_platform_operator_role(login_user):
+            ids = await KnowledgeSpaceScopeDao.aget_space_ids_by_level(dragged_level)
+            return {int(space_id) for space_id in ids}
+        return set()
+
+    if dragged_level not in TEAM_GROUP_LEVELS:
+        return set()
+
+    if is_system_admin(login_user):
+        ids = await KnowledgeSpaceScopeDao.aget_space_ids_by_levels(list(TEAM_GROUP_LEVELS))
+        return {int(space_id) for space_id in ids}
+
+    # 运营岗不能排团队/科室库. 这里不能用 can_platform_operate.
+    if has_platform_operator_role(login_user):
+        return set()
+
+    if not admin_department_ids:
+        return set()
+
+    bindings = await DepartmentKnowledgeSpaceDao.aget_by_department_ids(list(admin_department_ids))
+    bound_ids = {int(row.space_id) for row in bindings}
+    if not bound_ids:
+        return set()
+    team_ids = {
+        int(space_id) for space_id in await KnowledgeSpaceScopeDao.aget_space_ids_by_levels(list(TEAM_GROUP_LEVELS))
+    }
+    workset = bound_ids & team_ids
+    if visible_space_ids is not None:
+        workset &= visible_space_ids
+    return workset
+
+
+def assert_space_in_workset(space_id: int, workset: set[int]) -> None:
+    """被拖库不在工作集则 18040."""
+    if int(space_id) not in workset:
+        raise SpacePermissionDeniedError()
+
+
+def assert_neighbours_in_workset(
+    prev_space_id: int | None,
+    next_space_id: int | None,
+    workset: set[int],
+) -> None:
+    """邻居不在本次工作集则 18041 (跨组或过期视图)."""
+    for neighbour_id in (prev_space_id, next_space_id):
+        if neighbour_id is not None and int(neighbour_id) not in workset:
+            raise SpaceInvalidLevelError()
+
+
+async def can_reorder_folders(
+    login_user: Any,
+    *,
+    space_id: int,
+    parent_folder_id: int | None,
+) -> bool:
+    """当前父目录是否允许拖文件夹. 根目录鉴权知识空间, 子目录鉴权该文件夹."""
+    from bisheng.permission.domain.services.permission_service import PermissionService
+
+    user_id = int(login_user.user_id)
+    if parent_folder_id is None:
+        return await PermissionService.check(
+            user_id=user_id,
+            relation="can_manage",
+            object_type="knowledge_space",
+            object_id=str(space_id),
+            login_user=login_user,
+        )
+    return await PermissionService.check(
+        user_id=user_id,
+        relation="can_manage",
+        object_type="folder",
+        object_id=str(parent_folder_id),
+        login_user=login_user,
+    )
+
+
+async def assert_can_reorder_folders(
+    login_user: Any,
+    *,
+    space_id: int,
+    parent_folder_id: int | None,
+) -> None:
+    """文件夹写接口鉴权失败则 18040."""
+    allowed = await can_reorder_folders(
+        login_user,
+        space_id=space_id,
+        parent_folder_id=parent_folder_id,
+    )
+    if not allowed:
+        raise SpacePermissionDeniedError()
+
+
+def folder_parent_id(file_level_path: str | None) -> int | None:
+    """file_level_path 最后一段为父文件夹 ID, 空路径表示库根."""
+    ancestor_ids = [int(part) for part in (file_level_path or "").split("/") if part]
+    return ancestor_ids[-1] if ancestor_ids else None
+
+
+async def attach_can_reorder_flags(
+    login_user: Any,
+    items: Sequence[Any],
+    *,
+    admin_department_ids: set[int],
+    visible_space_ids: set[int] | None = None,
+) -> None:
+    """给列表/详情项写入 can_reorder. 每个 level 只算一次工作集, 禁止按库 N+1."""
+    if not items:
+        return
+    levels: set[KnowledgeSpaceLevelEnum] = set()
+    for item in items:
+        level = _space_level(item)
+        if level is not None:
+            levels.add(level)
+    listed_ids = {_space_id(item) for item in items}
+    visible = listed_ids if visible_space_ids is None else visible_space_ids
+    workset: set[int] = set()
+    for level in levels:
+        workset |= await resolve_space_reorder_workset_ids(
+            login_user,
+            dragged_level=level,
+            visible_space_ids=visible,
+            admin_department_ids=admin_department_ids,
+        )
+    for item in items:
+        _set_can_reorder(item, _space_id(item) in workset)
+
+
+def collect_item_ids(items: Iterable[Any]) -> set[int]:
+    """从列表项取出 ID, 供调用方做可见集."""
+    return {_space_id(item) for item in items}

--- a/src/backend/bisheng/qa_expert/api/endpoints.py
+++ b/src/backend/bisheng/qa_expert/api/endpoints.py
@@ -30,6 +30,7 @@ from bisheng.qa_expert.domain.schemas import (
     CommentCreateRequest,
     CommentDetailResponse,
     CommentPageData,
+    ExpertBatchIdsRequest,
     ExpertCreateRequest,
     ExpertResponse,
     ExpertUpdateRequest,
@@ -118,6 +119,8 @@ async def list_experts(
     answer_desc: bool | None = Query(None, description="回答数排序"),
     adoption_desc: bool | None = Query(None, description="采纳数排序"),
     vote_desc: bool | None = Query(None, description="点赞数排序"),
+    # 查询串是字符串 "1"；用 int + ge/le，不要用 Literal[0, 1]（Pydantic 不把 "1" 当成 1）
+    status: int | None = Query(None, ge=0, le=1, description="专家状态: 1有效 0停用, 缺省全部"),
     page: int = Query(1, ge=1, description="页码"),
     limit: int = Query(20, ge=1, le=500, description="每页数量"),
     service: ExpertService = Depends(get_expert_service),
@@ -138,6 +141,7 @@ async def list_experts(
         answer_desc=answer_desc,
         adoption_desc=adoption_desc,
         vote_desc=vote_desc,
+        status=status,
     )
     return resp_200(data={"experts": experts, "total": total})
 
@@ -163,6 +167,38 @@ async def create_expert(
     try:
         expert = await service.create_expert(request, user=user)
         return resp_200(data=_jsonable(expert))
+    except BaseErrorCode as exc:
+        return exc.return_resp_instance()
+    except Exception as e:
+        return resp_500(code=500, message=str(e))
+
+
+@router.post("/experts/batch-disable")
+async def batch_disable_experts(
+    request: ExpertBatchIdsRequest,
+    user: UserPayload = Depends(UserPayload.get_login_user),
+    service: ExpertService = Depends(get_expert_service),
+):
+    """批量停用专家"""
+    try:
+        result = await service.batch_disable_experts(request.expert_ids, user)
+        return resp_200(data=result)
+    except BaseErrorCode as exc:
+        return exc.return_resp_instance()
+    except Exception as e:
+        return resp_500(code=500, message=str(e))
+
+
+@router.post("/experts/batch-delete")
+async def batch_hard_delete_experts(
+    request: ExpertBatchIdsRequest,
+    user: UserPayload = Depends(UserPayload.get_login_user),
+    service: ExpertService = Depends(get_expert_service),
+):
+    """批量硬删专家档案(无回答记录时可删)"""
+    try:
+        result = await service.batch_hard_delete_experts(request.expert_ids, user)
+        return resp_200(data=result)
     except BaseErrorCode as exc:
         return exc.return_resp_instance()
     except Exception as e:
@@ -198,6 +234,22 @@ async def delete_expert(
         if not success:
             return resp_500(code=500, message="Failed to disable expert")
         return resp_200(data={"message": "Expert disabled successfully", "deprecated": True})
+    except BaseErrorCode as exc:
+        return exc.return_resp_instance()
+    except Exception as e:
+        return resp_500(code=500, message=str(e))
+
+
+@router.post("/experts/{expert_id}/delete")
+async def hard_delete_expert(
+    expert_id: int,
+    user: UserPayload = Depends(UserPayload.get_login_user),
+    service: ExpertService = Depends(get_expert_service),
+):
+    """硬删专家档案(无回答记录时可删)"""
+    try:
+        await service.hard_delete_expert(expert_id, user)
+        return resp_200(data={"message": "Expert deleted successfully", "expert_id": expert_id})
     except BaseErrorCode as exc:
         return exc.return_resp_instance()
     except Exception as e:

--- a/src/backend/bisheng/qa_expert/api/router.py
+++ b/src/backend/bisheng/qa_expert/api/router.py
@@ -25,7 +25,10 @@ router.add_api_route(
     methods=["GET"],
 )
 router.add_api_route("/experts", endpoints.create_expert, methods=["POST"])
+router.add_api_route("/experts/batch-disable", endpoints.batch_disable_experts, methods=["POST"])
+router.add_api_route("/experts/batch-delete", endpoints.batch_hard_delete_experts, methods=["POST"])
 router.add_api_route("/experts/{expert_id}", endpoints.update_expert, methods=["PUT"])
+router.add_api_route("/experts/{expert_id}/delete", endpoints.hard_delete_expert, methods=["POST"])
 router.add_api_route("/experts/{expert_id}/disable", endpoints.disable_expert, methods=["POST"])
 router.add_api_route("/experts/{expert_id}/enable", endpoints.enable_expert, methods=["POST"])
 router.add_api_route("/experts/{expert_id}", endpoints.delete_expert, methods=["DELETE"])

--- a/src/backend/bisheng/qa_expert/domain/repositories.py
+++ b/src/backend/bisheng/qa_expert/domain/repositories.py
@@ -85,6 +85,7 @@ class ExpertRepository:
         answer_desc: bool | None = None,
         adoption_desc: bool | None = None,
         vote_desc: bool | None = None,
+        status: int | None = None,
     ) -> tuple[list[Expert], int]:
         """列表查询专家"""
         async with get_async_db_session() as session:
@@ -116,6 +117,9 @@ class ExpertRepository:
             for column, value in exact_filters:
                 if value and value.strip():
                     base_stmt = base_stmt.where(func.trim(column) == value.strip())
+
+            if status is not None:
+                base_stmt = base_stmt.where(Expert.status == status)
 
             # 2. 执行计数查询（应用了相同的筛选条件）
             count_stmt = select(func.count()).select_from(base_stmt.subquery())
@@ -225,7 +229,7 @@ class ExpertRepository:
             return expert
 
     async def delete(self, expert_id: int) -> bool:
-        """删除专家"""
+        """硬删专家档案行"""
         async with get_async_db_session() as session:
             expert = await self.get_by_id(expert_id)
             if not expert:
@@ -234,6 +238,15 @@ class ExpertRepository:
             await session.commit()
             await session.flush()
             return True
+
+    async def count_by_ids(self, expert_ids: list[int]) -> int:
+        """统计给定 ID 中仍存在的专家档案数"""
+        if not expert_ids:
+            return 0
+        async with get_async_db_session() as session:
+            stmt = select(func.count()).select_from(Expert).where(Expert.id.in_(expert_ids))
+            result = await session.exec(stmt)
+            return int(result.one())
 
     async def get_expertinfo(self, expert_name: str):
         """原子性增加专家的回答数量"""
@@ -321,6 +334,15 @@ class QuestionInviteRepository:
             stmt = select(QuestionInvite.question_id).where(QuestionInvite.user_id == user_id)
             result = await session.exec(stmt)
             return [int(item) for item in result.all()]
+
+    async def delete_by_expert_id(self, expert_id: int) -> None:
+        """删除专家相关的全部邀请行(硬删前清理)"""
+        async with get_async_db_session() as session:
+            stmt = select(QuestionInvite).where(QuestionInvite.expert_id == expert_id)
+            result = await session.exec(stmt)
+            for row in result.all():
+                await session.delete(row)
+            await session.commit()
 
 
 class QuestionRepository:
@@ -663,6 +685,17 @@ class AnswerRepository:
             result = await session.exec(stmt)
 
             return result.first()
+
+    async def count_active_by_expert_id(self, expert_id: int) -> int:
+        """统计专家未软删的回答数(硬删前校验)"""
+        async with get_async_db_session() as session:
+            stmt = (
+                select(func.count())
+                .select_from(Answer)
+                .where(and_(Answer.expert_id == expert_id, Answer.status != 3))
+            )
+            result = await session.exec(stmt)
+            return int(result.one())
 
     async def count_adopted_by_question_id(self, question_id: int) -> int:
         """统计同题未软删且已采纳的回答数（用于最多 3 个最佳答案上限）。"""

--- a/src/backend/bisheng/qa_expert/domain/schemas.py
+++ b/src/backend/bisheng/qa_expert/domain/schemas.py
@@ -109,6 +109,42 @@ class ExpertCreateRequest(BaseModel):
     wechat_user_id: str | None = Field(None, description="绑定企业微信用户id")
 
 
+class ExpertBatchIdsRequest(BaseModel):
+    """批量操作专家 - 请求"""
+
+    expert_ids: list[int] = Field(..., min_length=1, max_length=200, description="专家档案 ID 列表")
+
+    @field_validator("expert_ids")
+    @classmethod
+    def _normalize_expert_ids(cls, value: list[int]) -> list[int]:
+        seen: set[int] = set()
+        normalized: list[int] = []
+        for item in value:
+            expert_id = int(item)
+            if expert_id <= 0 or expert_id in seen:
+                continue
+            seen.add(expert_id)
+            normalized.append(expert_id)
+        if not normalized:
+            raise ValueError("expert_ids must contain at least one valid id")
+        return normalized
+
+
+class ExpertBatchItemFailure(BaseModel):
+    """批量操作单条失败项"""
+
+    expert_id: int
+    code: int
+    message: str
+
+
+class ExpertBatchOperationResult(BaseModel):
+    """批量操作专家 - 响应"""
+
+    succeeded: list[int] = Field(default_factory=list)
+    failed: list[ExpertBatchItemFailure] = Field(default_factory=list)
+
+
 class ExpertUpdateRequest(BaseModel):
     """更新专家 - 请求"""
 

--- a/src/backend/bisheng/qa_expert/domain/services.py
+++ b/src/backend/bisheng/qa_expert/domain/services.py
@@ -25,6 +25,7 @@ from bisheng.common.errcode.qa_expert import (
     QaExpertCommentNotAllowedError,
     QaExpertContentLockedError,
     QaExpertDisabledError,
+    QaExpertHasAnswersCannotDeleteError,
     QaExpertQuestionAccessDeniedError,
 )
 from bisheng.common.utils.beijing_time import beijing_epoch_seconds, dump_qa_datetimes, to_beijing_iso
@@ -182,6 +183,8 @@ class ExpertService:
 
     def __init__(self):
         self.repository = ExpertRepository()
+        self.invite_repository = QuestionInviteRepository()
+        self.answer_repository = AnswerRepository()
         self.publish_service = None
 
     def _publish(self):
@@ -280,6 +283,7 @@ class ExpertService:
         answer_desc: bool | None = None,
         adoption_desc: bool | None = None,
         vote_desc: bool | None = None,
+        status: int | None = None,
     ) -> tuple[list[dict], int]:
         """列表查询专家"""
         sort_by_department = sort_by == "department"
@@ -297,6 +301,7 @@ class ExpertService:
             answer_desc=answer_desc,
             adoption_desc=adoption_desc,
             vote_desc=vote_desc,
+            status=status,
         )
         experts_all = await self._build_expert_rows(experts)
         if sort_by_department:
@@ -477,6 +482,48 @@ class ExpertService:
         """兼容 DELETE：映射为停用，不硬删。"""
         await self.disable_expert(expert_id, user)
         return True
+
+    async def hard_delete_expert(self, expert_id: int, user) -> None:
+        """硬删专家档案：无未软删回答时可删；历史回答保留 expert_id 引用。"""
+        self._require_admin(user)
+        expert = await self.repository.get_by_id(expert_id)
+        if not expert:
+            raise ExpertNotFoundError()
+        answer_count = await self.answer_repository.count_active_by_expert_id(expert_id)
+        if answer_count > 0:
+            raise QaExpertHasAnswersCannotDeleteError()
+        if int(expert.status) == EXPERT_STATUS_ACTIVE:
+            await self._publish().on_expert_disabled(int(expert.user_id))
+        await self.invite_repository.delete_by_expert_id(expert_id)
+        deleted = await self.repository.delete(expert_id)
+        if not deleted:
+            raise ExpertNotFoundError()
+
+    async def batch_disable_experts(self, expert_ids: list[int], user) -> dict:
+        """批量停用专家，单条失败不影响其余条目。"""
+        self._require_admin(user)
+        succeeded: list[int] = []
+        failed: list[dict] = []
+        for expert_id in expert_ids:
+            try:
+                await self.disable_expert(expert_id, user)
+                succeeded.append(expert_id)
+            except BaseErrorCode as exc:
+                failed.append({"expert_id": expert_id, "code": exc.code, "message": exc.message})
+        return {"succeeded": succeeded, "failed": failed}
+
+    async def batch_hard_delete_experts(self, expert_ids: list[int], user) -> dict:
+        """批量硬删专家档案，单条失败不影响其余条目。"""
+        self._require_admin(user)
+        succeeded: list[int] = []
+        failed: list[dict] = []
+        for expert_id in expert_ids:
+            try:
+                await self.hard_delete_expert(expert_id, user)
+                succeeded.append(expert_id)
+            except BaseErrorCode as exc:
+                failed.append({"expert_id": expert_id, "code": exc.code, "message": exc.message})
+        return {"succeeded": succeeded, "failed": failed}
 
     async def get_expertinfo(self, expert_name: str) -> dict | None:
         """获取专家信息"""

--- a/src/backend/test/knowledge/test_folder_reorder_auth_flow.py
+++ b/src/backend/test/knowledge/test_folder_reorder_auth_flow.py
@@ -1,0 +1,234 @@
+"""F106 文件夹排序鉴权流转: 171 MySQL, HTTP + SELECT knowledgefile.sort_weight."""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from bisheng.common.errcode.base import BaseErrorCode
+from bisheng.common.errcode.knowledge_space import SpacePermissionDeniedError
+from bisheng.common.schemas.api import resp_200
+from bisheng.knowledge.domain.models.knowledge_space_scope import KnowledgeSpaceLevelEnum
+from bisheng.knowledge.domain.services.knowledge_space_service import KnowledgeSpaceService
+from bisheng.permission.domain.services.permission_service import PermissionService
+from test.knowledge.test_space_reorder_auth_flow import (
+    WEIGHT_BAND,
+    _admin_user,
+    _cleanup,
+    _in_ids,
+    _insert_space,
+    _ops_user,
+    _plain_user,
+    reorder_flow_env,
+)
+
+
+@pytest.fixture
+async def flow_env(monkeypatch):
+    async with reorder_flow_env(monkeypatch) as env:
+        yield env
+
+
+def _folder_app(user) -> FastAPI:
+    app = FastAPI()
+
+    @app.exception_handler(BaseErrorCode)
+    async def _biz(_req, exc: BaseErrorCode):
+        return JSONResponse(
+            {"status_code": exc.code, "status_message": exc.message, "data": None},
+            status_code=200,
+        )
+
+    @app.post("/api/v1/knowledge/space/{space_id}/folders/{folder_id}/sort")
+    async def sort_folder(space_id: int, folder_id: int, payload: dict):
+        svc = KnowledgeSpaceService(request=None, login_user=user)
+        await svc.reorder_folder(
+            space_id,
+            folder_id,
+            prev_folder_id=payload.get("prev_folder_id"),
+            next_folder_id=payload.get("next_folder_id"),
+        )
+        return resp_200(data=True)
+
+    return app
+
+
+async def _insert_folder(
+    session: AsyncSession,
+    *,
+    space_id: int,
+    name: str,
+    file_level_path: str,
+    sort_weight: int | None,
+) -> int:
+    await session.execute(
+        text(
+            """
+            INSERT INTO knowledgefile
+              (user_id, knowledge_id, file_name, file_type, file_level_path, sort_weight, tenant_id)
+            VALUES (1, :kid, :name, 0, :path, :w, 1)
+            """
+        ),
+        {"kid": space_id, "name": name, "path": file_level_path, "w": sort_weight},
+    )
+    await session.flush()
+    return int(
+        (
+            await session.execute(
+                text("SELECT id FROM knowledgefile WHERE knowledge_id = :kid AND file_name = :n"),
+                {"kid": space_id, "n": name},
+            )
+        ).scalar_one()
+    )
+
+
+async def _folder_weights(session: AsyncSession, ids: list[int]) -> dict[int, int | None]:
+    rows = (
+        await session.execute(
+            _in_ids("SELECT id, sort_weight FROM knowledgefile WHERE id IN :ids"),
+            {"ids": list(ids)},
+        )
+    ).all()
+    return {int(row[0]): (int(row[1]) if row[1] is not None else None) for row in rows}
+
+
+async def _post_folder_sort(app, space_id: int, folder_id: int, prev_id: int | None, next_id: int | None):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        return await client.post(
+            f"/api/v1/knowledge/space/{space_id}/folders/{folder_id}/sort",
+            json={"prev_folder_id": prev_id, "next_folder_id": next_id},
+        )
+
+
+@pytest.mark.asyncio
+async def test_admin_and_manager_folder_reorder_operator_member_denied(flow_env, monkeypatch):
+    """AT-04/08/13/14/16/17/18: 管理员与库管可拖当前目录; 运营岗/成员/仅子文件夹管理员拒绝."""
+    engine, fixture_ids = flow_env
+    suffix = uuid.uuid4().hex[:8]
+    space_ids: list[int] = []
+    try:
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            space_id = await _insert_space(
+                session,
+                name=f"f106-folder-space-{suffix}",
+                level=KnowledgeSpaceLevelEnum.PUBLIC,
+                sort_weight=WEIGHT_BAND + 50_000,
+            )
+            root_a = await _insert_folder(
+                session,
+                space_id=space_id,
+                name=f"f106-root-a-{suffix}",
+                file_level_path="",
+                sort_weight=WEIGHT_BAND + 2000,
+            )
+            root_b = await _insert_folder(
+                session,
+                space_id=space_id,
+                name=f"f106-root-b-{suffix}",
+                file_level_path="",
+                sort_weight=WEIGHT_BAND,
+            )
+            parent = await _insert_folder(
+                session,
+                space_id=space_id,
+                name=f"f106-parent-{suffix}",
+                file_level_path="",
+                sort_weight=WEIGHT_BAND + 4000,
+            )
+            await session.commit()
+            child_a = await _insert_folder(
+                session,
+                space_id=space_id,
+                name=f"f106-child-a-{suffix}",
+                file_level_path=f"/{parent}",
+                sort_weight=WEIGHT_BAND + 2000,
+            )
+            child_b = await _insert_folder(
+                session,
+                space_id=space_id,
+                name=f"f106-child-b-{suffix}",
+                file_level_path=f"/{parent}",
+                sort_weight=WEIGHT_BAND,
+            )
+            await session.commit()
+        space_ids = [space_id]
+        fixture_ids.add(space_id)
+
+        admin_app = _folder_app(_admin_user())
+        moved = await _post_folder_sort(admin_app, space_id, root_a, None, root_b)
+        assert moved.json()["status_code"] == 200
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            weights = await _folder_weights(session, [root_a, root_b])
+        assert weights[root_a] == WEIGHT_BAND - 1000
+        assert weights[root_b] == WEIGHT_BAND
+
+        async def _check_manager(**kwargs):
+            object_type = kwargs.get("object_type")
+            object_id = str(kwargs.get("object_id"))
+            if object_type == "knowledge_space" and object_id == str(space_id):
+                return True
+            if object_type == "folder" and object_id == str(parent):
+                return True
+            return False
+
+        monkeypatch.setattr(PermissionService, "check", AsyncMock(side_effect=_check_manager))
+        manager = SimpleNamespace(
+            user_id=88010620,
+            user_name="f106-space-admin",
+            tenant_id=1,
+            is_admin=lambda: False,
+            is_global_super=False,
+            role_names=["普通用户"],
+        )
+        manager_app = _folder_app(manager)
+        root_ok = await _post_folder_sort(manager_app, space_id, root_a, root_b, None)
+        assert root_ok.json()["status_code"] == 200
+        nested_ok = await _post_folder_sort(manager_app, space_id, child_a, None, child_b)
+        assert nested_ok.json()["status_code"] == 200
+
+        async def _check_child_only(**kwargs):
+            return kwargs.get("object_type") == "folder" and str(kwargs.get("object_id")) == str(child_a)
+
+        monkeypatch.setattr(PermissionService, "check", AsyncMock(side_effect=_check_child_only))
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            before = await _folder_weights(session, [root_a, root_b])
+        child_admin_denied = await _post_folder_sort(manager_app, space_id, root_a, None, root_b)
+        assert child_admin_denied.json()["status_code"] == SpacePermissionDeniedError.Code
+
+        monkeypatch.setattr(PermissionService, "check", AsyncMock(return_value=False))
+        ops_denied = await _post_folder_sort(_folder_app(_ops_user()), space_id, root_a, None, root_b)
+        assert ops_denied.json()["status_code"] == SpacePermissionDeniedError.Code
+        member_denied = await _post_folder_sort(_folder_app(_plain_user()), space_id, root_a, None, root_b)
+        assert member_denied.json()["status_code"] == SpacePermissionDeniedError.Code
+        dept_denied = await _post_folder_sort(
+            _folder_app(
+                SimpleNamespace(
+                    user_id=88010603,
+                    user_name="f106-dept-admin",
+                    tenant_id=1,
+                    is_admin=lambda: False,
+                    is_global_super=False,
+                    role_names=["部门管理员"],
+                )
+            ),
+            space_id,
+            root_a,
+            None,
+            root_b,
+        )
+        assert dept_denied.json()["status_code"] == SpacePermissionDeniedError.Code
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            after = await _folder_weights(session, [root_a, root_b])
+        assert after == before
+        again = await _post_folder_sort(_folder_app(_ops_user()), space_id, root_a, None, root_b)
+        assert again.json()["status_code"] == SpacePermissionDeniedError.Code
+    finally:
+        await _cleanup(engine, space_ids)

--- a/src/backend/test/knowledge/test_space_reorder_auth_flow.py
+++ b/src/backend/test/knowledge/test_space_reorder_auth_flow.py
@@ -1,0 +1,707 @@
+"""F106 库排序鉴权流转: 171 MySQL, HTTP + SELECT sort_weight + 再打一枪."""
+
+from __future__ import annotations
+
+import os
+import re
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import bindparam, text
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from bisheng.common.errcode.base import BaseErrorCode
+from bisheng.common.errcode.knowledge_space import (
+    SpaceInvalidLevelError,
+    SpacePermissionDeniedError,
+)
+from bisheng.common.schemas.api import resp_200
+from bisheng.knowledge.domain.models.knowledge import KnowledgeTypeEnum
+from bisheng.knowledge.domain.models.knowledge_space_scope import (
+    KnowledgeSpaceLevelEnum,
+    KnowledgeSpaceOwnerTypeEnum,
+    KnowledgeSpaceScopeDao,
+)
+from bisheng.knowledge.domain.services.knowledge_space_service import KnowledgeSpaceService
+from bisheng.user.domain.services.platform_operator import PLATFORM_OPERATOR_ROLE_NAME
+
+WEIGHT_BAND = 800_000_000
+SPACE_TYPE = KnowledgeTypeEnum.SPACE.value
+
+
+def _mysql_async_url() -> str:
+    override = os.environ.get("QA_EXPERT_FLOW_DATABASE_URL") or os.environ.get("ORG_LEVEL_FLOW_DATABASE_URL")
+    if override:
+        return override.replace("pymysql", "aiomysql")
+    from bisheng.core.config.settings import decrypt_token
+
+    cfg_name = os.environ.get("config", "config.yaml")
+    cfg_path = Path(__file__).resolve().parents[2] / "bisheng" / Path(cfg_name).name
+    loaded = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    url = loaded["database_url"]
+    if not isinstance(url, str):
+        raise RuntimeError("config.yaml database_url 不是字符串")
+    match = re.search(r"(?<=:)[^:]+(?=@)", url)
+    if match:
+        url = re.sub(r"(?<=:)[^:]+(?=@)", decrypt_token(match.group(0)), url)
+    if "171" not in url and not override:
+        raise RuntimeError("流转测试默认打 192.168.106.171, 请确认 config.yaml")
+    return url.replace("pymysql", "aiomysql")
+
+
+def _admin_user():
+    return SimpleNamespace(
+        user_id=1,
+        user_name="f106-admin",
+        tenant_id=1,
+        is_admin=lambda: True,
+        is_global_super=True,
+        role="admin",
+        role_names=["系统管理员"],
+    )
+
+
+def _ops_user(*, user_id: int = 88010601):
+    return SimpleNamespace(
+        user_id=user_id,
+        user_name="f106-ops",
+        tenant_id=1,
+        is_admin=lambda: False,
+        is_global_super=False,
+        role="user",
+        role_names=[PLATFORM_OPERATOR_ROLE_NAME],
+    )
+
+
+def _plain_user(*, user_id: int = 88010602):
+    return SimpleNamespace(
+        user_id=user_id,
+        user_name="f106-member",
+        tenant_id=1,
+        is_admin=lambda: False,
+        is_global_super=False,
+        role="user",
+        role_names=["普通用户"],
+    )
+
+
+def _dept_admin_user(*, user_id: int = 88010603):
+    return SimpleNamespace(
+        user_id=user_id,
+        user_name="f106-dept-admin",
+        tenant_id=1,
+        is_admin=lambda: False,
+        is_global_super=False,
+        role="user",
+        role_names=["部门管理员"],
+    )
+
+
+def _sort_app(user) -> FastAPI:
+    app = FastAPI()
+
+    @app.exception_handler(BaseErrorCode)
+    async def _biz(_req, exc: BaseErrorCode):
+        return JSONResponse(
+            {"status_code": exc.code, "status_message": exc.message, "data": None},
+            status_code=200,
+        )
+
+    @app.post("/api/v1/knowledge/space/{space_id}/sort")
+    async def sort_space(space_id: int, payload: dict):
+        svc = KnowledgeSpaceService(request=None, login_user=user)
+        await svc.reorder_space(
+            space_id,
+            prev_space_id=payload.get("prev_space_id"),
+            next_space_id=payload.get("next_space_id"),
+        )
+        return resp_200(data=True)
+
+    @app.get("/api/v1/knowledge/space/level/{space_level}")
+    async def list_level(space_level: str):
+        svc = KnowledgeSpaceService(request=None, login_user=user)
+        if space_level == KnowledgeSpaceLevelEnum.PUBLIC.value:
+            spaces = await svc.get_public_spaces("sort_weight")
+        else:
+            spaces = await svc.get_spaces_by_level(space_level, "sort_weight")
+        return resp_200(spaces)
+
+    return app
+
+
+async def _insert_space(
+    session: AsyncSession,
+    *,
+    name: str,
+    level: KnowledgeSpaceLevelEnum,
+    sort_weight: int | None,
+    owner_type: KnowledgeSpaceOwnerTypeEnum = KnowledgeSpaceOwnerTypeEnum.DEPARTMENT,
+    owner_id: int = 1,
+    user_id: int = 1,
+) -> int:
+    await session.execute(
+        text(
+            """
+            INSERT INTO knowledge
+              (user_id, name, type, tenant_id, sort_weight, is_released, is_favorite, auth_type)
+            VALUES (:uid, :name, :type, 1, :w, 0, 0, 'PRIVATE')
+            """
+        ),
+        {"uid": user_id, "name": name, "type": SPACE_TYPE, "w": sort_weight},
+    )
+    await session.flush()
+    space_id = int((await session.execute(text("SELECT id FROM knowledge WHERE name = :n"), {"n": name})).scalar_one())
+    await session.execute(
+        text(
+            """
+            INSERT INTO knowledge_space_scope
+              (tenant_id, space_id, level, owner_type, owner_id, created_by)
+            VALUES (1, :sid, :level, :ot, :oid, :uid)
+            """
+        ),
+        {
+            "sid": space_id,
+            "level": level.value,
+            "ot": owner_type.value,
+            "oid": owner_id,
+            "uid": user_id,
+        },
+    )
+    return space_id
+
+
+def _in_ids(sql: str):
+    return text(sql).bindparams(bindparam("ids", expanding=True))
+
+
+async def _weights(session: AsyncSession, ids: list[int]) -> dict[int, int | None]:
+    rows = (
+        await session.execute(_in_ids("SELECT id, sort_weight FROM knowledge WHERE id IN :ids"), {"ids": list(ids)})
+    ).all()
+    return {int(row[0]): (int(row[1]) if row[1] is not None else None) for row in rows}
+
+
+@asynccontextmanager
+async def reorder_flow_env(monkeypatch):
+    """171 MySQL 会话补丁 + 把 level 工作集裁到本用例插入的 ID, 避免重铺打到现网行."""
+    from bisheng.core.context.tenant import set_current_tenant_id
+    from bisheng.core.database.connection import _patch_aiomysql_pre_ping
+
+    set_current_tenant_id(1)
+    _patch_aiomysql_pre_ping()
+    engine = create_async_engine(_mysql_async_url(), pool_pre_ping=True)
+    fixture_ids: set[int] = set()
+
+    @asynccontextmanager
+    async def patched_session():
+        session = AsyncSession(bind=engine, expire_on_commit=False)
+        try:
+            yield session
+        finally:
+            await session.close()
+
+    session_targets = (
+        "bisheng.core.database.get_async_db_session",
+        "bisheng.knowledge.domain.models.knowledge.get_async_db_session",
+        "bisheng.knowledge.domain.models.knowledge_file.get_async_db_session",
+        "bisheng.knowledge.domain.models.knowledge_space_file.get_async_db_session",
+        "bisheng.knowledge.domain.models.knowledge_space_scope.get_async_db_session",
+        "bisheng.knowledge.domain.models.department_knowledge_space.get_async_db_session",
+        "bisheng.knowledge.domain.services.knowledge_space_service.get_async_db_session",
+        "bisheng.knowledge.domain.services.knowledge_space_pin_service.get_async_db_session",
+        "bisheng.common.models.space_channel_member.get_async_db_session",
+        "bisheng.database.models.department.get_async_db_session",
+    )
+    for target in session_targets:
+        monkeypatch.setattr(target, patched_session)
+
+    orig_by_levels = KnowledgeSpaceScopeDao.aget_space_ids_by_levels
+    orig_by_level = KnowledgeSpaceScopeDao.aget_space_ids_by_level
+
+    async def _filtered_levels(levels):
+        ids = await orig_by_levels(levels)
+        if not fixture_ids:
+            return ids
+        return [space_id for space_id in ids if int(space_id) in fixture_ids]
+
+    async def _filtered_level(level):
+        ids = await orig_by_level(level)
+        if not fixture_ids:
+            return ids
+        return [space_id for space_id in ids if int(space_id) in fixture_ids]
+
+    monkeypatch.setattr(KnowledgeSpaceScopeDao, "aget_space_ids_by_levels", _filtered_levels)
+    monkeypatch.setattr(KnowledgeSpaceScopeDao, "aget_space_ids_by_level", _filtered_level)
+
+    try:
+        yield engine, fixture_ids
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture
+async def flow_env(monkeypatch):
+    async with reorder_flow_env(monkeypatch) as env:
+        yield env
+
+
+async def _post_sort(app, space_id: int, prev_id: int | None, next_id: int | None):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        return await client.post(
+            f"/api/v1/knowledge/space/{space_id}/sort",
+            json={"prev_space_id": prev_id, "next_space_id": next_id},
+        )
+
+
+async def _cleanup(engine, space_ids: list[int], dept_ids: list[int] | None = None) -> None:
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        if space_ids:
+            await session.execute(
+                _in_ids("DELETE FROM department_knowledge_space WHERE space_id IN :ids"),
+                {"ids": list(space_ids)},
+            )
+            await session.execute(
+                _in_ids("DELETE FROM knowledge_space_scope WHERE space_id IN :ids"),
+                {"ids": list(space_ids)},
+            )
+            await session.execute(
+                _in_ids("DELETE FROM knowledgefile WHERE knowledge_id IN :ids"),
+                {"ids": list(space_ids)},
+            )
+            await session.execute(
+                _in_ids("DELETE FROM knowledge WHERE id IN :ids"),
+                {"ids": list(space_ids)},
+            )
+        if dept_ids:
+            await session.execute(
+                _in_ids("DELETE FROM department WHERE id IN :ids"),
+                {"ids": list(dept_ids)},
+            )
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_admin_reorder_public_and_department_and_team_ks_flow(flow_env):
+    """AT-01/02/03/21/24: 系统管理员拖公共/部门库, 团队旁科室, 跨组邻居 18041, 连续写."""
+    engine, fixture_ids = flow_env
+    suffix = uuid.uuid4().hex[:8]
+    space_ids: list[int] = []
+    try:
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            pub_a = await _insert_space(
+                session,
+                name=f"f106-pub-a-{suffix}",
+                level=KnowledgeSpaceLevelEnum.PUBLIC,
+                sort_weight=WEIGHT_BAND + 2000,
+                owner_type=KnowledgeSpaceOwnerTypeEnum.TENANT_ROOT_DEPARTMENT,
+            )
+            pub_b = await _insert_space(
+                session,
+                name=f"f106-pub-b-{suffix}",
+                level=KnowledgeSpaceLevelEnum.PUBLIC,
+                sort_weight=WEIGHT_BAND,
+                owner_type=KnowledgeSpaceOwnerTypeEnum.TENANT_ROOT_DEPARTMENT,
+            )
+            dept_a = await _insert_space(
+                session,
+                name=f"f106-dept-a-{suffix}",
+                level=KnowledgeSpaceLevelEnum.DEPARTMENT,
+                sort_weight=WEIGHT_BAND + 2000,
+            )
+            dept_b = await _insert_space(
+                session,
+                name=f"f106-dept-b-{suffix}",
+                level=KnowledgeSpaceLevelEnum.DEPARTMENT,
+                sort_weight=WEIGHT_BAND,
+            )
+            team = await _insert_space(
+                session,
+                name=f"f106-team-{suffix}",
+                level=KnowledgeSpaceLevelEnum.TEAM,
+                sort_weight=WEIGHT_BAND + 10_000,
+                owner_type=KnowledgeSpaceOwnerTypeEnum.USER_GROUP,
+            )
+            clinic = await _insert_space(
+                session,
+                name=f"f106-ks-{suffix}",
+                level=KnowledgeSpaceLevelEnum.TEAM_KS,
+                sort_weight=WEIGHT_BAND + 12_000,
+                owner_type=KnowledgeSpaceOwnerTypeEnum.DEPARTMENT,
+            )
+            await session.commit()
+        space_ids = [pub_a, pub_b, dept_a, dept_b, team, clinic]
+        fixture_ids.update(space_ids)
+
+        app = _sort_app(_admin_user())
+        moved = await _post_sort(app, pub_a, None, pub_b)
+        assert moved.status_code == 200
+        assert moved.json()["status_code"] == 200
+        assert moved.json()["data"] is True
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            weights = await _weights(session, [pub_a, pub_b])
+        assert weights[pub_a] == WEIGHT_BAND - 1000
+        assert weights[pub_b] == WEIGHT_BAND
+
+        again = await _post_sort(app, pub_a, pub_b, None)
+        assert again.json()["status_code"] == 200
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            weights = await _weights(session, [pub_a, pub_b])
+        assert weights[pub_a] == WEIGHT_BAND + 1000
+        assert weights[pub_b] == WEIGHT_BAND
+
+        dept_moved = await _post_sort(app, dept_a, None, dept_b)
+        assert dept_moved.json()["status_code"] == 200
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            weights = await _weights(session, [dept_a, dept_b])
+        assert weights[dept_a] == WEIGHT_BAND - 1000
+        assert weights[dept_b] == WEIGHT_BAND
+
+        team_moved = await _post_sort(app, team, clinic, None)
+        assert team_moved.json()["status_code"] == 200
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            weights = await _weights(session, [team, clinic])
+        assert weights[team] == WEIGHT_BAND + 13_000
+        assert weights[clinic] == WEIGHT_BAND + 12_000
+
+        before = None
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            before = await _weights(session, [pub_a, dept_a])
+        denied = await _post_sort(app, pub_a, None, dept_a)
+        assert denied.json()["status_code"] == SpaceInvalidLevelError.Code
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            after = await _weights(session, [pub_a, dept_a])
+        assert after == before
+        denied_again = await _post_sort(app, pub_a, None, dept_a)
+        assert denied_again.json()["status_code"] == SpaceInvalidLevelError.Code
+    finally:
+        await _cleanup(engine, space_ids)
+
+
+@pytest.mark.asyncio
+async def test_operator_public_department_ok_team_denied_and_not_admin(flow_env):
+    """AT-05/06/07/40: 运营岗 is_admin=false, 可拖公共/部门库, 团队 18040 无脏写."""
+    engine, fixture_ids = flow_env
+    suffix = uuid.uuid4().hex[:8]
+    ops = _ops_user()
+    assert ops.is_admin() is False
+    space_ids: list[int] = []
+    try:
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            pub_a = await _insert_space(
+                session,
+                name=f"f106-ops-pub-a-{suffix}",
+                level=KnowledgeSpaceLevelEnum.PUBLIC,
+                sort_weight=WEIGHT_BAND + 2000,
+                owner_type=KnowledgeSpaceOwnerTypeEnum.TENANT_ROOT_DEPARTMENT,
+            )
+            pub_b = await _insert_space(
+                session,
+                name=f"f106-ops-pub-b-{suffix}",
+                level=KnowledgeSpaceLevelEnum.PUBLIC,
+                sort_weight=WEIGHT_BAND,
+                owner_type=KnowledgeSpaceOwnerTypeEnum.TENANT_ROOT_DEPARTMENT,
+            )
+            dept_a = await _insert_space(
+                session,
+                name=f"f106-ops-dept-a-{suffix}",
+                level=KnowledgeSpaceLevelEnum.DEPARTMENT,
+                sort_weight=WEIGHT_BAND + 2000,
+            )
+            dept_b = await _insert_space(
+                session,
+                name=f"f106-ops-dept-b-{suffix}",
+                level=KnowledgeSpaceLevelEnum.DEPARTMENT,
+                sort_weight=WEIGHT_BAND,
+            )
+            team = await _insert_space(
+                session,
+                name=f"f106-ops-team-{suffix}",
+                level=KnowledgeSpaceLevelEnum.TEAM,
+                sort_weight=WEIGHT_BAND + 20_000,
+                owner_type=KnowledgeSpaceOwnerTypeEnum.USER_GROUP,
+            )
+            clinic = await _insert_space(
+                session,
+                name=f"f106-ops-ks-{suffix}",
+                level=KnowledgeSpaceLevelEnum.TEAM_KS,
+                sort_weight=WEIGHT_BAND + 21_000,
+            )
+            await session.commit()
+        space_ids = [pub_a, pub_b, dept_a, dept_b, team, clinic]
+        fixture_ids.update(space_ids)
+        app = _sort_app(ops)
+
+        pub_moved = await _post_sort(app, pub_a, None, pub_b)
+        assert pub_moved.json()["status_code"] == 200
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            weights = await _weights(session, [pub_a, pub_b])
+        assert weights[pub_a] == WEIGHT_BAND - 1000
+
+        dept_moved = await _post_sort(app, dept_a, None, dept_b)
+        assert dept_moved.json()["status_code"] == 200
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            weights = await _weights(session, [dept_a])
+        assert weights[dept_a] == WEIGHT_BAND - 1000
+
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            before = await _weights(session, [team, clinic])
+        denied = await _post_sort(app, team, None, clinic)
+        assert denied.json()["status_code"] == SpacePermissionDeniedError.Code
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            after = await _weights(session, [team, clinic])
+        assert after == before
+        denied_again = await _post_sort(app, team, None, clinic)
+        assert denied_again.json()["status_code"] == SpacePermissionDeniedError.Code
+        clinic_denied = await _post_sort(app, clinic, team, None)
+        assert clinic_denied.json()["status_code"] == SpacePermissionDeniedError.Code
+    finally:
+        await _cleanup(engine, space_ids)
+
+
+@pytest.mark.asyncio
+async def test_member_and_space_admin_cannot_reorder_space_personal_invalid(flow_env):
+    """AT-15/18/19: 库管与成员拖库 18040; 个人库 18041."""
+    engine, fixture_ids = flow_env
+    suffix = uuid.uuid4().hex[:8]
+    owner_id = 88010610
+    space_ids: list[int] = []
+    try:
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            owned = await _insert_space(
+                session,
+                name=f"f106-owned-{suffix}",
+                level=KnowledgeSpaceLevelEnum.PUBLIC,
+                sort_weight=WEIGHT_BAND + 30_000,
+                owner_type=KnowledgeSpaceOwnerTypeEnum.TENANT_ROOT_DEPARTMENT,
+                user_id=owner_id,
+            )
+            neighbour = await _insert_space(
+                session,
+                name=f"f106-owned-n-{suffix}",
+                level=KnowledgeSpaceLevelEnum.PUBLIC,
+                sort_weight=WEIGHT_BAND + 31_000,
+                owner_type=KnowledgeSpaceOwnerTypeEnum.TENANT_ROOT_DEPARTMENT,
+            )
+            personal = await _insert_space(
+                session,
+                name=f"f106-personal-{suffix}",
+                level=KnowledgeSpaceLevelEnum.PERSONAL,
+                sort_weight=WEIGHT_BAND + 32_000,
+                owner_type=KnowledgeSpaceOwnerTypeEnum.USER,
+                owner_id=owner_id,
+                user_id=owner_id,
+            )
+            await session.commit()
+        space_ids = [owned, neighbour, personal]
+        fixture_ids.update(space_ids)
+
+        owner = SimpleNamespace(
+            user_id=owner_id,
+            user_name="f106-owner",
+            tenant_id=1,
+            is_admin=lambda: False,
+            is_global_super=False,
+            role="user",
+            role_names=["普通用户"],
+        )
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            before = await _weights(session, [owned, personal])
+        owner_denied = await _post_sort(_sort_app(owner), owned, None, neighbour)
+        assert owner_denied.json()["status_code"] == SpacePermissionDeniedError.Code
+        member_denied = await _post_sort(_sort_app(_plain_user()), owned, None, neighbour)
+        assert member_denied.json()["status_code"] == SpacePermissionDeniedError.Code
+        personal_denied = await _post_sort(_sort_app(_admin_user()), personal, None, None)
+        assert personal_denied.json()["status_code"] == SpaceInvalidLevelError.Code
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            after = await _weights(session, [owned, personal])
+        assert after == before
+        owner_again = await _post_sort(_sort_app(owner), owned, None, neighbour)
+        assert owner_again.json()["status_code"] == SpacePermissionDeniedError.Code
+    finally:
+        await _cleanup(engine, space_ids)
+
+
+@pytest.mark.asyncio
+async def test_department_admin_bound_team_ok_unbound_and_public_denied_respread(flow_env, monkeypatch):
+    """AT-09~12/22/23: 部门管理员按绑定表拖团队/科室, 未绑定与公共库拒绝, 重铺不写出工作集."""
+    engine, fixture_ids = flow_env
+    suffix = uuid.uuid4().hex[:8]
+    space_ids: list[int] = []
+    dept_ids: list[int] = []
+    admin_dept_ids: set[int] = set()
+    try:
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO department
+                      (dept_id, name, parent_id, tenant_id, path, status, source, org_level, is_deleted)
+                    VALUES
+                      (:d, :n, NULL, 1, :p, 'active', 'local', 'dept', 0)
+                    """
+                ),
+                {"d": f"f106-dept-{suffix}", "n": f"f106部门-{suffix}", "p": f"/tmp-{suffix}/"},
+            )
+            await session.commit()
+            dept_id = int(
+                (
+                    await session.execute(
+                        text("SELECT id FROM department WHERE dept_id = :d"),
+                        {"d": f"f106-dept-{suffix}"},
+                    )
+                ).scalar_one()
+            )
+            await session.execute(
+                text("UPDATE department SET path = :p WHERE id = :id"),
+                {"p": f"/{dept_id}/", "id": dept_id},
+            )
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO department
+                      (dept_id, name, parent_id, tenant_id, path, status, source, org_level, is_deleted)
+                    VALUES
+                      (:d, :n, :pid, 1, :p, 'active', 'local', 'office', 0)
+                    """
+                ),
+                {
+                    "d": f"f106-other-{suffix}",
+                    "n": f"f106其他-{suffix}",
+                    "pid": dept_id,
+                    "p": f"/{dept_id}/tmp-o/",
+                },
+            )
+            await session.commit()
+            other_id = int(
+                (
+                    await session.execute(
+                        text("SELECT id FROM department WHERE dept_id = :d"),
+                        {"d": f"f106-other-{suffix}"},
+                    )
+                ).scalar_one()
+            )
+            await session.execute(
+                text("UPDATE department SET path = :p WHERE id = :id"),
+                {"p": f"/{other_id}/", "id": other_id},
+            )
+            bound_team = await _insert_space(
+                session,
+                name=f"f106-bind-team-{suffix}",
+                level=KnowledgeSpaceLevelEnum.TEAM,
+                sort_weight=None,
+                owner_type=KnowledgeSpaceOwnerTypeEnum.USER_GROUP,
+            )
+            bound_ks = await _insert_space(
+                session,
+                name=f"f106-bind-ks-{suffix}",
+                level=KnowledgeSpaceLevelEnum.TEAM_KS,
+                sort_weight=None,
+                owner_id=dept_id,
+            )
+            unbound = await _insert_space(
+                session,
+                name=f"f106-unbound-{suffix}",
+                level=KnowledgeSpaceLevelEnum.TEAM,
+                sort_weight=WEIGHT_BAND + 40_000,
+                owner_type=KnowledgeSpaceOwnerTypeEnum.USER_GROUP,
+            )
+            outsider = await _insert_space(
+                session,
+                name=f"f106-out-{suffix}",
+                level=KnowledgeSpaceLevelEnum.TEAM,
+                sort_weight=None,
+                owner_type=KnowledgeSpaceOwnerTypeEnum.USER_GROUP,
+            )
+            other_bound = await _insert_space(
+                session,
+                name=f"f106-other-bound-{suffix}",
+                level=KnowledgeSpaceLevelEnum.TEAM,
+                sort_weight=WEIGHT_BAND + 41_000,
+                owner_type=KnowledgeSpaceOwnerTypeEnum.USER_GROUP,
+            )
+            public_a = await _insert_space(
+                session,
+                name=f"f106-da-pub-{suffix}",
+                level=KnowledgeSpaceLevelEnum.PUBLIC,
+                sort_weight=WEIGHT_BAND + 42_000,
+                owner_type=KnowledgeSpaceOwnerTypeEnum.TENANT_ROOT_DEPARTMENT,
+            )
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO department_knowledge_space
+                      (tenant_id, department_id, space_id, created_by)
+                    VALUES
+                      (1, :d1, :s1, 1),
+                      (1, :d1, :s2, 1),
+                      (1, :d2, :s3, 1)
+                    """
+                ),
+                {
+                    "d1": dept_id,
+                    "s1": bound_team,
+                    "s2": bound_ks,
+                    "d2": other_id,
+                    "s3": other_bound,
+                },
+            )
+            await session.commit()
+        space_ids = [bound_team, bound_ks, unbound, outsider, other_bound, public_a]
+        dept_ids = [other_id, dept_id]
+        fixture_ids.update(space_ids)
+        admin_dept_ids.add(dept_id)
+
+        async def _admin_ids(self):
+            if int(self.login_user.user_id) == 88010603:
+                return set(admin_dept_ids)
+            return set()
+
+        monkeypatch.setattr(KnowledgeSpaceService, "_admin_department_ids", _admin_ids)
+
+        async def _visible_ids(*_args, **_kwargs):
+            return [str(i) for i in fixture_ids]
+
+        monkeypatch.setattr(
+            "bisheng.permission.domain.services.permission_service.PermissionService.list_accessible_ids",
+            _visible_ids,
+        )
+
+        app = _sort_app(_dept_admin_user())
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            outside_before = await _weights(session, [unbound, outsider, other_bound, public_a])
+
+        ok = await _post_sort(app, bound_team, None, bound_ks)
+        assert ok.json()["status_code"] == 200
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            bound_after = await _weights(session, [bound_team, bound_ks])
+            outside_after = await _weights(session, [unbound, outsider, other_bound, public_a])
+        assert bound_after[bound_team] is not None
+        assert bound_after[bound_ks] is not None
+        assert outside_after[unbound] == outside_before[unbound]
+        assert outside_after[outsider] is None
+        assert outside_after[other_bound] == outside_before[other_bound]
+        assert outside_after[public_a] == outside_before[public_a]
+
+        for space_id, prev, nxt in (
+            (unbound, None, bound_team),
+            (other_bound, None, bound_team),
+            (public_a, None, None),
+        ):
+            denied = await _post_sort(app, space_id, prev, nxt)
+            assert denied.json()["status_code"] == SpacePermissionDeniedError.Code
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            still = await _weights(session, [unbound, outsider, other_bound, public_a])
+        assert still == outside_after
+        denied_again = await _post_sort(app, unbound, None, bound_team)
+        assert denied_again.json()["status_code"] == SpacePermissionDeniedError.Code
+    finally:
+        await _cleanup(engine, space_ids, dept_ids)

--- a/src/backend/test/knowledge/test_space_reorder_flags_api.py
+++ b/src/backend/test/knowledge/test_space_reorder_flags_api.py
@@ -1,0 +1,180 @@
+"""F106 列表 can_reorder / can_reorder_folders 与写接口资格一致."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from httpx import ASGITransport, AsyncClient
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from bisheng.common.errcode.base import BaseErrorCode
+from bisheng.common.schemas.api import resp_200
+from bisheng.knowledge.domain.models.knowledge_space_scope import KnowledgeSpaceLevelEnum
+from bisheng.knowledge.domain.services.knowledge_space_service import KnowledgeSpaceService
+from bisheng.permission.domain.services.permission_service import PermissionService
+from test.knowledge.test_folder_reorder_auth_flow import _insert_folder
+from test.knowledge.test_space_reorder_auth_flow import (
+    WEIGHT_BAND,
+    _cleanup,
+    _insert_space,
+    _ops_user,
+    _plain_user,
+    reorder_flow_env,
+)
+
+
+@pytest.fixture
+async def flow_env(monkeypatch):
+    async with reorder_flow_env(monkeypatch) as env:
+        yield env
+
+
+def _flags_app(user) -> FastAPI:
+    app = FastAPI()
+
+    @app.exception_handler(BaseErrorCode)
+    async def _biz(_req, exc: BaseErrorCode):
+        return JSONResponse(
+            {"status_code": exc.code, "status_message": exc.message, "data": None},
+            status_code=200,
+        )
+
+    @app.get("/api/v1/knowledge/space/level/{space_level}")
+    async def list_level(space_level: str):
+        svc = KnowledgeSpaceService(request=None, login_user=user)
+        if space_level == KnowledgeSpaceLevelEnum.PUBLIC.value:
+            spaces = await svc.get_public_spaces("sort_weight")
+        else:
+            spaces = await svc.get_spaces_by_level(space_level, "sort_weight")
+        return resp_200(spaces)
+
+    @app.get("/api/v1/knowledge/space/{space_id}")
+    async def space_info(space_id: int):
+        svc = KnowledgeSpaceService(request=None, login_user=user)
+        return resp_200(await svc.get_space_info(space_id))
+
+    @app.get("/api/v1/knowledge/space/{space_id}/children")
+    async def children(space_id: int, parent_id: int | None = None):
+        svc = KnowledgeSpaceService(request=None, login_user=user)
+        return resp_200(await svc.list_space_children(space_id, parent_id=parent_id, page_size=20))
+
+    return app
+
+
+@pytest.mark.asyncio
+async def test_can_reorder_flag_matches_write_eligibility(flow_env, monkeypatch):
+    """AT-20: 运营岗公共库 true, 团队 false; 成员 false. 与随后 sort 写是否 200 一致."""
+    engine, fixture_ids = flow_env
+    suffix = uuid.uuid4().hex[:8]
+    space_ids: list[int] = []
+    try:
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            pub = await _insert_space(
+                session,
+                name=f"f106-flag-pub-{suffix}",
+                level=KnowledgeSpaceLevelEnum.PUBLIC,
+                sort_weight=WEIGHT_BAND + 60_000,
+            )
+            team = await _insert_space(
+                session,
+                name=f"f106-flag-team-{suffix}",
+                level=KnowledgeSpaceLevelEnum.TEAM,
+                sort_weight=WEIGHT_BAND + 61_000,
+            )
+            await session.commit()
+        space_ids = [pub, team]
+        fixture_ids.update(space_ids)
+
+        async def _visible_ids(*_args, **_kwargs):
+            return [str(i) for i in fixture_ids]
+
+        monkeypatch.setattr(PermissionService, "list_accessible_ids", AsyncMock(side_effect=_visible_ids))
+        monkeypatch.setattr(KnowledgeSpaceService, "_get_relation_models_map", AsyncMock(return_value={}))
+        monkeypatch.setattr(KnowledgeSpaceService, "_get_relation_bindings", AsyncMock(return_value=[]))
+
+        async with AsyncClient(transport=ASGITransport(app=_flags_app(_ops_user())), base_url="http://test") as client:
+            listed = await client.get("/api/v1/knowledge/space/level/public")
+            assert listed.json()["status_code"] == 200
+            pub_row = next(item for item in listed.json()["data"] if int(item["id"]) == pub)
+            assert pub_row["can_reorder"] is True
+            team_listed = await client.get("/api/v1/knowledge/space/level/team")
+            team_rows = [item for item in team_listed.json()["data"] if int(item["id"]) == team]
+            if team_rows:
+                assert team_rows[0]["can_reorder"] is False
+
+        async with AsyncClient(
+            transport=ASGITransport(app=_flags_app(_plain_user())), base_url="http://test"
+        ) as client:
+            listed = await client.get("/api/v1/knowledge/space/level/public")
+            pub_row = next(item for item in listed.json()["data"] if int(item["id"]) == pub)
+            assert pub_row["can_reorder"] is False
+    finally:
+        await _cleanup(engine, space_ids)
+
+
+@pytest.mark.asyncio
+async def test_children_can_reorder_folders_root_vs_unauthorized_dir(flow_env, monkeypatch):
+    """AT-25: 库管根目录 can_reorder_folders=true, 无权子目录 false."""
+    engine, fixture_ids = flow_env
+    suffix = uuid.uuid4().hex[:8]
+    space_ids: list[int] = []
+    try:
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            space_id = await _insert_space(
+                session,
+                name=f"f106-flag-folder-{suffix}",
+                level=KnowledgeSpaceLevelEnum.PUBLIC,
+                sort_weight=WEIGHT_BAND + 62_000,
+            )
+            parent = await _insert_folder(
+                session,
+                space_id=space_id,
+                name=f"f106-flag-parent-{suffix}",
+                file_level_path="",
+                sort_weight=WEIGHT_BAND,
+            )
+            await session.commit()
+        space_ids = [space_id]
+        fixture_ids.add(space_id)
+
+        async def _check(**kwargs):
+            if kwargs.get("object_type") == "knowledge_space" and str(kwargs.get("object_id")) == str(space_id):
+                return kwargs.get("relation") in {"can_manage", "can_read", "can_view"}
+            if kwargs.get("relation") == "can_read":
+                return True
+            return False
+
+        monkeypatch.setattr(PermissionService, "check", AsyncMock(side_effect=_check))
+        monkeypatch.setattr(
+            KnowledgeSpaceService,
+            "_require_read_permission",
+            AsyncMock(return_value=None),
+        )
+        monkeypatch.setattr(
+            KnowledgeSpaceService,
+            "_require_folder_relation",
+            AsyncMock(return_value=None),
+        )
+        monkeypatch.setattr(
+            KnowledgeSpaceService,
+            "_scan_visible_child_items",
+            AsyncMock(return_value=([], False)),
+        )
+
+        manager = _plain_user(user_id=88010620)
+        async with AsyncClient(transport=ASGITransport(app=_flags_app(manager)), base_url="http://test") as client:
+            root = await client.get(f"/api/v1/knowledge/space/{space_id}/children")
+            assert root.json()["status_code"] == 200
+            assert root.json()["data"]["can_reorder_folders"] is True
+            nested = await client.get(
+                f"/api/v1/knowledge/space/{space_id}/children",
+                params={"parent_id": parent},
+            )
+            assert nested.json()["status_code"] == 200
+            assert nested.json()["data"]["can_reorder_folders"] is False
+    finally:
+        await _cleanup(engine, space_ids)

--- a/src/backend/test/qa_expert/test_expert_hard_delete.py
+++ b/src/backend/test/qa_expert/test_expert_hard_delete.py
@@ -1,0 +1,111 @@
+# ruff: noqa: RUF002
+"""专家硬删与批量停用/删除流转测试。"""
+
+from sqlalchemy import text
+
+from bisheng.database.models.qa_expert import Answer, Expert, QuestionInvite
+from bisheng.qa_expert.domain.repositories import AnswerRepository
+
+
+async def test_hard_delete_removes_expert_row(flow_env):
+    env = flow_env
+    env.as_user(env.portal_admin)
+    expert = await env.seed_expert(user_id=501, name="hard-del")
+    expert_id = int(expert.id)
+
+    resp = await env.client.post(f"/api/v1/qa_experts/experts/{expert_id}/delete")
+    body = resp.json()
+    assert body["status_code"] == 200
+
+    row = await env.reload_row(Expert, id=expert_id)
+    assert row is None
+
+
+async def test_hard_delete_rejects_expert_with_answers(flow_env):
+    env = flow_env
+    env.as_user(env.portal_admin)
+    expert = await env.seed_expert(user_id=502, name="has-answer")
+    expert_id = int(expert.id)
+
+    await AnswerRepository().create(
+        Answer(
+            tenant_id=1,
+            question_id=999999,
+            expert_id=expert_id,
+            user_id=int(expert.user_id),
+            expert_name=expert.expert_name,
+            content="ans",
+            status=1,
+        )
+    )
+
+    resp = await env.client.post(f"/api/v1/qa_experts/experts/{expert_id}/delete")
+    body = resp.json()
+    assert body["status_code"] == 18314
+
+    row = await env.reload_row(Expert, id=expert_id)
+    assert row is not None
+
+    async with env.engine.connect() as conn:
+        await conn.execute(text("DELETE FROM qa_answer WHERE expert_id = :eid"), {"eid": expert_id})
+        await conn.commit()
+
+
+async def test_batch_disable_and_batch_delete(flow_env):
+    env = flow_env
+    env.as_user(env.portal_admin)
+    a = await env.seed_expert(user_id=503, name="batch-a")
+    b = await env.seed_expert(user_id=504, name="batch-b")
+    c = await env.seed_expert(user_id=505, name="batch-c")
+    ids = [int(a.id), int(b.id)]
+
+    disable_resp = await env.client.post(
+        "/api/v1/qa_experts/experts/batch-disable",
+        json={"expert_ids": ids},
+    )
+    disable_body = disable_resp.json()
+    assert disable_body["status_code"] == 200
+    assert set(disable_body["data"]["succeeded"]) == set(ids)
+    assert disable_body["data"]["failed"] == []
+
+    for expert_id in ids:
+        row = await env.reload_row(Expert, id=expert_id)
+        assert int(row.status) == 0
+
+    delete_ids = [int(a.id), int(c.id)]
+    delete_resp = await env.client.post(
+        "/api/v1/qa_experts/experts/batch-delete",
+        json={"expert_ids": delete_ids},
+    )
+    delete_body = delete_resp.json()
+    assert delete_body["status_code"] == 200
+    assert set(delete_body["data"]["succeeded"]) == set(delete_ids)
+
+    for expert_id in delete_ids:
+        assert await env.reload_row(Expert, id=expert_id) is None
+
+    remaining = await env.reload_row(Expert, id=int(b.id))
+    assert remaining is not None
+
+
+async def test_hard_delete_clears_invites(flow_env):
+    env = flow_env
+    env.as_user(env.portal_admin)
+    expert = await env.seed_expert(user_id=506, name="invite-clean")
+    expert_id = int(expert.id)
+
+    async with env.engine.connect() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO qa_question_invite (tenant_id, question_id, expert_id, user_id) "
+                "VALUES (1, 999998, :eid, :uid)"
+            ),
+            {"eid": expert_id, "uid": int(expert.user_id)},
+        )
+        await conn.commit()
+
+    resp = await env.client.post(f"/api/v1/qa_experts/experts/{expert_id}/delete")
+    assert resp.json()["status_code"] == 200
+
+    invites = await env.reload_all(QuestionInvite, expert_id=expert_id)
+    assert invites == []

--- a/src/backend/test/qa_expert/test_expert_list_active_only.py
+++ b/src/backend/test/qa_expert/test_expert_list_active_only.py
@@ -1,0 +1,64 @@
+# ruff: noqa: RUF002
+"""邀请/榜单列表只返回有效专家；管理列表默认仍含停用。"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from bisheng.database.models.qa_expert import Expert
+from bisheng.qa_expert.api import endpoints
+from bisheng.qa_expert.api.router import router
+from bisheng.qa_expert.domain.repositories import ExpertRepository
+
+
+async def test_list_status_one_hides_disabled_experts(flow_env):
+    env = flow_env
+    env.as_user(env.portal_admin)
+    active = await env.seed_expert(user_id=601, name="active-list")
+    disabled = await env.seed_expert(user_id=602, name="disabled-list")
+
+    disable_resp = await env.client.post(f"/api/v1/qa_experts/experts/{int(disabled.id)}/disable")
+    assert disable_resp.json()["status_code"] == 200
+    row = await env.reload_row(Expert, id=int(disabled.id))
+    assert int(row.status) == 0
+
+    repo = ExpertRepository()
+    all_rows, _all_total = await repo.list_all(skip=0, limit=200)
+    all_ids = {int(item.id) for item in all_rows}
+    assert int(active.id) in all_ids
+    assert int(disabled.id) in all_ids
+
+    active_rows, _active_total = await repo.list_all(skip=0, limit=200, status=1)
+    active_ids = {int(item.id) for item in active_rows}
+    assert int(active.id) in active_ids
+    assert int(disabled.id) not in active_ids
+
+    again_rows, _ = await repo.list_all(skip=0, limit=200, status=1)
+    assert int(disabled.id) not in {int(item.id) for item in again_rows}
+
+
+def test_list_experts_query_status_accepts_string_one():
+    """门户榜单会带 status=1 查询串, 必须能转成整数, 不能 422。"""
+    service = SimpleNamespace(list_experts=AsyncMock(return_value=([], 0)))
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1")
+    app.dependency_overrides[endpoints.get_expert_service] = lambda: service
+    client = TestClient(app)
+
+    resp = client.get(
+        "/api/v1/qa_experts/experts",
+        params={
+            "page": 1,
+            "limit": 8,
+            "sort_by": "expert_score",
+            "sort_order": "desc",
+            "status": "1",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status_code"] == 200
+    service.list_experts.assert_awaited()
+    assert service.list_experts.await_args.kwargs["status"] == 1

--- a/src/backend/test/qa_expert/test_expert_management_list.py
+++ b/src/backend/test/qa_expert/test_expert_management_list.py
@@ -224,6 +224,7 @@ async def test_service_sorts_department_names_before_paginating(monkeypatch) -> 
         answer_desc=None,
         adoption_desc=None,
         vote_desc=None,
+        status=None,
     )
 
 
@@ -253,3 +254,23 @@ async def test_service_maps_department_filter_options(monkeypatch) -> None:
         {"id": "102", "name": "设备部", "short_name": "设备", "display_name": "设备"},
         {"id": "101", "name": "质量部", "short_name": None, "display_name": "质量部"},
     ]
+
+
+async def test_repository_status_filter_excludes_disabled(expert_engine) -> None:
+    await _seed_experts(expert_engine)
+    async with AsyncSession(expert_engine, expire_on_commit=False) as session:
+        expert = await session.get(Expert, 2)
+        expert.status = 0
+        session.add(expert)
+        await session.commit()
+
+    _all_rows, all_total = await repository_module.ExpertRepository().list_all(skip=0, limit=10)
+    active_rows, active_total = await repository_module.ExpertRepository().list_all(
+        skip=0,
+        limit=10,
+        status=1,
+    )
+
+    assert all_total == 3
+    assert active_total == 2
+    assert {row.expert_name for row in active_rows} == {"甲专家", "丙专家"}

--- a/src/frontend/client/src/api/knowledge.test.ts
+++ b/src/frontend/client/src/api/knowledge.test.ts
@@ -156,6 +156,20 @@ describe("mapSpace", () => {
       auth_type: VisibilityType.PRIVATE,
     } as any).portalDiscoveryEnabled).toBeUndefined();
   });
+
+  it("maps can_reorder from the list payload", () => {
+    expect(mapSpace({
+      id: 204,
+      name: "可排序库",
+      auth_type: VisibilityType.PUBLIC,
+      can_reorder: true,
+    } as any).canReorder).toBe(true);
+    expect(mapSpace({
+      id: 205,
+      name: "不可排序库",
+      auth_type: VisibilityType.PUBLIC,
+    } as any).canReorder).toBe(false);
+  });
 });
 
 describe("getSquareSpacesApi", () => {

--- a/src/frontend/client/src/api/knowledge.ts
+++ b/src/frontend/client/src/api/knowledge.ts
@@ -203,6 +203,8 @@ export interface KnowledgeSpace {
     businessDomainCodes?: string[];
     /** Whether this configurable space participates in portal knowledge discovery */
     portalDiscoveryEnabled?: boolean;
+    /** 当前用户能否拖拽这一条库 (服务端矩阵, 与 sort 写接口一致) */
+    canReorder?: boolean;
 }
 
 export interface KnowledgeSpaceCreateOptions {
@@ -684,6 +686,7 @@ interface RawKnowledgeSpace {
     department_short_name?: string;
     department_display_name?: string;
     portal_discovery_enabled?: boolean | null;
+    can_reorder?: boolean;
 }
 
 export interface KnowledgeSpaceTagLibraryListItem {
@@ -873,6 +876,7 @@ export function mapSpace(raw: RawKnowledgeSpace): KnowledgeSpace {
             raw.portal_discovery_enabled === null || raw.portal_discovery_enabled === undefined
                 ? undefined
                 : Boolean(raw.portal_discovery_enabled),
+        canReorder: Boolean((raw as any).can_reorder ?? (raw as any).canReorder ?? false),
     };
 }
 
@@ -1416,9 +1420,9 @@ export async function getPortalDiscoverableSpacesApi(): Promise<KnowledgeSpace[]
 }
 
 /**
- * Move a space between two neighbours in its level's admin-defined order.
+ * Move a space between two neighbours in its reorder workset.
  * Pass the ids it was dropped between; either is null at the list edges.
- * System admin only.
+ * Eligibility is decided by the server matrix, not a local admin-only gate.
  */
 export async function reorderSpaceApi(
     spaceId: string,
@@ -1431,9 +1435,10 @@ export async function reorderSpaceApi(
 }
 
 /**
- * Move a folder between two sibling folders in its directory's admin-defined order.
+ * Move a folder between two sibling folders in its directory order.
  * Pass the ids it was dropped between; either is null at the list edges.
- * System admin only; only folders participate in this ordering.
+ * Eligibility is the current parent directory can_manage, not a local admin-only gate.
+ * Only folders participate in this ordering.
  */
 export async function reorderFolderApi(
     spaceId: string,
@@ -2508,10 +2513,16 @@ export async function getSpaceChildrenApi(params: {
     order_field?: string;
     order_sort?: string;
     file_status?: number[];
-}): Promise<{ data: KnowledgeFile[]; page_size: number; has_more: boolean; next_cursor: string | null }> {
+}): Promise<{
+    data: KnowledgeFile[];
+    page_size: number;
+    has_more: boolean;
+    next_cursor: string | null;
+    can_reorder_folders: boolean;
+}> {
     const { space_id, ...queryParams } = params;
     if (!space_id) {
-        return { data: [], page_size: queryParams.page_size ?? 20, has_more: false, next_cursor: null };
+        return { data: [], page_size: queryParams.page_size ?? 20, has_more: false, next_cursor: null, can_reorder_folders: false };
     }
     const res = await request.get<ApiResponse<any>>(
         `/api/v1/knowledge/space/${space_id}/children`,
@@ -2535,6 +2546,7 @@ export async function getSpaceChildrenApi(params: {
         page_size: Number(payload?.page_size ?? queryParams.page_size ?? 20),
         has_more: !!payload?.has_more,
         next_cursor: payload?.next_cursor ?? null,
+        can_reorder_folders: Boolean(payload?.can_reorder_folders),
     };
 }
 

--- a/src/frontend/client/src/pages/knowledge/SpaceDetail/index.tsx
+++ b/src/frontend/client/src/pages/knowledge/SpaceDetail/index.tsx
@@ -39,7 +39,6 @@ import {
     resolveFolderReorderNeighbours,
     type FolderDropPosition,
 } from "./resolveFolderReorderNeighbours";
-import store from "~/store";
 import { SearchParams } from "./CompoundSearchInput";
 import { EditTagsModal } from "./EditTagsModal";
 import { BatchCategoryModal } from "./BatchCategoryModal";
@@ -152,6 +151,8 @@ interface KnowledgeSpaceContentProps {
     clearPendingDeletion: (ids: Array<string | number>) => void;
     setFiles: React.Dispatch<React.SetStateAction<KnowledgeFile[]>>;
     setTotal: React.Dispatch<React.SetStateAction<number>>;
+    /** 当前父目录能否拖拽文件夹, 来自 /children 的 can_reorder_folders. */
+    canReorderFolders?: boolean;
 }
 
 export function KnowledgeSpaceContent({
@@ -215,6 +216,7 @@ export function KnowledgeSpaceContent({
     clearPendingDeletion,
     setFiles,
     setTotal,
+    canReorderFolders = false,
 }: KnowledgeSpaceContentProps) {
     const localize = useLocalize();
     const isH5 = usePrefersMobileLayout();
@@ -928,20 +930,14 @@ export function KnowledgeSpaceContent({
         };
     }, [isAdmin, permissionEntryProbeKey, space.id, space.spaceLevel]);
 
-    // Folder manual ordering is admin-defined and shared by everyone, so it follows the
-    // same gate as knowledge-space ordering: system admins only.
-    const currentUser = useRecoilValue(store.user);
-    const isSystemAdmin = currentUser?.role === "admin";
-
-    // Card view drags the same folders as the list view; the grid wrapper carries the
-    // handlers so FileCard itself stays unaware of ordering.
+    // Folder order follows /children can_reorder_folders, not a local admin-only gate.
+    const folderReorderEnabled = canReorderFolders && !sortBy;
     const [cardDraggingFolderId, setCardDraggingFolderId] = useState<string | null>(null);
     const [cardFolderDropTarget, setCardFolderDropTarget] = useState<{ id: string; position: FolderDropPosition } | null>(null);
-    const cardFolderReorderEnabled = isSystemAdmin && !sortBy;
 
     const isCardDraggableFolder = useCallback((file: KnowledgeFile) => (
-        cardFolderReorderEnabled && file.type === FileType.FOLDER && !file.isCreating
-    ), [cardFolderReorderEnabled]);
+        folderReorderEnabled && file.type === FileType.FOLDER && !file.isCreating
+    ), [folderReorderEnabled]);
 
     const handleCardFolderDragEnd = useCallback(() => {
         setCardDraggingFolderId(null);
@@ -1906,7 +1902,7 @@ export function KnowledgeSpaceContent({
                                     onAcceptAlias={onAcceptAlias}
                                     onRejectAlias={onRejectAlias}
                                     onNavigateFolder={(id, name) => onNavigateFolder(id, name)}
-                                    canReorderFolders={isSystemAdmin}
+                                    canReorderFolders={canReorderFolders}
                                     onReorderFolder={(folderId, prevFolderId, nextFolderId) =>
                                         void handleReorderFolder(folderId, prevFolderId, nextFolderId)
                                     }

--- a/src/frontend/client/src/pages/knowledge/hooks/useFileManager.ts
+++ b/src/frontend/client/src/pages/knowledge/hooks/useFileManager.ts
@@ -159,6 +159,7 @@ export function useFileManager({ activeSpace, initialFolderId, enabled = true }:
     const [sortDirection, setSortDirection] = useState<SortDirection | undefined>(undefined);
     const [currentFolderId, setCurrentFolderId] = useState<string | undefined>();
     const [currentPath, setCurrentPath] = useState<Array<{ id?: string; name: string }>>([]);
+    const [canReorderFolders, setCanReorderFolders] = useState(false);
 
     // Optimistic-deletion ignore set. Held in a ref so loadFiles can read the
     // latest value synchronously without re-rendering. Items in this set are
@@ -338,10 +339,14 @@ export function useFileManager({ activeSpace, initialFolderId, enabled = true }:
                     const fetchedSoFar = searchPageToFetch * pageSize;
                     setHasMore(fetchedSoFar < mergedTotal);
                     setNextSearchPage(searchPageToFetch);
+                    setCanReorderFolders(false);
                 } else {
                     setNextCursor((res as any).next_cursor ?? null);
                     setHasMore(!!(res as any).has_more);
-                    if (!isAppending) setNextSearchPage(0);
+                    if (!isAppending) {
+                        setNextSearchPage(0);
+                        setCanReorderFolders(Boolean((res as any).can_reorder_folders));
+                    }
                 }
 
                 const ignore = pendingDeletionIdsRef.current;
@@ -685,5 +690,6 @@ export function useFileManager({ activeSpace, initialFolderId, enabled = true }:
         handleNavigateFolder,
         markPendingDeletion,
         clearPendingDeletion,
+        canReorderFolders,
     };
 }

--- a/src/frontend/client/src/pages/knowledge/index.tsx
+++ b/src/frontend/client/src/pages/knowledge/index.tsx
@@ -786,6 +786,7 @@ export default function Knowledge() {
                                         pageSize={fileManager.pageSize}
                                         total={fileManager.total}
                                         hasMore={fileManager.hasMore}
+                                        canReorderFolders={fileManager.canReorderFolders}
                                         onPageChange={fileManager.handlePageChange}
                                         loading={fileManager.loading}
                                         onSearch={fileManager.handleSearch}

--- a/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/PortalKnowledgeWorkbench.tsx
@@ -295,6 +295,7 @@ export default function PortalKnowledgeWorkbench() {
     const [canCreateFolder, setCanCreateFolder] = useState(false);
     const [canUploadFile, setCanUploadFile] = useState(false);
     const [currentFolderId, setCurrentFolderId] = useState<string | undefined>();
+    const [canReorderFoldersByParent, setCanReorderFoldersByParent] = useState<Record<string, boolean>>({});
     const [restoringDeepLinkKey, setRestoringDeepLinkKey] = useState<string | null>(
         () => portalDeepLinkTarget?.key ?? null,
     );
@@ -313,6 +314,10 @@ export default function PortalKnowledgeWorkbench() {
     const downloadPendingRef = useRef(false);
     const activeSpaceIdRef = useRef<string | undefined>();
     const currentFolderIdRef = useRef<string | undefined>();
+    const rememberCanReorderFolders = useCallback((parentId: string | undefined, flag: boolean) => {
+        const key = parentId || "";
+        setCanReorderFoldersByParent((prev) => (prev[key] === flag ? prev : { ...prev, [key]: flag }));
+    }, []);
     const previousSpaceIdRef = useRef<string | undefined>(undefined);
     const lastPortalLocationKeyRef = useRef("");
     /** Skip the automatic reloadFiles in the activeSpace effect after back-to-list sets the URL.
@@ -1140,6 +1145,7 @@ export default function PortalKnowledgeWorkbench() {
                 file_status: statusFilterNumbers,
             });
             if (activeSpaceIdRef.current !== spaceId) return;
+            rememberCanReorderFolders(undefined, Boolean(res.can_reorder_folders));
             const nextFiles = markFolderStatsLoading(res.data);
             setTreeNodes((prev) => {
                 if (append) {
@@ -1173,7 +1179,7 @@ export default function PortalKnowledgeWorkbench() {
                 setTreeRootLoadingMore(false);
             }
         }
-    }, [activeSpace?.id, loadFolderStats, showToast, sortBy, sortDirection, statusFilterNumbers, treeRootNextCursor]);
+    }, [activeSpace?.id, loadFolderStats, rememberCanReorderFolders, showToast, sortBy, sortDirection, statusFilterNumbers, treeRootNextCursor]);
 
     // Always-current ref to loadRootTree so the space/sort/filter reset effect
     // below can call it WITHOUT listing it as a dependency. loadRootTree's
@@ -1206,6 +1212,7 @@ export default function PortalKnowledgeWorkbench() {
                 file_status: statusFilterNumbers,
             });
             if (activeSpaceIdRef.current !== spaceId) return;
+            rememberCanReorderFolders(folderId, Boolean(res.can_reorder_folders));
             const nextFiles = markFolderStatsLoading(res.data);
             setTreeNodes((prev) => updateTreeNode(prev, folderId, (node) => ({
                 ...node,
@@ -1223,7 +1230,7 @@ export default function PortalKnowledgeWorkbench() {
             if (activeSpaceIdRef.current !== spaceId) return;
             showToast({ message: "文件列表加载失败", severity: NotificationSeverity.ERROR });
         }
-    }, [activeSpace?.id, currentFolderId, loadFolderStats, loadRootTree, showToast, sortBy, sortDirection, statusFilterNumbers]);
+    }, [activeSpace?.id, currentFolderId, loadFolderStats, loadRootTree, rememberCanReorderFolders, showToast, sortBy, sortDirection, statusFilterNumbers]);
 
     const reloadFilesRef = useRef(reloadFiles);
     reloadFilesRef.current = reloadFiles;
@@ -1647,6 +1654,7 @@ export default function PortalKnowledgeWorkbench() {
             setTreeRootTotal(0);
             setTreeRootHasMore(false);
             setTreeRootNextCursor(null);
+            setCanReorderFoldersByParent({});
             if (!openingDeepLinkedFileHere) {
                 setCurrentFolderId(undefined);
             }
@@ -2569,6 +2577,7 @@ export default function PortalKnowledgeWorkbench() {
                 file_status: statusFilterNumbers,
             });
             if (activeSpaceIdRef.current !== spaceId) return;
+            rememberCanReorderFolders(node.file.id, Boolean(res.can_reorder_folders));
             const total = (res as any).total ?? res.data.length;
             const nextFiles = markFolderStatsLoading(res.data);
             setTreeNodes((prev) => updateTreeNode(prev, node.file.id, (item) => ({
@@ -2592,7 +2601,7 @@ export default function PortalKnowledgeWorkbench() {
             })));
             showToast({ message: "文件夹加载失败", severity: NotificationSeverity.ERROR });
         }
-    }, [activeSpace?.id, loadFolderStats, showToast, sortBy, sortDirection, statusFilterNumbers]);
+    }, [activeSpace?.id, loadFolderStats, rememberCanReorderFolders, showToast, sortBy, sortDirection, statusFilterNumbers]);
 
     const handleLoadMoreChildren = useCallback(async (node: PortalFileTreeNode) => {
         const spaceId = activeSpace?.id;
@@ -2611,6 +2620,7 @@ export default function PortalKnowledgeWorkbench() {
                 file_status: statusFilterNumbers,
             });
             if (activeSpaceIdRef.current !== spaceId) return;
+            rememberCanReorderFolders(node.file.id, Boolean(res.can_reorder_folders));
             const total = (res as any).total ?? node.total;
             const nextFiles = markFolderStatsLoading(res.data);
             setTreeNodes((prev) => updateTreeNode(prev, node.file.id, (item) => ({
@@ -2629,7 +2639,7 @@ export default function PortalKnowledgeWorkbench() {
             setTreeNodes((prev) => updateTreeNode(prev, node.file.id, (item) => ({ ...item, loading: false })));
             showToast({ message: "加载更多失败", severity: NotificationSeverity.ERROR });
         }
-    }, [activeSpace?.id, loadFolderStats, showToast, sortBy, sortDirection, statusFilterNumbers]);
+    }, [activeSpace?.id, loadFolderStats, rememberCanReorderFolders, showToast, sortBy, sortDirection, statusFilterNumbers]);
 
     const handleNavigateFolder = useCallback(async (
         folderId?: string,
@@ -2717,6 +2727,7 @@ export default function PortalKnowledgeWorkbench() {
                     file_status: statusFilterNumbers,
                 });
                 if (activeSpaceIdRef.current !== spaceId) return;
+                rememberCanReorderFolders(folderId, Boolean(res.can_reorder_folders));
                 const total = (res as any).total ?? res.data.length;
                 const nextFiles = markFolderStatsLoading(res.data);
                 setTreeNodes((prev) => updateTreeNode(
@@ -2750,7 +2761,7 @@ export default function PortalKnowledgeWorkbench() {
         } finally {
             navigatingFolderRef.current = null;
         }
-    }, [activeSpace?.id, loadFolderStats, loadRootTree, showToast, sortBy, sortDirection, statusFilterNumbers, treeNodes]);
+    }, [activeSpace?.id, loadFolderStats, loadRootTree, rememberCanReorderFolders, showToast, sortBy, sortDirection, statusFilterNumbers, treeNodes]);
 
     // Expose the latest handler to event callbacks defined earlier in the file.
     navigateFolderRef.current = handleNavigateFolder;
@@ -3070,7 +3081,6 @@ export default function PortalKnowledgeWorkbench() {
                         onOpenSpaceSettings={(space) => void handleOpenSpaceSettings(space)}
                         onOpenSpaceMembers={handleOpenSpaceMembers}
                         onPinSpace={(space, pinned, group) => void handlePinSpace(space, pinned, group)}
-                        canReorderSpaces={isSystemAdmin}
                         onReorderSpace={(space, prevSpaceId, nextSpaceId, group) =>
                             void handleReorderSpace(space, prevSpaceId, nextSpaceId, group)
                         }
@@ -3122,6 +3132,7 @@ export default function PortalKnowledgeWorkbench() {
                                                     hasMore={currentFileListHasMore}
                                                     onPageChange={handleNativePageChange}
                                                     loading={currentFileListLoading}
+                                                    canReorderFolders={!searchMode && Boolean(canReorderFoldersByParent[currentFolderId || ""])}
                                                     onSearch={(params) => void handleNativeSearch(params)}
                                                     onFilterStatus={handleNativeStatusFilter}
                                                     onSort={handleNativeSort}

--- a/src/frontend/client/src/pages/knowledge/portal/components/SpaceSidebar.tsx
+++ b/src/frontend/client/src/pages/knowledge/portal/components/SpaceSidebar.tsx
@@ -119,7 +119,8 @@ export function resolveReorderNeighbours(
     if (targetIndex < 0) return null;
 
     const insertAt = position === "before" ? targetIndex : targetIndex + 1;
-    const samePinGroup = (item: KnowledgeSpace) => Boolean(item.isPinned) === Boolean(dragged.isPinned);
+    const samePinGroup = (item: KnowledgeSpace) =>
+        Boolean(item.isPinned) === Boolean(dragged.isPinned) && Boolean(item.canReorder);
     const prevSpace = remaining.slice(0, insertAt).filter(samePinGroup).pop() ?? null;
     const nextSpace = remaining.slice(insertAt).find(samePinGroup) ?? null;
     return { prevSpaceId: prevSpace?.id ?? null, nextSpaceId: nextSpace?.id ?? null };
@@ -323,8 +324,10 @@ export function SpaceSidebar({
 
     // Personal spaces are per-user, so there is no shared order to define for them.
     const isGroupReorderable = useCallback((group: SpaceGroup) => (
-        canReorderSpaces && Boolean(onReorderSpace) && group.level !== SpaceLevel.PERSONAL
-    ), [canReorderSpaces, onReorderSpace]);
+        Boolean(onReorderSpace)
+        && group.level !== SpaceLevel.PERSONAL
+        && group.spaces.some((item) => item.canReorder)
+    ), [onReorderSpace]);
 
     const handleSpaceDragStart = useCallback((group: SpaceGroup, space: KnowledgeSpace) => {
         setSpaceDrag({ groupKey: group.key, spaceId: space.id });
@@ -346,7 +349,8 @@ export function SpaceSidebar({
         // against rows sharing its pin state — dropping across the boundary can't move
         // it there anyway.
         const dragged = group.spaces.find((item) => item.id === spaceDrag.spaceId);
-        if (!dragged || Boolean(dragged.isPinned) !== Boolean(space.isPinned)) return;
+        if (!dragged || !dragged.canReorder || !space.canReorder) return;
+        if (Boolean(dragged.isPinned) !== Boolean(space.isPinned)) return;
         event.preventDefault();
         event.dataTransfer.dropEffect = "move";
         const bounds = event.currentTarget.getBoundingClientRect();
@@ -512,18 +516,18 @@ export function SpaceSidebar({
                                                             spaceDropTarget?.spaceId === space.id && spaceDropTarget.position === "after"
                                                                 ? s.spaceRowDropAfter : "",
                                                         ].filter(Boolean).join(" ")}
-                                                        draggable={isGroupReorderable(group)}
-                                                        onDragStart={isGroupReorderable(group)
+                                                        draggable={Boolean(space.canReorder) && isGroupReorderable(group)}
+                                                        onDragStart={space.canReorder && isGroupReorderable(group)
                                                             ? () => handleSpaceDragStart(group, space)
                                                             : undefined}
                                                         onDragEnd={isGroupReorderable(group) ? handleSpaceDragEnd : undefined}
-                                                        onDragOver={isGroupReorderable(group)
+                                                        onDragOver={space.canReorder && isGroupReorderable(group)
                                                             ? (event) => handleSpaceDragOver(event, group, space)
                                                             : undefined}
-                                                        onDragLeave={isGroupReorderable(group)
+                                                        onDragLeave={space.canReorder && isGroupReorderable(group)
                                                             ? () => setSpaceDropTarget((prev) => (prev?.spaceId === space.id ? null : prev))
                                                             : undefined}
-                                                        onDrop={isGroupReorderable(group)
+                                                        onDrop={space.canReorder && isGroupReorderable(group)
                                                             ? (event) => handleSpaceDrop(event, group, space)
                                                             : undefined}
                                                     >

--- a/src/frontend/client/src/pages/knowledge/portal/components/resolveReorderNeighbours.test.ts
+++ b/src/frontend/client/src/pages/knowledge/portal/components/resolveReorderNeighbours.test.ts
@@ -3,7 +3,8 @@ import type { KnowledgeSpace } from "~/api/knowledge";
 import { resolveReorderNeighbours } from "./SpaceSidebar";
 
 /** Sidebar order: pinned spaces are floated to the top, so a,b sit above c,d,e. */
-const space = (id: string, isPinned = false) => ({ id, name: id, isPinned } as KnowledgeSpace);
+const space = (id: string, isPinned = false, canReorder = true) =>
+    ({ id, name: id, isPinned, canReorder } as KnowledgeSpace);
 const SPACES = [space("a", true), space("b", true), space("c"), space("d"), space("e")];
 
 describe("resolveReorderNeighbours", () => {
@@ -55,6 +56,22 @@ describe("resolveReorderNeighbours", () => {
         expect(resolveReorderNeighbours(spaces, "c", "a", "after")).toEqual({
             prevSpaceId: null,
             nextSpaceId: null,
+        });
+    });
+
+    it("does not use a canReorder=false row as prev or next neighbour", () => {
+        const spaces = [
+            space("a", false, true),
+            space("b", false, false),
+            space("c", false, true),
+        ];
+        expect(resolveReorderNeighbours(spaces, "c", "b", "after")).toEqual({
+            prevSpaceId: "a",
+            nextSpaceId: null,
+        });
+        expect(resolveReorderNeighbours(spaces, "a", "b", "before")).toEqual({
+            prevSpaceId: null,
+            nextSpaceId: "c",
         });
     });
 });


### PR DESCRIPTION
## Summary
- 去掉库/文件夹排序写接口的 `is_admin()` 总闸，按运营岗、部门管理员、库/文件夹管理员矩阵鉴权
- 列表下发 `can_reorder` / `can_reorder_folders`；Client 按行开关拖拽，不再用系统管理员总闸
- 运营岗可排公共/部门库，不能排团队/科室库，也不能凭运营岗身份排文件夹

## Test plan
- [ ] 运营岗能拖公共/部门库，不能拖团队/科室库与文件夹
- [ ] 部门管理员只能拖「管辖部门含子级 ∩ 已绑定」的团队/科室库
- [ ] 库/文件夹管理员可拖自己有 `can_manage` 的对象；无权 18040
- [ ] 门户知识库 iframe 侧栏按行显示拖拽，与 Client 一致
- [ ] `pytest test/knowledge/test_space_reorder_auth_flow.py test/knowledge/test_folder_reorder_auth_flow.py test/knowledge/test_space_reorder_flags_api.py`


Made with [Cursor](https://cursor.com)