### PR TITLE
fix(points): 接口同步入库不再记分

### DIFF
--- a/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
+++ b/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
@@ -16745,7 +16745,12 @@ class KnowledgeSpaceService(KnowledgeUtils):
         allow_duplicate_name: bool = False,
         allow_duplicate_content: bool = False,
         skip_space_business_domain_check: bool = False,
+        award_points: bool = True,
     ) -> list[KnowledgeSpaceFileResponse]:
+        """向知识空间添加文件.
+
+        award_points 为 False 时不挂钩积分, 供接口同步使用; 页面直传保持默认 True.
+        """
         from bisheng.knowledge.domain.services.knowledge_pdf_artifact_service import (
             enqueue_current_pdf_artifact,
         )
@@ -16976,23 +16981,24 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 )
         await self.update_folder_update_time(file_level_path)
         await KnowledgeDao.async_update_knowledge_update_time_by_id(knowledge_id)
-        # 积分旁路：直传人即发布人，上传成功记分，失败不影响返回。
-        try:
-            from bisheng.points.domain.services.points_award_hooks import notify_space_files_ready
+        # 页面直传记分; 接口同步传 award_points=False, 失败不影响返回.
+        if award_points:
+            try:
+                from bisheng.points.domain.services.points_award_hooks import notify_space_files_ready
 
-            await notify_space_files_ready(
-                tenant_id=int(getattr(db_knowledge, "tenant_id", None) or self.login_user.tenant_id or 1),
-                space_id=int(knowledge_id),
-                files=process_files,
-                uploader_id=int(self.login_user.user_id),
-                publisher_id=int(self.login_user.user_id),
-                is_favorite_space=bool(getattr(db_knowledge, "is_favorite", False)),
-            )
-        except Exception:
-            _logger.exception(
-                "points.award.hooks add_file notify failed knowledge_id=%s",
-                knowledge_id,
-            )
+                await notify_space_files_ready(
+                    tenant_id=int(getattr(db_knowledge, "tenant_id", None) or self.login_user.tenant_id or 1),
+                    space_id=int(knowledge_id),
+                    files=process_files,
+                    uploader_id=int(self.login_user.user_id),
+                    publisher_id=int(self.login_user.user_id),
+                    is_favorite_space=bool(getattr(db_knowledge, "is_favorite", False)),
+                )
+            except Exception:
+                _logger.exception(
+                    "points.award.hooks add_file notify failed knowledge_id=%s",
+                    knowledge_id,
+                )
         return failed_files + process_files
 
     @staticmethod

--- a/src/backend/bisheng/open_endpoints/domain/services/filelib_sync_service.py
+++ b/src/backend/bisheng/open_endpoints/domain/services/filelib_sync_service.py
@@ -231,6 +231,7 @@ class FilelibSyncService:
                     staged_upload_path,
                 )
                 business_domain_code = domain.code if domain is not None else None
+                # 接口同步不计分: 只跳过挂钩, 页面直传仍走 add_file 默认 award_points=True.
                 upload_results = await self.knowledge_space_service.add_file(
                     knowledge_id=int(target.space.id),
                     file_path=[staged_upload_path],
@@ -247,6 +248,7 @@ class FilelibSyncService:
                         or domain is None
                         or target.used_responsible_person_personal
                     ),
+                    award_points=False,
                 )
             if len(upload_results) != 1 or upload_results[0].status == KnowledgeFileStatus.FAILED.value:
                 raise FilelibSyncConflictError(msg="duplicate file content or name")

--- a/src/backend/test/knowledge/test_add_file_award_points_flag.py
+++ b/src/backend/test/knowledge/test_add_file_award_points_flag.py
@@ -1,0 +1,146 @@
+"""add_file 的 award_points 开关: 接口同步关挂钩, 页面直传仍调用 notify."""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from bisheng.knowledge.domain.models.knowledge import AuthTypeEnum
+from test.test_knowledge_space_service import (
+    _load_service_class,
+    _make_file,
+    _make_login_user,
+    _make_space,
+)
+
+
+class _FakeSession:
+    def add(self, _obj):
+        return None
+
+    async def flush(self):
+        return None
+
+    async def commit(self):
+        return None
+
+
+@asynccontextmanager
+async def _fake_session_ctx():
+    yield _FakeSession()
+
+
+@pytest.fixture
+def space_service():
+    svc = _load_service_class()(None, _make_login_user())
+    svc.normalize_file_category_code = lambda value: str(value).strip().upper() if value else None
+    svc.normalize_business_domain_code = lambda value: str(value).strip().upper() if value else None
+    return svc
+
+
+async def _run_add_file(space_service, *, award_points: bool, notify, file_id: int = 4242):
+    """走与接口同步相同的 enqueue_processing=False 入库尾路径, 断言挂钩是否发出."""
+    space_service.normalize_file_category_code = lambda value: str(value).strip().upper() if value else None
+    space_service.normalize_business_domain_code = lambda value: str(value).strip().upper() if value else None
+    knowledge_id = 19
+    space = _make_space(space_id=knowledge_id, auth_type=AuthTypeEnum.PUBLIC)
+    added_file = _make_file(
+        file_id=file_id,
+        knowledge_id=knowledge_id,
+        file_name="report.pdf",
+        file_level_path="",
+        level=0,
+    )
+    added_file.file_size = 100
+    added_file.tenant_id = 1
+    with (
+        patch.object(space_service, "_require_permission_id", new_callable=AsyncMock),
+        patch.object(space_service, "_check_filename_sensitive_words", return_value=None),
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service._require_not_write_frozen",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.KnowledgeDao.aquery_by_id",
+            new_callable=AsyncMock,
+            return_value=space,
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.SpaceFileDao.get_user_total_file_size",
+            new_callable=AsyncMock,
+            return_value=0,
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.QuotaService.get_knowledge_space_upload_limit_bytes",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.QuotaService.get_tenant_storage_remaining_bytes",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.KnowledgeService.process_one_file",
+            return_value=added_file,
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.KnowledgeService.apply_manual_upload_tags",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.PermissionService.batch_write_tuples",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.OwnerService.write_owner_tuple",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.KnowledgeDao.async_update_knowledge_update_time_by_id",
+            new_callable=AsyncMock,
+        ),
+        patch.object(space_service, "update_folder_update_time", new_callable=AsyncMock),
+        patch.object(space_service, "_initialize_child_resource_permissions", new_callable=AsyncMock),
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.get_async_db_session",
+            new=_fake_session_ctx,
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_pdf_artifact_service.enqueue_current_pdf_artifact",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "bisheng.points.domain.services.points_award_hooks.notify_space_files_ready",
+            new=notify,
+        ),
+    ):
+        return await space_service.add_file(
+            knowledge_id,
+            ["/tmp/report.pdf"],
+            enqueue_processing=False,
+            skip_space_business_domain_check=True,
+            award_points=award_points,
+        )
+
+
+@pytest.mark.asyncio
+async def test_add_file_default_notifies_points(space_service):
+    notify = AsyncMock()
+    result = await _run_add_file(space_service, award_points=True, notify=notify)
+    assert result[0].id == 4242
+    notify.assert_awaited_once()
+    assert notify.await_args.kwargs["space_id"] == 19
+    assert notify.await_args.kwargs["uploader_id"] == 7
+
+
+@pytest.mark.asyncio
+async def test_add_file_skips_points_when_award_points_false(space_service):
+    notify = AsyncMock()
+    result = await _run_add_file(space_service, award_points=False, notify=notify, file_id=4242)
+    assert result[0].id == 4242
+    notify.assert_not_awaited()
+    # 再打一枪: 仍不挂钩, 避免默认值回退把同步路径重新打开.
+    result_again = await _run_add_file(space_service, award_points=False, notify=notify, file_id=4243)
+    assert result_again[0].id == 4243
+    notify.assert_not_awaited()

--- a/src/backend/test/open_endpoints/test_filelib_sync.py
+++ b/src/backend/test/open_endpoints/test_filelib_sync.py
@@ -700,6 +700,7 @@ def test_regular_upload_keeps_enqueue_processing_enabled_by_default():
 
         default = inspect.signature(KnowledgeSpaceService.add_file)
     assert default.parameters["enqueue_processing"].default is True
+    assert default.parameters["award_points"].default is True
 
 
 async def test_missing_multipart_fields_returns_actual_422():
@@ -925,6 +926,7 @@ async def test_sync_orchestration_allows_repeated_external_id_and_writes_source_
         "allow_duplicate_name": True,
         "allow_duplicate_content": True,
         "skip_space_business_domain_check": True,
+        "award_points": False,
     }
     assert persist_update.call_args_list == [call(knowledge_file), call(knowledge_file)]
     assert events.method_calls == [
@@ -1009,6 +1011,7 @@ async def test_sync_orchestration_skips_business_domain_when_dynamic_resolution_
     add_kwargs = knowledge_space_service.add_file.await_args.kwargs
     assert add_kwargs["business_domain_code"] is None
     assert add_kwargs["skip_space_business_domain_check"] is True
+    assert add_kwargs["award_points"] is False
 
 
 def test_external_file_id_is_not_reserved_by_sync_service():

--- a/src/backend/test/open_endpoints/test_filelib_sync_from_staged_file.py
+++ b/src/backend/test/open_endpoints/test_filelib_sync_from_staged_file.py
@@ -263,6 +263,7 @@ async def test_sync_from_staged_file_re_stages_local_file_with_display_name(tmp_
     )
     knowledge_space_service.add_file.assert_awaited_once()
     assert knowledge_space_service.add_file.await_args.kwargs["file_path"] == [minio_path]
+    assert knowledge_space_service.add_file.await_args.kwargs["award_points"] is False
 
 
 @pytest.mark.asyncio

--- a/src/backend/test/open_endpoints/test_filelib_sync_version_link.py
+++ b/src/backend/test/open_endpoints/test_filelib_sync_version_link.py
@@ -121,6 +121,7 @@ async def test_sync_same_name_upload_cleans_duplicates_before_add_file():
     service._cleanup_duplicate_files_before_sync.assert_awaited_once()
     assert knowledge_space_service.add_file.await_args.kwargs["allow_duplicate_name"] is True
     assert knowledge_space_service.add_file.await_args.kwargs["allow_duplicate_content"] is True
+    assert knowledge_space_service.add_file.await_args.kwargs["award_points"] is False
     assert result.version_link_pending is False
     assert result.replaced_file_id == 55
 


### PR DESCRIPTION
## Summary
- 接口同步（`POST /api/v2/filelib/file/sync`，含汽车板介绍同步）入库成功后不再挂钩 G1/G2/G5/G6。
- `add_file` 增加 `award_points`（默认 `True`）；仅 filelib sync 传 `False`。页面直传、频道入库、审批发布仍按原规则记分。
- 无 DDL。同步仍写 `knowledgefile` 等；不再因同步写入 `user_point_log` / `user_point_account`。

## Test plan
- [x] `pytest` 同步契约：filelib sync 调 `add_file(..., award_points=False)`，直传默认 `True`
- [x] `test_add_file_award_points_flag.py`：关开关后不调用 `notify_space_files_ready`，再打一枪仍不调用
- [ ] 171 上普通用户 Token 跑通 `file/sync` 后 `SELECT user_point_log` 无新流水（现网 Token 绑普通用户仍会卡权限，未做）


Made with [Cursor](https://cursor.com)