### PR TITLE
fix(knowledge): allow directly invited users to leave spaces

### DIFF
--- a/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
+++ b/src/backend/bisheng/knowledge/domain/services/knowledge_space_service.py
@@ -39,6 +39,7 @@ from bisheng.common.errcode.knowledge_space import (
     SpaceFolderUploadCountExceededError,
     SpaceLimitError,
     SpaceNotFoundError,
+    SpaceOrganizationGrantExitDeniedError,
     SpacePermissionDeniedError,
     SpaceSubscribeLimitError,
     SpaceSubscribePrivateError,
@@ -866,6 +867,49 @@ class KnowledgeSpaceService(KnowledgeUtils):
             is_active=False,
             operator_user_id=self.login_user.user_id,
         )
+
+    async def _actor_space_permission_sources(self, space_id: int):
+        """Return the effective F048 sources that grant this user the space."""
+        from bisheng.permission.application.access import get_f048_runtime
+        from bisheng.tenant.domain.services.f048_permission_subject import (
+            TenantPermissionSubjectDirectory,
+        )
+
+        actor = await self._permission_actor()
+        adapter = await self._resource_adapter("knowledge_space")
+        target = await adapter.resolve_permission_target(
+            resource_type="knowledge_space",
+            resource_id=str(space_id),
+            actor=actor,
+            action="visible",
+        )
+        projected_subjects = await TenantPermissionSubjectDirectory().actor_projected_subjects(actor)
+        explanation = await (await get_f048_runtime()).explain_permissions(
+            actor=actor,
+            target=target,
+            actor_projected_subjects=projected_subjects,
+            include_roster=False,
+        )
+        return explanation.sources
+
+    async def _revoke_direct_space_invitation(self, space_id: int) -> bool:
+        """Remove the current user's direct invitation grants, if any."""
+        from bisheng.permission.application.access import get_f048_runtime
+
+        actor = await self._permission_actor()
+        adapter = await self._resource_adapter("knowledge_space")
+        target = await adapter.resolve_permission_target(
+            resource_type="knowledge_space",
+            resource_id=str(space_id),
+            actor=actor,
+            action="visible",
+        )
+        result = await (await get_f048_runtime()).remove_actor_direct_sources(
+            actor=actor,
+            target=target,
+            idempotency_key=f"space-leave-direct:{space_id}:{actor.user_id}:{target.resource_version}",
+        )
+        return result is not None
 
     async def _get_effective_actions(
         self,
@@ -2188,9 +2232,8 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 user_subscription_status,
                 user_subscription_update_time,
             )
-            if (
-                subscription_status == SpaceSubscriptionStatusEnum.NOT_SUBSCRIBED
-                and "visible" in visible_map.get(str(space.id), frozenset())
+            if subscription_status == SpaceSubscriptionStatusEnum.NOT_SUBSCRIBED and "visible" in visible_map.get(
+                str(space.id), frozenset()
             ):
                 subscription_status = SpaceSubscriptionStatusEnum.SUBSCRIBED
             result_list.append(
@@ -2450,10 +2493,13 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 actor=actor,
                 action="visible",
             )
-            performance["target_build_elapsed_ms"] = performance.get(
-                "target_build_elapsed_ms",
-                0.0,
-            ) + (perf_counter() - target_started_at) * 1000
+            performance["target_build_elapsed_ms"] = (
+                performance.get(
+                    "target_build_elapsed_ms",
+                    0.0,
+                )
+                + (perf_counter() - target_started_at) * 1000
+            )
             performance["verified_target_count"] = performance.get(
                 "verified_target_count",
                 0,
@@ -2464,16 +2510,17 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 actor=actor,
                 targets=targets,
             )
-            performance["decision_elapsed_ms"] = performance.get(
-                "decision_elapsed_ms",
-                0.0,
-            ) + (perf_counter() - decision_started_at) * 1000
+            performance["decision_elapsed_ms"] = (
+                performance.get(
+                    "decision_elapsed_ms",
+                    0.0,
+                )
+                + (perf_counter() - decision_started_at) * 1000
+            )
             for resource_type, resource_ids in by_type.items():
                 for resource_id in resource_ids:
                     permissions[(resource_type, str(resource_id))] = (
-                        {"visible"}
-                        if visible_map.get((resource_type, str(resource_id)), False)
-                        else set()
+                        {"visible"} if visible_map.get((resource_type, str(resource_id)), False) else set()
                     )
         else:
             # Compatibility path for callers that have only ids. The children
@@ -2566,9 +2613,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 permission_decision_elapsed_ms=(permission_context or {})
                 .get("performance", {})
                 .get("decision_elapsed_ms", 0.0),
-                verified_target_count=(permission_context or {})
-                .get("performance", {})
-                .get("verified_target_count", 0),
+                verified_target_count=(permission_context or {}).get("performance", {}).get("verified_target_count", 0),
             )
 
         def candidate_cursor(item: KnowledgeFile) -> list:
@@ -2802,9 +2847,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
                 exclude_file_ids = (
                     await self.version_repo.find_non_primary_file_ids_by_knowledge_ids([space_id]) or None
                 )
-            stage_elapsed_ms["version_filter_elapsed_ms"] = (
-                perf_counter() - stage_started_at
-            ) * 1000
+            stage_elapsed_ms["version_filter_elapsed_ms"] = (perf_counter() - stage_started_at) * 1000
 
             stage = "scan_visible"
             stage_started_at = perf_counter()
@@ -2827,9 +2870,7 @@ class KnowledgeSpaceService(KnowledgeUtils):
             stage = "version_enrich"
             stage_started_at = perf_counter()
             await self._enrich_with_version_info(visible_page_items)
-            stage_elapsed_ms["version_enrich_elapsed_ms"] = (
-                perf_counter() - stage_started_at
-            ) * 1000
+            stage_elapsed_ms["version_enrich_elapsed_ms"] = (perf_counter() - stage_started_at) * 1000
 
             stage = "extra_info"
             stage_started_at = perf_counter()
@@ -4930,6 +4971,18 @@ class KnowledgeSpaceService(KnowledgeUtils):
         ):
             raise SpacePermissionDeniedError()
 
+        permission_sources = await self._actor_space_permission_sources(space_id)
+        organization_sources = sorted(
+            {
+                source.subject_type
+                for source in permission_sources
+                if source.subject_type in {"department", "user_group"}
+            }
+        )
+        if organization_sources:
+            raise SpaceOrganizationGrantExitDeniedError(blocked_by=organization_sources)
+
+        direct_invitation_removed = await self._revoke_direct_space_invitation(space_id)
         await self._revoke_direct_space_user_permissions(space_id, self.login_user.user_id)
         deleted = await SpaceChannelMemberDao.delete_space_member(space_id, self.login_user.user_id)
-        return deleted
+        return bool(direct_invitation_removed or deleted)

--- a/src/backend/bisheng/permission/application/runtime.py
+++ b/src/backend/bisheng/permission/application/runtime.py
@@ -789,6 +789,53 @@ class F048PermissionRuntime:
             idempotency_key=idempotency_key,
         )
 
+    async def remove_actor_direct_sources(
+        self,
+        *,
+        actor: PermissionActor,
+        target: VerifiedPermissionTarget,
+        idempotency_key: str,
+    ):
+        """Remove only the actor's local, non-protected direct grants.
+
+        This is the narrow permission-layer primitive used when an invited user
+        leaves a resource. It deliberately does not require
+        ``manage_permission``: the actor may remove their own direct invitation,
+        but cannot remove creator, membership, department, user-group, inherited,
+        or another user's sources.
+        """
+
+        if target.tenant_id != actor.current_tenant_id:
+            raise PermissionInvalidResourceError()
+        context = replace(
+            await self.build_grant_context(actor=actor, target=target),
+            system_authorized=True,
+            capabilities=(),
+        )
+        changes = tuple(
+            CanonicalGrantChange(
+                operation="REMOVE",
+                assignee_id=source.source_id,
+                expected_assignee_version=source.version,
+            )
+            for grant in context.grants
+            for source in grant.sources
+            if source.active
+            and not source.protected
+            and source.source_type == "DIRECT"
+            and source.subject_type == "user"
+            and source.subject_id == str(actor.user_id)
+        )
+        if not changes:
+            return None
+        return await self._grants.mutate(
+            context,
+            changes=changes,
+            expected_resource_version=target.resource_version,
+            expected_catalog_release_id=context.current_catalog_release_id,
+            idempotency_key=idempotency_key,
+        )
+
     async def remove_ordinary_sources(
         self,
         *,

--- a/src/backend/test/knowledge/test_knowledge_space_service.py
+++ b/src/backend/test/knowledge/test_knowledge_space_service.py
@@ -13,6 +13,7 @@ import pytest
 from bisheng.common.errcode.knowledge_space import (
     SpaceFolderDepthError,
     SpaceNotFoundError,
+    SpaceOrganizationGrantExitDeniedError,
     SpacePermissionDeniedError,
 )
 from bisheng.common.errcode.llm import WorkbenchEmbeddingError
@@ -126,8 +127,7 @@ async def test_get_space_info_raises_when_space_is_missing(
     service: KnowledgeSpaceService,
 ) -> None:
     with patch(
-        "bisheng.knowledge.domain.services.knowledge_space_service."
-        "KnowledgeDao.aquery_by_id",
+        "bisheng.knowledge.domain.services.knowledge_space_service.KnowledgeDao.aquery_by_id",
         new_callable=AsyncMock,
         return_value=None,
     ):
@@ -141,20 +141,17 @@ async def test_create_limit_count_excludes_department_spaces(
     with (
         # A finite quota keeps the count path alive; -1 would skip it entirely.
         patch(
-            "bisheng.knowledge.domain.services.knowledge_space_service."
-            "QuotaService.get_effective_quota",
+            "bisheng.knowledge.domain.services.knowledge_space_service.QuotaService.get_effective_quota",
             new_callable=AsyncMock,
             return_value=50,
         ),
         patch(
-            "bisheng.knowledge.domain.services.knowledge_space_service."
-            "KnowledgeDao.async_count_spaces_by_user",
+            "bisheng.knowledge.domain.services.knowledge_space_service.KnowledgeDao.async_count_spaces_by_user",
             new_callable=AsyncMock,
             return_value=0,
         ) as mock_count,
         patch(
-            "bisheng.knowledge.domain.services.knowledge_space_service."
-            "LLMService.get_workbench_llm",
+            "bisheng.knowledge.domain.services.knowledge_space_service.LLMService.get_workbench_llm",
             new_callable=AsyncMock,
             return_value=None,
         ),
@@ -219,26 +216,115 @@ async def test_unsubscribe_space_blocks_creator(
 
     with (
         patch(
-            "bisheng.knowledge.domain.services.knowledge_space_service."
-            "KnowledgeDao.aquery_by_id",
+            "bisheng.knowledge.domain.services.knowledge_space_service.KnowledgeDao.aquery_by_id",
             new_callable=AsyncMock,
             return_value=owned_space,
         ),
         patch(
-            "bisheng.knowledge.domain.services.knowledge_space_service."
-            "SpaceChannelMemberDao.async_find_member",
+            "bisheng.knowledge.domain.services.knowledge_space_service.SpaceChannelMemberDao.async_find_member",
             new_callable=AsyncMock,
             return_value=creator_member,
         ),
         patch(
-            "bisheng.knowledge.domain.services.knowledge_space_service."
-            "SpaceChannelMemberDao.delete_space_member",
+            "bisheng.knowledge.domain.services.knowledge_space_service.SpaceChannelMemberDao.delete_space_member",
             new_callable=AsyncMock,
         ) as mock_delete_member,
     ):
         with pytest.raises(SpacePermissionDeniedError):
             await service.unsubscribe_space(1)
 
+    mock_delete_member.assert_not_awaited()
+
+
+async def test_directly_invited_user_can_exit_without_membership_row(
+    service: KnowledgeSpaceService,
+) -> None:
+    invited_space = _make_space(user_id=99)
+
+    with (
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.KnowledgeDao.aquery_by_id",
+            new_callable=AsyncMock,
+            return_value=invited_space,
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.SpaceChannelMemberDao.async_find_member",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch.object(
+            service,
+            "_actor_space_permission_sources",
+            new_callable=AsyncMock,
+            return_value=[SimpleNamespace(subject_type="user", source_type="DIRECT")],
+        ),
+        patch.object(
+            service,
+            "_revoke_direct_space_invitation",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as mock_revoke_invitation,
+        patch.object(
+            service,
+            "_revoke_direct_space_user_permissions",
+            new_callable=AsyncMock,
+        ) as mock_revoke_membership,
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.SpaceChannelMemberDao.delete_space_member",
+            new_callable=AsyncMock,
+            return_value=False,
+        ) as mock_delete_member,
+    ):
+        assert await service.unsubscribe_space(1) is True
+
+    mock_revoke_invitation.assert_awaited_once_with(1)
+    mock_revoke_membership.assert_awaited_once_with(1, service.login_user.user_id)
+    mock_delete_member.assert_awaited_once_with(1, service.login_user.user_id)
+
+
+async def test_organization_granted_user_still_cannot_exit(
+    service: KnowledgeSpaceService,
+) -> None:
+    granted_space = _make_space(user_id=99)
+
+    with (
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.KnowledgeDao.aquery_by_id",
+            new_callable=AsyncMock,
+            return_value=granted_space,
+        ),
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.SpaceChannelMemberDao.async_find_member",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch.object(
+            service,
+            "_actor_space_permission_sources",
+            new_callable=AsyncMock,
+            return_value=[SimpleNamespace(subject_type="department", source_type="DEPARTMENT")],
+        ),
+        patch.object(
+            service,
+            "_revoke_direct_space_invitation",
+            new_callable=AsyncMock,
+        ) as mock_revoke_invitation,
+        patch.object(
+            service,
+            "_revoke_direct_space_user_permissions",
+            new_callable=AsyncMock,
+        ) as mock_revoke_membership,
+        patch(
+            "bisheng.knowledge.domain.services.knowledge_space_service.SpaceChannelMemberDao.delete_space_member",
+            new_callable=AsyncMock,
+        ) as mock_delete_member,
+        pytest.raises(SpaceOrganizationGrantExitDeniedError) as exc_info,
+    ):
+        await service.unsubscribe_space(1)
+
+    assert exc_info.value.kwargs["blocked_by"] == ["department"]
+    mock_revoke_invitation.assert_not_awaited()
+    mock_revoke_membership.assert_not_awaited()
     mock_delete_member.assert_not_awaited()
 
 
@@ -274,8 +360,7 @@ async def test_add_folder_under_level_9_parent_raises_depth_error(
             return_value=parent_folder,
         ),
         patch(
-            "bisheng.knowledge.domain.services.knowledge_space_service."
-            "KnowledgeFileDao.aadd_file",
+            "bisheng.knowledge.domain.services.knowledge_space_service.KnowledgeFileDao.aadd_file",
             new_callable=AsyncMock,
         ) as mock_add_file,
     ):
@@ -312,14 +397,12 @@ async def test_add_folder_under_level_8_parent_creates_level_9_child(
             return_value=parent_folder,
         ),
         patch(
-            "bisheng.knowledge.domain.services.knowledge_space_service."
-            "SpaceFileDao.count_folder_by_name",
+            "bisheng.knowledge.domain.services.knowledge_space_service.SpaceFileDao.count_folder_by_name",
             new_callable=AsyncMock,
             return_value=0,
         ),
         patch(
-            "bisheng.knowledge.domain.services.knowledge_space_service."
-            "KnowledgeFileDao.aadd_file",
+            "bisheng.knowledge.domain.services.knowledge_space_service.KnowledgeFileDao.aadd_file",
             new_callable=AsyncMock,
             side_effect=lambda folder: folder,
         ) as mock_add_file,

--- a/src/backend/test/permission/test_f048_business_source_projection.py
+++ b/src/backend/test/permission/test_f048_business_source_projection.py
@@ -104,6 +104,16 @@ def _source(source_id: int = 1):
     )
 
 
+def _direct_source(*, source_id: int, user_id: int, protected: bool = False):
+    return GrantSourceService().canonicalize_source(
+        source_id=source_id,
+        subject_type="user",
+        subject_id=str(user_id),
+        source_type="DIRECT",
+        protected=protected,
+    )
+
+
 @pytest.mark.asyncio
 async def test_business_membership_add_uses_system_authorized_mutation() -> None:
     viewer = _grant(_model("viewer", 1))
@@ -169,6 +179,52 @@ async def test_business_membership_same_model_is_idempotent() -> None:
         source=_source(),
         model_key="viewer",
         idempotency_key="membership-noop",
+    )
+
+    assert result is None
+    assert mutation.calls == []
+
+
+@pytest.mark.asyncio
+async def test_actor_can_remove_only_their_own_direct_sources() -> None:
+    actor_direct = replace(_direct_source(source_id=41, user_id=7), version=3)
+    other_direct = _direct_source(source_id=42, user_id=8)
+    protected = _direct_source(source_id=43, user_id=7, protected=True)
+    organization = GrantSourceService().canonicalize_source(
+        source_id=44,
+        subject_type="department",
+        subject_id="9",
+        source_type="DEPARTMENT",
+    )
+    viewer = _grant(
+        _model("viewer", 1),
+        sources=(actor_direct, other_direct, organization),
+    )
+    owner = _grant(_model("owner", 4), sources=(protected,))
+    runtime, mutation = _runtime(_context(grants=(viewer, owner)))
+
+    await runtime.remove_actor_direct_sources(
+        actor=PermissionActor(user_id=7, current_tenant_id=5),
+        target=_target(),
+        idempotency_key="leave-direct",
+    )
+
+    context, request = mutation.calls[0]
+    assert context.system_authorized is True
+    assert [(row.operation, row.assignee_id, row.expected_assignee_version) for row in request["changes"]] == [
+        ("REMOVE", 41, 3),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_actor_direct_source_removal_is_idempotent_when_absent() -> None:
+    viewer = _grant(_model("viewer", 1), sources=(_direct_source(source_id=42, user_id=8),))
+    runtime, mutation = _runtime(_context(grants=(viewer,)))
+
+    result = await runtime.remove_actor_direct_sources(
+        actor=PermissionActor(user_id=7, current_tenant_id=5),
+        target=_target(),
+        idempotency_key="leave-direct-none",
     )
 
     assert result is None


### PR DESCRIPTION
## 问题

知识空间被单独邀请的用户接受后，退出流程只撤销 `SPACE_MEMBERSHIP` 授权，未撤销权限模型中的 `DIRECT` 个人授权源，因此无法真正退出；同时不能把个人直邀与部门/用户组授权混为一谈。

关联缺陷：[IKELTQ](https://gitee.com/Data-Elem_1/dashboard/issues?id=IKELTQ)

## 修复

- 在 F048 权限运行时增加受限的自助撤销能力，仅能删除当前用户自己的、本地非保护 `DIRECT` 授权源。
- 知识空间退出前解析当前用户的有效授权来源：个人直邀允许退出，部门/用户组授权继续返回 `18071`。
- 同时保留既有订阅成员授权和成员记录清理，兼容普通订阅退出。

## 验证

- `18 passed`：`test/knowledge/test_knowledge_space_service.py`、`test/permission/test_f048_business_source_projection.py`
- `scripts/arch-guard.sh` 通过
- 修改文件编译检查通过
- Ruff 对新增权限运行时和测试文件通过；`knowledge_space_service.py` 全文件仍有 11 个既有告警，均不在本次改动行。

by AI