### PR TITLE
fix(knowledge): retry transient PaddleOCR congestion

### DIFF
--- a/src/backend/bisheng/core/config/settings.py
+++ b/src/backend/bisheng/core/config/settings.py
@@ -581,6 +581,8 @@ class PaddleOcrConf(BaseModel):
 
     url: str = Field(default="", description="PaddleOcrService Address")
     timeout: int = Field(default=60, description="PaddleOcrService Request Timeout (sec)")
+    max_retries: int = Field(default=3, ge=0, description="Retries for transient PaddleOcrService errors")
+    retry_backoff: float = Field(default=1.0, ge=0, description="Initial PaddleOcrService retry delay (sec)")
     auth_token: str = Field(default="", description="PaddleOcrService Authentication Token")
     headers: dict = Field(default_factory=dict, description="PaddleOcrService Headers")
     request_kwargs: dict = Field(default_factory=dict, description="PaddleOcrService Request Arguments")

--- a/src/backend/bisheng/initdb_config.yaml
+++ b/src/backend/bisheng/initdb_config.yaml
@@ -19,6 +19,9 @@ knowledges: # 知识库相关配置
     url: "https://xxx.aistudio-app.com/layout-parsing"
     auth_token: ''
     timeout: 60
+    # 瞬时拥塞（如队列已满、限流、503）采用指数退避重试
+    max_retries: 3
+    retry_backoff: 1
     headers:
       x-api-key: "11"
     request_kwargs:

--- a/src/backend/bisheng/knowledge/rag/pipeline/loader/paddle_ocr.py
+++ b/src/backend/bisheng/knowledge/rag/pipeline/loader/paddle_ocr.py
@@ -1,6 +1,8 @@
+import asyncio
 import base64
 import os
 import re
+import time
 
 import httpx
 import requests
@@ -19,6 +21,9 @@ _TABLE_HTML_RE = re.compile(r"<table[^>]*>.*?</table>", re.DOTALL | re.IGNORECAS
 
 class PaddleOcrLoader(BaseBishengLoader):
     """PaddleOCR document loader for parsing documents using PaddleOCR API."""
+
+    _RETRYABLE_HTTP_STATUS_CODES = {429, 502, 503, 504}
+    _RETRYABLE_ERROR_CODES = {10010, 12002}
 
     # Mapping from PaddleOCR block labels to standard types.
     # Observed labels in production: paragraph_title, doc_title, figure_title,
@@ -55,6 +60,8 @@ class PaddleOcrLoader(BaseBishengLoader):
         retain_images: bool = True,
         filter_page_header_footer: bool = False,
         request_kwargs: dict | None = None,
+        max_retries: int = 3,
+        retry_backoff: float = 1.0,
         *args,
         **kwargs,
     ):
@@ -65,6 +72,8 @@ class PaddleOcrLoader(BaseBishengLoader):
         self.request_kwargs = request_kwargs if request_kwargs else {}
 
         self.timeout = timeout
+        self.max_retries = max(0, max_retries)
+        self.retry_backoff = max(0.0, retry_backoff)
         self.retain_images = retain_images
         self.filter_page_header_footer = filter_page_header_footer
 
@@ -101,44 +110,90 @@ class PaddleOcrLoader(BaseBishengLoader):
             raise EtlException(f"PaddleOCR API error: {result.get('errorMsg', 'Unknown error')}")
         return result.get("result", {})
 
+    def _should_retry(self, status_code: int, result: dict | None) -> bool:
+        error_code = result.get("errorCode") if result else None
+        return status_code in self._RETRYABLE_HTTP_STATUS_CODES or error_code in self._RETRYABLE_ERROR_CODES
+
+    def _retry_delay(self, retry_index: int) -> float:
+        return self.retry_backoff * (2**retry_index)
+
+    @staticmethod
+    def _response_json(resp) -> dict | None:
+        try:
+            result = resp.json()
+        except ValueError:
+            return None
+        return result if isinstance(result, dict) else None
+
+    def _log_retry(self, status_code: int, result: dict | None, retry_number: int, delay: float) -> None:
+        error_code = result.get("errorCode") if result else None
+        logger.warning(
+            "PaddleOCR API temporarily unavailable (status={}, error_code={}); retry {}/{} in {}s",
+            status_code,
+            error_code,
+            retry_number,
+            self.max_retries,
+            delay,
+        )
+
     def _call_api_sync(self, b64_data: str) -> dict:
         """Call PaddleOCR API synchronously."""
         payload = self._build_payload(b64_data)
-        try:
-            resp = requests.post(
-                self.url,
-                json=payload,
-                headers=self.headers,
-                timeout=self.timeout,
-            )
-        except requests.Timeout as e:
-            logger.error(f"PaddleOCR API request timed out: {e}")
-            raise EtlException("PaddleOCR API timeout")
-        except Exception as e:
-            if "Timeout" in str(e):
+        for retry_index in range(self.max_retries + 1):
+            try:
+                resp = requests.post(
+                    self.url,
+                    json=payload,
+                    headers=self.headers,
+                    timeout=self.timeout,
+                )
+            except requests.Timeout as e:
                 logger.error(f"PaddleOCR API request timed out: {e}")
                 raise EtlException("PaddleOCR API timeout")
-            raise e
+            except Exception as e:
+                if "Timeout" in str(e):
+                    logger.error(f"PaddleOCR API request timed out: {e}")
+                    raise EtlException("PaddleOCR API timeout")
+                raise
 
-        if resp.status_code != 200:
-            raise EtlException(f"PaddleOCR API error: status={resp.status_code}, resp={resp.text}")
-        try:
-            resp_json = resp.json()
-        except (ValueError, requests.exceptions.JSONDecodeError) as e:
-            logger.error(f"PaddleOCR API returned invalid JSON: {e}")
-            raise EtlException("PaddleOCR API returned invalid JSON response")
-        return self._validate_response(resp_json)
+            resp_json = self._response_json(resp)
+            if self._should_retry(resp.status_code, resp_json) and retry_index < self.max_retries:
+                delay = self._retry_delay(retry_index)
+                self._log_retry(resp.status_code, resp_json, retry_index + 1, delay)
+                time.sleep(delay)
+                continue
+            if resp.status_code != 200:
+                raise EtlException(f"PaddleOCR API error: status={resp.status_code}, resp={resp.text}")
+            if resp_json is None:
+                logger.error("PaddleOCR API returned invalid JSON")
+                raise EtlException("PaddleOCR API returned invalid JSON response")
+            return self._validate_response(resp_json)
+
+        raise AssertionError("unreachable")
 
     async def _call_api_async(self, b64_data: str) -> dict:
         """Call PaddleOCR API asynchronously."""
         payload = self._build_payload(b64_data)
         try:
             async with httpx.AsyncClient(timeout=self.timeout) as client:
-                resp = await client.post(
-                    self.url,
-                    json=payload,
-                    headers=self.headers,
-                )
+                for retry_index in range(self.max_retries + 1):
+                    resp = await client.post(
+                        self.url,
+                        json=payload,
+                        headers=self.headers,
+                    )
+                    resp_json = self._response_json(resp)
+                    if self._should_retry(resp.status_code, resp_json) and retry_index < self.max_retries:
+                        delay = self._retry_delay(retry_index)
+                        self._log_retry(resp.status_code, resp_json, retry_index + 1, delay)
+                        await asyncio.sleep(delay)
+                        continue
+                    if resp.status_code != 200:
+                        raise EtlException(f"PaddleOCR API error: status={resp.status_code}, resp={resp.text}")
+                    if resp_json is None:
+                        logger.error("PaddleOCR API returned invalid JSON")
+                        raise EtlException("PaddleOCR API returned invalid JSON response")
+                    return self._validate_response(resp_json)
         except httpx.TimeoutException as e:
             logger.error(f"PaddleOCR API request timed out: {e}")
             raise EtlException("PaddleOCR API timeout")
@@ -146,16 +201,9 @@ class PaddleOcrLoader(BaseBishengLoader):
             if "Timeout" in str(e):
                 logger.error(f"PaddleOCR API request timed out: {e}")
                 raise EtlException("PaddleOCR API timeout")
-            raise e
+            raise
 
-        if resp.status_code != 200:
-            raise EtlException(f"PaddleOCR API error: status={resp.status_code}, resp={resp.text}")
-        try:
-            resp_json = resp.json()
-        except (ValueError, Exception) as e:
-            logger.error(f"PaddleOCR API returned invalid JSON: {e}")
-            raise EtlException("PaddleOCR API returned invalid JSON response")
-        return self._validate_response(resp_json)
+        raise AssertionError("unreachable")
 
     def _map_block_type(self, block_label: str) -> str:
         """Map PaddleOCR block label to standard type."""
@@ -262,7 +310,7 @@ class PaddleOcrLoader(BaseBishengLoader):
         # token appears twice), then SORT the page's entries by start before
         # appending to metadata. Across pages, ordering is naturally monotonic
         # because text_offset advances.
-        metadata = dict(bboxes=[], pages=[], indexes=[], types=[])
+        metadata = {"bboxes": [], "pages": [], "indexes": [], "types": []}
         text_offset = 0
 
         for page_idx, page_result in enumerate(layout_results):
@@ -292,7 +340,7 @@ class PaddleOcrLoader(BaseBishengLoader):
                 # Drift guard: short margin labels (`aside_text "汽车"`), page
                 # numbers (`number "2/4"`), and similar decoration blocks have
                 # block_order=None AND tokens that frequently alias substrings of
-                # body text (e.g. "汽车" appears 17× on the cover page). Without
+                # body text (e.g. "汽车" appears 17x on the cover page). Without
                 # a reading-order hint we cannot disambiguate which occurrence
                 # belongs to this bbox, and naively picking the leftmost binds
                 # the decoration's bbox to an unrelated body-text position.
@@ -420,10 +468,10 @@ class PaddleOcrLoader(BaseBishengLoader):
 
         Why: PaddleOCR rasterizes each PDF page (typically at 144 DPI, i.e. 2x
         PDF point dimensions) and returns block_bbox in that pixel space, e.g.
-        an A4 page becomes ~1191×1684. The frontend renders bbox overlays via
-        pdf.js's `getViewport({scale: 1})` (PDF point space, ~595×842 for A4)
+        an A4 page becomes ~1191x1684. The frontend renders bbox overlays via
+        pdf.js's `getViewport({scale: 1})` (PDF point space, ~595x842 for A4)
         and uses `scaleState = canvas_css_width / viewport.width`. Feeding raw
-        pixel bbox there draws every box at roughly 2× the intended location,
+        pixel bbox there draws every box at roughly 2x the intended location,
         visibly drifting to the lower-right of the actual text. Normalizing to
         PDF points before persisting matches the convention etl4lm/mineru already
         produce.

--- a/src/backend/test/knowledge/rag/test_paddleocr_retry.py
+++ b/src/backend/test/knowledge/rag/test_paddleocr_retry.py
@@ -1,0 +1,89 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bisheng.knowledge.rag.pipeline.loader.paddle_ocr import PaddleOcrLoader
+from bisheng.utils.exceptions import EtlException
+
+
+def _loader(**kwargs) -> PaddleOcrLoader:
+    return PaddleOcrLoader(
+        url="https://paddle-ocr.example/layout-parsing",
+        file_path="unused.png",
+        file_metadata={},
+        file_extension="png",
+        tmp_dir=".",
+        retry_backoff=0.25,
+        **kwargs,
+    )
+
+
+def _response(status_code: int, payload: dict, text: str = "response") -> MagicMock:
+    response = MagicMock(status_code=status_code, text=text)
+    response.json.return_value = payload
+    return response
+
+
+def test_sync_retries_queue_full_response_then_succeeds() -> None:
+    queue_full = _response(
+        503,
+        {"errorCode": 10010, "errorMsg": "queue full"},
+    )
+    success = _response(200, {"errorCode": 0, "result": {"layoutParsingResults": []}})
+    loader = _loader(max_retries=2)
+
+    with patch(
+        "bisheng.knowledge.rag.pipeline.loader.paddle_ocr.requests.post", side_effect=[queue_full, success]
+    ) as post:
+        with patch("bisheng.knowledge.rag.pipeline.loader.paddle_ocr.time.sleep") as sleep:
+            result = loader._call_api_sync("encoded")
+
+    assert result == {"layoutParsingResults": []}
+    assert post.call_count == 2
+    sleep.assert_called_once_with(0.25)
+
+
+def test_sync_does_not_retry_non_transient_response() -> None:
+    bad_request = _response(400, {"errorCode": 40001, "errorMsg": "bad request"}, text="bad request")
+    loader = _loader(max_retries=3)
+
+    with patch("bisheng.knowledge.rag.pipeline.loader.paddle_ocr.requests.post", return_value=bad_request) as post:
+        with pytest.raises(EtlException, match="status=400"):
+            loader._call_api_sync("encoded")
+
+    post.assert_called_once()
+
+
+def test_sync_stops_after_configured_retries() -> None:
+    queue_full = _response(503, {"errorCode": 10010, "errorMsg": "queue full"}, text="queue full")
+    loader = _loader(max_retries=1)
+
+    with patch(
+        "bisheng.knowledge.rag.pipeline.loader.paddle_ocr.requests.post",
+        side_effect=[queue_full, queue_full],
+    ) as post:
+        with patch("bisheng.knowledge.rag.pipeline.loader.paddle_ocr.time.sleep") as sleep:
+            with pytest.raises(EtlException, match="status=503"):
+                loader._call_api_sync("encoded")
+
+    assert post.call_count == 2
+    sleep.assert_called_once_with(0.25)
+
+
+async def test_async_retries_rate_limit_business_code_then_succeeds() -> None:
+    rate_limited = _response(200, {"errorCode": 12002, "errorMsg": "rate limited"})
+    success = _response(200, {"errorCode": 0, "result": {"layoutParsingResults": []}})
+    client = MagicMock()
+    client.post = AsyncMock(side_effect=[rate_limited, success])
+    client_context = MagicMock()
+    client_context.__aenter__ = AsyncMock(return_value=client)
+    client_context.__aexit__ = AsyncMock(return_value=None)
+    loader = _loader(max_retries=2)
+
+    with patch("bisheng.knowledge.rag.pipeline.loader.paddle_ocr.httpx.AsyncClient", return_value=client_context):
+        with patch("bisheng.knowledge.rag.pipeline.loader.paddle_ocr.asyncio.sleep", new_callable=AsyncMock) as sleep:
+            result = await loader._call_api_async("encoded")
+
+    assert result == {"layoutParsingResults": []}
+    assert client.post.await_count == 2
+    sleep.assert_awaited_once_with(0.25)


### PR DESCRIPTION
## Summary

Gitee issue IKEM87 reports that an image uploaded to Knowledge Space is immediately marked failed when PaddleOCR returns HTTP 503 with `errorCode=10010` (`task submission queue is full`).

The upload and file-state workflow is working as designed; the failure is in the parse step. `PaddleOcrLoader` treated transient provider congestion exactly like a permanent parse error and therefore moved the knowledge file directly to the failed state.

## Changes

- Retry transient PaddleOCR HTTP responses (429/502/503/504) and provider queue/rate-limit codes (10010/12002).
- Apply the same bounded exponential-backoff behavior to synchronous and asynchronous parser calls.
- Keep non-transient errors and the final exhausted response unchanged so the existing worker failure handling remains intact.
- Add configurable `max_retries` and `retry_backoff` settings with conservative defaults (3 retries, 1-second initial delay).
- Add regression coverage for recovery, non-retryable errors, retry exhaustion, and async calls.

## Verification

- `ruff check` passed for all changed Python files.
- `pytest --confcutdir=test/knowledge/rag test/knowledge/rag/test_paddleocr_retry.py -q`: 4 passed.
- `scripts/arch-guard.sh`: passed.

Refs: Gitee issue IKEM87 (https://gitee.com/Data-Elem_1/dashboard/issues?id=IKEM87)
