### PR TITLE
fix(qa_expert): 删未采纳回答时回退专家回答数

### DIFF
--- a/src/backend/bisheng/qa_expert/domain/moderate_delete_service.py
+++ b/src/backend/bisheng/qa_expert/domain/moderate_delete_service.py
@@ -189,4 +189,7 @@ class ModerateDeleteService:
                 update_kwargs["status"] = 0
             await self.question_repo.update(question_id, **update_kwargs)
 
+        # 软删后回退专家累计回答数, 与作者自删路径同一不变量
+        await self.expert_repo.increment_answer_count(int(expert.id), count=-1)
+
         return author_id, "qa_answer", str(target_id)

--- a/src/backend/bisheng/qa_expert/domain/repositories.py
+++ b/src/backend/bisheng/qa_expert/domain/repositories.py
@@ -3,7 +3,7 @@
 
 from types import SimpleNamespace
 
-from sqlalchemy import Integer, cast, desc, func, update
+from sqlalchemy import Integer, case, cast, desc, func, update
 from sqlmodel import and_, or_, select
 
 from bisheng.common.utils.beijing_time import now_beijing
@@ -193,10 +193,14 @@ class ExpertRepository:
             return {key: sorted(values, key=str.casefold) for key, values in options.items()}
 
     async def increment_answer_count(self, expert_id: int, count: int = 1):
-        """原子性增加专家的回答数量"""
+        """原子增减专家回答数。删答回退时 count 可为负, 结果不低于 0。"""
         async with get_async_db_session() as session:
-            stmt = update(Expert).where(Expert.id == expert_id).values(answer_count=Expert.answer_count + count)
-
+            next_count = Expert.answer_count + count
+            stmt = (
+                update(Expert)
+                .where(Expert.id == expert_id)
+                .values(answer_count=case((next_count < 0, 0), else_=next_count))
+            )
             await session.exec(stmt)
             await session.commit()
 
@@ -690,9 +694,7 @@ class AnswerRepository:
         """统计专家未软删的回答数(硬删前校验)"""
         async with get_async_db_session() as session:
             stmt = (
-                select(func.count())
-                .select_from(Answer)
-                .where(and_(Answer.expert_id == expert_id, Answer.status != 3))
+                select(func.count()).select_from(Answer).where(and_(Answer.expert_id == expert_id, Answer.status != 3))
             )
             result = await session.exec(stmt)
             return int(result.one())

--- a/src/backend/bisheng/qa_expert/domain/services.py
+++ b/src/backend/bisheng/qa_expert/domain/services.py
@@ -1899,6 +1899,9 @@ class AnswerService:
         if question is not None:
             new_count = max(int(getattr(question, "answer_count", 0) or 0) - 1, 0)
             await self.question_repo.update(answer.question_id, answer_count=new_count)
+        # 软删后回退专家累计回答数, 前端解决率 = adoption_count / answer_count
+        if getattr(answer, "expert_id", None) not in (None, ""):
+            await self.expert_repo.increment_answer_count(int(answer.expert_id), count=-1)
         return True
 
     async def _send_answer_notification(self, question: Question, answer: Answer):

--- a/src/backend/test/qa_expert/test_delete_answer.py
+++ b/src/backend/test/qa_expert/test_delete_answer.py
@@ -23,6 +23,7 @@ def _answer_service() -> AnswerService:
     svc.publish_refresher = AsyncMock()
     svc.question_repo.update = AsyncMock()
     svc.invite_repo.list_user_ids_by_question_ids = AsyncMock(return_value={})
+    svc.expert_repo.increment_answer_count = AsyncMock()
     return svc
 
 
@@ -38,6 +39,7 @@ async def test_author_deletes_unadopted_and_cascades_comments():
     kwargs = svc.question_repo.update.await_args.kwargs
     assert kwargs.get("answer_count") == 0
     assert "content_locked" not in kwargs
+    svc.expert_repo.increment_answer_count.assert_awaited_once_with(3, count=-1)
 
 
 async def test_non_author_cannot_delete():
@@ -49,6 +51,7 @@ async def test_non_author_cannot_delete():
     with pytest.raises(PermissionDeniedError):
         await svc.delete_answer(11, 99)
     svc.repository.delete.assert_not_awaited()
+    svc.expert_repo.increment_answer_count.assert_not_awaited()
 
 
 async def test_adopted_answer_cannot_delete():
@@ -61,6 +64,7 @@ async def test_adopted_answer_cannot_delete():
         await svc.delete_answer(11, 8)
     svc.repository.delete.assert_not_awaited()
     svc.comment_repo.delete_by_answer_id.assert_not_awaited()
+    svc.expert_repo.increment_answer_count.assert_not_awaited()
 
 
 async def test_delete_runs_lazy_expire_before_pending_check():
@@ -74,6 +78,7 @@ async def test_delete_runs_lazy_expire_before_pending_check():
     assert await svc.delete_answer(11, 8) is True
     svc.publish_refresher.assert_awaited_once_with(9)
     svc.publish_request_repo.get_pending_by_question.assert_awaited_once_with(9)
+    svc.expert_repo.increment_answer_count.assert_awaited_once_with(3, count=-1)
 
 
 async def test_pending_publish_blocks_unadopted_delete():
@@ -86,6 +91,7 @@ async def test_pending_publish_blocks_unadopted_delete():
     with pytest.raises(QaExpertAnswerDeleteNotAllowedError):
         await svc.delete_answer(11, 8)
     svc.repository.delete.assert_not_awaited()
+    svc.expert_repo.increment_answer_count.assert_not_awaited()
 
 
 async def test_finished_publish_allows_unadopted_delete():
@@ -99,6 +105,7 @@ async def test_finished_publish_allows_unadopted_delete():
     svc.publish_request_repo.get_pending_by_question = AsyncMock(return_value=None)
     assert await svc.delete_answer(11, 8) is True
     svc.repository.delete.assert_awaited_once_with(11)
+    svc.expert_repo.increment_answer_count.assert_awaited_once_with(3, count=-1)
 
 
 async def test_directed_stranger_cannot_list_comments():

--- a/src/backend/test/qa_expert/test_expert_answer_count_on_delete.py
+++ b/src/backend/test/qa_expert/test_expert_answer_count_on_delete.py
@@ -1,0 +1,148 @@
+"""作者删未采纳回答: qa_expert.answer_count 减 1, 采纳数不变; 拒绝路径不改计数。"""
+
+from __future__ import annotations
+
+from bisheng.database.models.qa_expert import Answer, Expert, Question
+
+PREFIX = "/api/v1/qa_experts"
+
+
+def _ok(resp) -> dict:
+    body = resp.json()
+    assert resp.status_code == 200, body
+    return body
+
+
+async def _create_question(env, payload: dict) -> int:
+    payload = {**payload, "title": env.t(payload["title"])}
+    resp = await env.client.post(f"{PREFIX}/questions", json=payload)
+    body = _ok(resp)
+    assert body.get("status_code") == 200, body
+    data = body.get("data") or {}
+    qid = data.get("id")
+    if qid:
+        return int(qid)
+    row = await env.reload_row(Question, title=payload["title"])
+    assert row is not None
+    return int(row.id)
+
+
+async def _create_answer(env, question_id: int, content: str) -> int:
+    resp = await env.client.post(
+        f"{PREFIX}/answers",
+        json={"question_id": question_id, "content": content, "reveal_on_public": True},
+    )
+    body = _ok(resp)
+    assert body.get("status_code") == 200, body
+    data = body.get("data") or {}
+    aid = data.get("id")
+    if aid:
+        return int(aid)
+    rows = await env.reload_all(Answer, question_id=question_id)
+    assert rows
+    return int(max(rows, key=lambda r: r.id).id)
+
+
+async def _expert_by_user_api(env, user_id: int) -> dict:
+    """再读一枪: GET 专家档案, 核对接口与落库一致。"""
+    body = _ok(await env.client.get(f"{PREFIX}/experts/userid/{user_id}"))
+    assert body.get("status_code") == 200, body
+    data = body.get("data") or {}
+    if hasattr(data, "answer_count"):
+        return {
+            "answer_count": int(data.answer_count or 0),
+            "adoption_count": int(data.adoption_count or 0),
+        }
+    return {
+        "answer_count": int(data.get("answer_count") or 0),
+        "adoption_count": int(data.get("adoption_count") or 0),
+    }
+
+
+async def test_author_delete_unadopted_decrements_expert_answer_count(flow_env):
+    """两答一采纳, 删未采纳: 回答数 2→1, 采纳数仍 1; 再删同一条拒绝且计数不变。"""
+    env = flow_env
+    expert = await env.seed_expert(user_id=201, name="专家甲")
+    expert_uid = env.uid(201)
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "删答回退专家计数",
+            "description": "公开",
+            "business_domain": "steel",
+            "question_type": "public",
+        },
+    )
+    env.as_user(env.user(201, name="专家甲"))
+    keep_aid = await _create_answer(env, qid, "将被采纳")
+    drop_aid = await _create_answer(env, qid, "未采纳可删")
+    env.as_user(env.asker)
+    adopted = _ok(await env.client.post(f"{PREFIX}/questions/{qid}/adopt", json={"answer_id": keep_aid}))
+    assert adopted.get("status_code") == 200, adopted
+
+    before = await env.reload_row(Expert, id=int(expert.id))
+    assert int(before.answer_count) == 2
+    assert int(before.adoption_count) == 1
+
+    env.as_user(env.user(201, name="专家甲"))
+    deleted = _ok(await env.client.delete(f"{PREFIX}/answers/{drop_aid}"))
+    assert deleted.get("status_code") == 200, deleted
+
+    stored_answer = await env.reload_row(Answer, id=drop_aid)
+    assert int(stored_answer.status) == 3
+    stored_question = await env.reload_row(Question, id=qid)
+    assert int(stored_question.answer_count) == 1
+    stored_expert = await env.reload_row(Expert, id=int(expert.id))
+    assert int(stored_expert.answer_count) == 1
+    assert int(stored_expert.adoption_count) == 1
+
+    api = await _expert_by_user_api(env, expert_uid)
+    assert api["answer_count"] == 1
+    assert api["adoption_count"] == 1
+
+    again = _ok(await env.client.delete(f"{PREFIX}/answers/{drop_aid}"))
+    assert again.get("status_code") != 200
+    stored_again = await env.reload_row(Expert, id=int(expert.id))
+    assert int(stored_again.answer_count) == 1
+    assert int(stored_again.adoption_count) == 1
+    api_again = await _expert_by_user_api(env, expert_uid)
+    assert api_again["answer_count"] == 1
+    assert int((await env.reload_row(Question, id=qid)).answer_count) == 1
+
+
+async def test_author_cannot_delete_adopted_leaves_expert_counts(flow_env):
+    """已采纳拒绝删除: qa_expert.answer_count / adoption_count 均不变。"""
+    env = flow_env
+    expert = await env.seed_expert(user_id=201, name="专家甲")
+    env.as_user(env.asker)
+    qid = await _create_question(
+        env,
+        {
+            "title": "已采纳不回退计数",
+            "description": "公开",
+            "business_domain": "steel",
+            "question_type": "public",
+        },
+    )
+    env.as_user(env.user(201, name="专家甲"))
+    aid = await _create_answer(env, qid, "唯一采纳")
+    env.as_user(env.asker)
+    adopted = _ok(await env.client.post(f"{PREFIX}/questions/{qid}/adopt", json={"answer_id": aid}))
+    assert adopted.get("status_code") == 200, adopted
+    before = await env.reload_row(Expert, id=int(expert.id))
+    assert int(before.answer_count) == 1
+    assert int(before.adoption_count) == 1
+
+    env.as_user(env.user(201, name="专家甲"))
+    denied = _ok(await env.client.delete(f"{PREFIX}/answers/{aid}"))
+    assert denied.get("status_code") == 18312
+    after = await env.reload_row(Expert, id=int(expert.id))
+    assert int(after.answer_count) == 1
+    assert int(after.adoption_count) == 1
+    still = await env.reload_row(Answer, id=aid)
+    assert int(still.status) != 3
+    assert bool(still.adopted)
+    api = await _expert_by_user_api(env, env.uid(201))
+    assert api["answer_count"] == 1
+    assert api["adoption_count"] == 1

--- a/src/backend/test/qa_expert/test_moderate_delete_answer.py
+++ b/src/backend/test/qa_expert/test_moderate_delete_answer.py
@@ -28,6 +28,7 @@ def _service_with_mocks() -> tuple[ModerateDeleteService, MagicMock]:
     svc.answer_repo = MagicMock()
     svc.comment_repo = MagicMock()
     svc.expert_repo = MagicMock()
+    svc.expert_repo.increment_answer_count = AsyncMock()
     svc.pending_deduct = MagicMock()
     return svc, svc.pending_deduct
 
@@ -97,6 +98,7 @@ async def test_delete_answer_no_rule_cascades_and_clears_adopted():
         adopted_answer_id=None,
         status=0,
     )
+    svc.expert_repo.increment_answer_count.assert_awaited_once_with(5, count=-1)
     pending.deduct_or_enqueue.assert_not_called()
 
 
@@ -144,6 +146,7 @@ async def test_delete_answer_with_rule_uses_qa_answer_biz_type():
     assert kwargs["operator_id"] == 9
     assert kwargs["remark"] == "违规"
     svc.question_repo.update.assert_awaited_once_with(101, answer_count=0)
+    svc.expert_repo.increment_answer_count.assert_awaited_once_with(6, count=-1)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- 作者删除自己的未采纳回答后，回退 `qa_expert.answer_count`（不低于 0），前端解决率按 `adoption_count / answer_count` 自动重算。
- 超管违规删除回答走同一计数回退，避免两条路径计数漂移。
- 已采纳回答仍不可自删；拒绝路径不改专家计数。

## Test plan
- [x] `pytest test/qa_expert/test_expert_answer_count_on_delete.py`（171 流转：两答一采纳后删未采纳，回答 2→1、采纳仍 1；再删拒绝且计数不变）
- [x] `pytest test/qa_expert/test_delete_answer.py test/qa_expert/test_moderate_delete_answer.py`
- [ ] 页面：专家删一条未采纳回答后，回答卡「回答 N · 解决率」与专家列表回答数减 1


Made with [Cursor](https://cursor.com)