### PR TITLE
docs: add Parallel Search MCP setup example

### DIFF
--- a/docs/architecture/05-linsight-agent.md
+++ b/docs/architecture/05-linsight-agent.md
@@ -317,6 +317,38 @@ MCP（Model Context Protocol）集成模块位于 `src/backend/bisheng/mcp_manag
 }
 ```
 
+### 远程示例：Parallel Search
+
+[Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) 提供 `web_search`（搜索公开网页）和 `web_fetch`（提取网页内容），匿名连接不需要 Parallel 账号或 API Key，免费使用有速率限制。
+
+在工具页面选择「MCP工具」→「添加MCP服务器」，填写服务名称，并将下面的 JSON 粘贴到 MCP 服务配置中。`type` 必须为 `streamable`；省略后会按 SSE 连接，无法使用此端点。每次添加一个服务器：
+
+```json
+{
+  "mcpServers": {
+    "parallel-search": {
+      "type": "streamable",
+      "name": "Parallel Search",
+      "description": "搜索公开网页并提取网页内容",
+      "url": "https://search.parallel.ai/mcp"
+    }
+  }
+}
+```
+
+配置框失去焦点或点击刷新时，BiSheng 就会连接 Parallel 获取工具列表，不必等到保存。确认「可用工具」中出现 `web_search` 和 `web_fetch` 后，可点击工具旁的测试按钮。在 `web_search` 的测试窗口，按参数分别填写下面的值，`search_queries` 使用 JSON 数组：
+
+```json
+{
+  "objective": "查找 Parallel Search MCP 的官方使用文档",
+  "search_queries": ["Parallel Search MCP documentation"]
+}
+```
+
+保存后，在需要联网检索的 Agent 或工作流中选择这些工具。Agent 获得工具后可能自行调用；搜索词、请求的 URL，以及传入的目标、上下文和元数据会发送给 Parallel。请只传入允许发送给该服务的内容。此配置不会替换现有搜索工具或更改权限，也不需要设置认证请求头。
+
+停止使用时，先从相关 Agent 或工作流中移除这些工具；不再需要该连接时，可由有权限的用户在 MCP 服务器编辑页删除它。
+
 ### 传输层实现
 
 所有客户端继承自 `BaseMcpClient` 抽象基类，统一实现 `get_transport()` 方法返回读写流，由基类的 `initialize()` 方法建立 `ClientSession`。


### PR DESCRIPTION
## What

Adds a Parallel Search example to the existing MCP integration chapter, using BiSheng's `streamable` configuration and tool editor.

## Why

The chapter has a local Streamable HTTP example. This gives users a hosted option for public web search and page extraction without a Parallel account or API key.

BiSheng's [search adapters](https://github.com/dataelement/bisheng/blob/2456ec17cee4782f094d09bbbea1908a8bbe2d2a/src/backend/bisheng_langchain/gpts/tools/web_search/tool.py#L99-L113) include Tavily, but a fresh install still [needs a provider configured](https://github.com/dataelement/bisheng/blob/2456ec17cee4782f094d09bbbea1908a8bbe2d2a/src/backend/bisheng/workstation/domain/services/chat_service.py#L588-L615). Tavily is the only one of those search providers on the current Artificial Analysis leaderboard.

The biggest quality gap is on BrowseComp: **Parallel advanced scored 76.5% versus Tavily basic's 58.5%, an 18-point lead**. Parallel advanced also scored 74.8 versus 65.6 on the combined Search Index. Those are from [Artificial Analysis's August 31 results](https://artificialanalysis.ai/agents/search-api).

This PR's anonymous MCP connection uses fast mode. That mode also beat Tavily basic: **73.1 versus 65.6 on the Search Index**, with average time per task of **19.2s versus 45.9s**. That's a good reason to offer Parallel alongside the existing search options. These are Search API results in [AA's test setup](https://artificialanalysis.ai/methodology/search-api), where time per task includes model and search time; they aren't measurements of BiSheng or this MCP integration.

I work at Parallel, which operates this service.

## How

Documentation only. The example reuses the existing MCP client and preserves installed servers, search selection and permissions. It explains discovery before saving, tool testing, removal, rate limits, and which queries, URLs and context go to Parallel when an agent calls the tools.

## Test

- [x] Focused local checks: loaded the exact documented JSON with `ClientManager.connect_mcp_from_json`, discovered `web_search` and `web_fetch`, and called both through `McpTool.get_mcp_tool` / `StructuredTool.ainvoke` without Parallel credentials. Search returned 10 results; fetch returned the linked official documentation without tool or per-URL errors.
- [x] Used the repository's locked `mcp==1.27.1`, `langchain-core==1.4.8` and `loguru==0.7.3` versions in an isolated environment with prebuilt packages. Checked the test dialog's text-array conversion locally.
- [x] `bash scripts/arch-guard.sh docs/architecture/05-linsight-agent.md` and `git diff --check` passed.
- [ ] Browser flow and 114 test server validation. No repository build or full application stack was run.

## Related

- [Parallel Search MCP documentation](https://docs.parallel.ai/integrations/mcp/search-mcp)
